### PR TITLE
dev(mrac): initial implementation

### DIFF
--- a/contracts/MRAC/controller.cairo
+++ b/contracts/MRAC/controller.cairo
@@ -1,0 +1,130 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from contracts.lib.int125.Int125 import Int125
+
+# implementation of the Model Reference Adaptive Control controller
+# section 4.8 of the Whitepaper
+
+# TODO: better comments
+
+const SCALE = 10 ** 18
+
+struct Parameters:
+    # interest rate
+    member u : Int125.Int
+    # reference rate
+    member r : Int125.Int
+    # collaterization ratio
+    member y : Int125.Int
+
+    # tuning parameters
+    member theta : Int125.Int
+    member theta_underline : Int125.Int
+    member theta_bar : Int125.Int
+    member gamma : Int125.Int
+    member T : Int125.Int
+
+    # the whitepaper also references "epsilon" tuning parameter
+    # but it is not used in the update law formula
+end
+
+#
+# EVENTS
+#
+
+@event
+func Parameters_changed(params : Parameters):
+end
+
+#
+# STORAGE
+#
+
+@storage_var
+func parameters() -> (params : Parameters):
+end
+
+#
+# FUNCTIONS
+#
+
+# TODO: ownable or some kind of auth, apply the check to the contract
+@constructor
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        params : Parameters):
+    # params must be scaled by SCALE
+    # TODO: do a check for it? how?
+    parameters.write(params)
+    Parameters_changed.emit(params)
+
+    return ()
+end
+
+@view
+func get_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        parameters : Parameters):
+    let (params) = parameters.read()
+    return (params)
+end
+
+@external
+func adjust_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        new_r : felt, new_theta_underline : felt, new_theta_bar : felt, new_gamma : felt,
+        new_T : felt):
+    # TODO: check if the new_params are already scaled?
+    let (params) = parameters.read()
+    let new_params = Parameters(
+        u=params.u,
+        r=Int125.Int(new_r),
+        y=params.y,
+        theta=params.theta,
+        theta_underline=Int125.Int(new_theta_underline),
+        theta_bar=Int125.Int(new_theta_bar),
+        gamma=Int125.Int(new_gamma),
+        T=Int125.Int(new_T))
+
+    parameters.write(new_params)
+    Parameters_changed.emit(new_params)
+
+    return ()
+end
+
+# implementation of the update law (23)
+# u(k) = theta(k)
+# theta(k+1) = theta(k) + T * gamma * (theta(k) - theta_underline(k)) * (theta_bar(k) - theta(k)) * (r(k) - y(k))
+func calculate_new_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        params : Parameters, new_util_rate : felt) -> (params : Parameters):
+    let new_y = Int125.Int(new_util_rate * SCALE)
+
+    let (Tg) = Int125_mul_scaled(params.T, params.gamma)
+    let (theta1, _) = Int125.sub(params.theta, params.theta_underline)
+    let (Tg_t1) = Int125_mul_scaled(Tg, theta1)
+    let (theta2, _) = Int125.sub(params.theta_bar, params.theta)
+    let (Tg_t1_t2) = Int125_mul_scaled(Tg_t1, theta2)
+    let (r_sub_y, _) = Int125.sub(params.r, new_y)
+
+    let (prod) = Int125_mul_scaled(Tg_t1_t2, r_sub_y)
+
+    let (new_theta, _) = Int125.add(params.theta, prod)
+
+    let new_params = Parameters(
+        u=new_theta,
+        r=params.r,
+        y=new_y,
+        theta=new_theta,
+        theta_underline=params.theta_underline,
+        theta_bar=params.theta_bar,
+        gamma=params.gamma,
+        T=params.T)
+
+    return (new_params)
+end
+
+# multiply and descale, unchecked
+func Int125_mul_scaled{range_check_ptr}(a : Int125.Int, b : Int125.Int) -> (product : Int125.Int):
+    let (m, _) = Int125.mul(a, b)
+    let (s, _) = Int125.div_rem(m, Int125.Int(SCALE))
+    return (s)
+end

--- a/contracts/lib/int125/Int125.cairo
+++ b/contracts/lib/int125/Int125.cairo
@@ -1,0 +1,365 @@
+# adapted from
+# https://raw.githubusercontent.com/bellissimogiorno/cairo-integer-types/f26c5eb24eccf8dfdbba06ab1e732b014e8cccfd/code/int125.cairo
+
+# Cairo library for arithmetic on signed 125-bit integers
+
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+
+# https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/math.cairo
+from starkware.cairo.common.math import (
+    assert_le, assert_nn_le, assert_not_zero, assert_in_range, assert_not_equal, assert_nn)
+# https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/math_cmp.cairo
+from starkware.cairo.common.math_cmp import is_nn, is_le, is_in_range
+# https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/pow.cairo
+from starkware.cairo.common.pow import pow
+# https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/bitwise.cairo
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_or, bitwise_xor
+
+# The file should be parametric over values for BIT_LENGTH up to 125
+# To see where the limit of 125 comes from, see comments on `mul` in `template_for_uint.cairo` (not this file; the unsigned integer file).
+const BIT_LENGTH = 125
+const SHIFT = 2 ** 124
+
+# Gather everything into a namespace for easier import
+namespace Int125:
+    # Represents a signed integer in the range [-SHIFT, SHIFT)
+    # In other words, this is a numerical type with values in -SHIFT to SHIFT-1 inclusive.
+    struct Int:
+        member value : felt
+    end
+
+    # A trivial identity function, for diagnostic purposes
+    func id(a : Int) -> (res : Int):
+        return (res=a)
+    end
+
+    # Verifies that -SHIFT <= a < SHIFT .
+    func num_check{range_check_ptr}(a : Int):
+        assert_in_range(a.value, -SHIFT, SHIFT)
+        return ()
+    end
+
+    # Calculate absolute value of a felt , and sign flag -1 (for strictly negative) and +1 (for nonnegative)
+    # Designed to work for input -RANGE_CHECK_BOUND < a < RANGE_CHECK_BOUND.
+    # Behaviour on input outside these bounds has not been considered.
+    func felt_abs{range_check_ptr}(a : felt) -> (res : felt, sign : felt):
+        alloc_locals
+        let (raw_sign) = is_nn(a)  # is_nn returns 1 if 0 <= a < RANGE_CHECK_BOUND and 0 otherwise
+        local sign = (-1) + 2 * raw_sign  # sign holds 1 if  0 <= a < RANGE_CHECK_BOUND and -1 otherwise
+        return (res=a * sign, sign=sign)
+    end
+
+    # ARITHMETIC
+
+    # Adds two int.
+    # Returns the result as an int, plus a bit (1, 0, or -1+PRIME) indicating if overflow has occured and if so in which direction.
+    func add{range_check_ptr}(a : Int, b : Int) -> (res : Int, overflow : felt):
+        alloc_locals
+        local res : Int
+        local overflow : felt
+        %{
+            a_plus_b = (ids.a.value + ids.b.value) % PRIME
+            if (a_plus_b >= ids.SHIFT) & (a_plus_b < 2*ids.SHIFT):
+               (ids.overflow, ids.res.value) = (1, (a_plus_b - 2 * ids.SHIFT) % PRIME)
+            elif (a_plus_b < PRIME - ids.SHIFT) & (PRIME - 2 * ids.SHIFT <= a_plus_b):
+               (ids.overflow, ids.res.value) = (-1 % PRIME, (a_plus_b + 2 * ids.SHIFT) % PRIME)
+            else:
+               (ids.overflow, ids.res.value) = (0, a_plus_b)
+        %}
+
+        assert overflow * overflow * overflow = overflow  # overflow is -1, 0 or 1
+        assert res.value = a.value + b.value - overflow * (2 * SHIFT)
+        num_check(res)
+
+        return (res, overflow)
+    end
+
+    # Subtraction.
+    # Returns the result as an int, plus a bit (1, 0, or -1+PRIME) indicating if overflow has occured and if so in which direction.
+    # Note: the "obvious" implementation via `neg` is wrong, due to a corner case that b = -SHIFT!  E.g. -1 - (-SHIFT) should be SHIFT-1, not -1-SHIFT.
+    func sub{range_check_ptr}(a : Int, b : Int) -> (res : Int, overflow : felt):
+        alloc_locals
+        local res : Int
+        local overflow : felt
+        %{
+            a_sub_b = (ids.a.value - ids.b.value) % PRIME
+            if (a_sub_b >= ids.SHIFT) & (a_sub_b < 2*ids.SHIFT):
+               (ids.overflow, ids.res.value) = (1, (a_sub_b - 2 * ids.SHIFT) % PRIME)
+            elif (a_sub_b < PRIME - ids.SHIFT) & (PRIME - 2 * ids.SHIFT <= a_sub_b):
+               (ids.overflow, ids.res.value) = (-1 % PRIME, (a_sub_b + 2 * ids.SHIFT) % PRIME)
+            else:
+               (ids.overflow, ids.res.value) = (0, a_sub_b)
+        %}
+
+        assert overflow * overflow * overflow = overflow  # overflow is -1, 0 or 1
+        assert res.value = a.value - b.value - overflow * (2 * SHIFT)
+        num_check(res)
+
+        return (res, overflow)
+    end
+
+    # Multiplies two int.
+    # Returns the result as two int (low and high parts).
+    func mul{range_check_ptr}(a : Int, b : Int) -> (res : Int, overflow : Int):
+        alloc_locals
+        # let's guess values for m_overflow and m_res such that a * b = m_res + SHIFT * m_overflow
+        local m_overflow : felt
+        local m_res : felt
+        # THE RUNNER
+        %{
+            # Let's figure out what a and b were as Python integers in [-SHIFT, SHIFT):
+            a_value = ids.a.value if ids.a.value < ids.SHIFT else ids.a.value - PRIME
+            b_value = ids.b.value if ids.b.value < ids.SHIFT else ids.b.value - PRIME
+            # Multiply them
+            m_value = a_value * b_value
+            # Do the division
+            (runner_overflow, runner_res) = divmod(m_value, 2 * ids.SHIFT)
+            # runner_res is nearly what we want ... but it's in [0, 2 * SHIFT) whereas we need something in [-SHIFT, SHIFT).
+            if runner_res >= ids.SHIFT:
+               ids.m_res = (runner_res - 2 * ids.SHIFT) % PRIME
+               ids.m_overflow = (runner_overflow + 1) % PRIME
+            else:
+               ids.m_res = runner_res
+               ids.m_overflow = runner_overflow % PRIME
+            # Worked example:
+            # Suppose SHIFT = 128 (so 8-bit integers) and m_value = -127.
+            # Then divmod(-127, 256) = (-1, 129) and m_res = -127 and m_overflow = 0
+            # Then divmod(-129, 256) = (-1, 127) and m_res = 127 and m_overflow = -1
+        %}
+        # THE VALIDATOR:
+        # We have nondeterministically chosen values for m_overflow and m_res.
+        num_check(Int(m_res))
+        num_check(Int(m_overflow))
+        assert m_res + (m_overflow * (2 * SHIFT)) = a.value * b.value
+        # Lucky guess!  Return these values:
+        return (res=Int(m_res), overflow=Int(m_overflow))
+    end
+
+    # Division between int.
+    # Returns the quotient and the remainder.
+    # Conforms to EVM specifications: division by 0 yields 0.
+    func div_rem{range_check_ptr}(a : Int, b : Int) -> (quotient : Int, remainder : Int):
+        alloc_locals
+        local quotient : Int
+        local remainder : Int
+
+        # If b == 0, return (0, 0).
+        if b.value == 0:
+            return (quotient=Int(0), remainder=Int(0))
+        end
+        # If b == -1, return (-a, 0).  (Note that -SHIFT / -1 = -SHIFT)
+        if b.value == -1:
+            let (quotient) = neg(a)  # this isn't just -a.value because -MIN_VAL = MIN_VAL
+            return (quotient=quotient, remainder=Int(0))
+        end
+
+        # split a and b into a nonnegative absolute value, and a sign
+        let (a_abs, a_sign) = felt_abs(a.value)
+        let (b_abs, b_sign) = felt_abs(b.value)
+
+        # python's divmod may behave differently from div_rem on negative inputs, but it's the same for nonnegative inputs
+        %{ ids.quotient.value, ids.remainder.value = divmod(ids.a_abs, ids.b_abs) %}
+        let (remainder_small) = lt(remainder, Int(b_abs))  # 0 <= remainder < b_abs
+        assert remainder_small = 1
+        let (quotient_small) = le(quotient, Int(a_abs))  # 0 <= quotient <= a
+        assert quotient_small = 1
+        let expected_value = b_abs * quotient.value + remainder.value
+        assert expected_value = a_abs
+        # So now we have |a|/|b| in quotient, and the signs of a and b in a_sign and b_sign.
+
+        # The remainder should have the same sign as a: if a is positive then the remainder is positive; if a is negative then the remainder is negative
+        let remainder_with_sign = Int(remainder.value * a_sign)
+
+        # If a and b are both negative or both positive then the quotient should be positive.
+        if a_sign == b_sign:
+            return (quotient=quotient, remainder=remainder_with_sign)
+        else:
+            # If a and b have opposing signs (a is negative and b is positive, or vice versa) then the quotient should be negative
+            let (quotient_neg) = neg(quotient)
+            return (quotient=quotient_neg, remainder=remainder_with_sign)
+        end
+    end
+    # Let's consider some examples of the above:
+    # We expect div_rem(7, 2) = (3, 1), since 7 = 3*2+1
+    # We expect div_rem(7, -2) = (-3, 1), since 7 = -3*-2 +1
+    # We expect div_rem(-7, 2) = (-3, -1), since -7 = -3*2 -1
+    # We expect div_rem(-7, -2) = (3, -1), since -7 = 3*-2 -1
+
+    # 2**exp % 2**(BIT_LENGTH-2) as an int.
+    # For example, if BIT_LENGTH = 8 then the maximum representable power of 2 is 2**6=64.
+    func pow2{range_check_ptr}(a : Int) -> (res : Int):
+        # If a < 0 or a > BIT_LENGTH - 2, then the result will be zero modulo 2**(BIT_LENGTH - 1).
+        # is_in_range is inclusive on the left bound and exclusive on the right bound
+        let (a_is_in_range) = is_in_range(a.value, 0, BIT_LENGTH - 1)
+        if a_is_in_range == 0:
+            return (Int(0))
+        end
+        let (res_value) = pow(2, a.value)
+        return (Int(res_value))
+    end
+
+    # NEGATION AND BITWISE NOT
+
+    # Returns the bitwise NOT of an integer.
+    # E.g. for an 8-bit signed integer, not(127)=-128 and not(0)=-1.
+    func not(a : Int) -> (res : Int):
+        return (Int(-(a.value + 1)))
+    end
+
+    # Returns -x the negation of x, in the sense that it is that number such that x + -x = 0, if addition wraps around such that 127+1=-128 (examples given for 8-bit signed integers).
+    # Note that -128 is -128, since -128+-128=0, and more generally neg(-SHIFT) = -SHIFT
+    func neg(a : Int) -> (res : Int):
+        if a.value == -SHIFT:
+            return (res=a)
+        else:
+            return (res=Int(-a.value))
+        end
+    end
+
+    # Conditionally negates an integer.
+    # `b` below stands for `boolean`. It's a pun between "b the argument that follows a" and "b the boolean" (programmers can be very witty).
+    # We intend `b` to have value 0 (don't negate) or 1 (do negate).
+    func cond_neg(a : Int, b : felt) -> (res : Int):
+        if b != 0:
+            return neg(a)
+        else:
+            return (a)
+        end
+    end
+
+    # COMPARISONS
+
+    # Return true if integers are equal.
+    func eq(a : Int, b : Int) -> (res):
+        if a.value != b.value:
+            return (0)
+        else:
+            return (1)
+        end
+    end
+
+    # Returns 1 if the first integer is less than the second, otherwise returns 0.  Handles negative integers smoothly, because is_le does.
+    func lt{range_check_ptr}(a : Int, b : Int) -> (res):
+        return is_le(a.value + 1, b.value)
+    end
+
+    # Returns 1 if the first int is less than or equal to the second int, otherwise returns 0.
+    func le{range_check_ptr}(a : Int, b : Int) -> (res):
+        return is_le(a.value, b.value)
+    end
+
+    # BITWISE OPERATIONS (non-native on the Cairo abstract machine and therefore not as fast as you might expect of a bitwise architecture)
+
+    # bitwise builtin in current Cairo version (cairo-lang==0.6.1) doesn't like numbers greater than or equal to 2^251.
+    # Therefore, in the code below we adjust negative inputs upwards by adding an offset of (2 ** SHIFT).
+
+    # bitwise XOR
+    func xor{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(a : Int, b : Int) -> (res : Int):
+        alloc_locals
+        local res_value : felt
+        let a_offset = a.value + SHIFT  # guarantee positive number, since minimum input value is DEFAULT_PRIME - SHIFT.  e.g. 0 maps to 128, 127 maps to 255, and -1 maps to 127.  This gets applied to _both_ inputs, so intuitively, XOR doesn't notice or care.
+        let b_offset = b.value + SHIFT
+        let (res_value) = bitwise_xor(a_offset, b_offset)
+        let (must_shift) = is_le(SHIFT, res_value)  # If the result is SHIFT of greater, this indicates a twos complement negative value
+        if must_shift == 1:
+            return (Int(res_value - (2 * SHIFT)))
+        else:
+            return (Int(res_value))
+        end
+    end
+    # Worked examples:
+    # xor(0,-1)  ->   bitwise_xor(128,127) = 255   ->   -1
+    # xor(0,-2)  ->   bitwise_xor(128,126) = 254   ->   -2
+    # xor(127,-127)-> bitwise_xor(255,1)   = 254   ->   -2
+
+    # # bitwise OR
+    func or{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(a : Int, b : Int) -> (res : Int):
+        alloc_locals
+        local res_value : felt
+        local a_offset : felt
+        local b_offset : felt
+        let (must_shift_a) = is_le(a.value, -1)  # are a or b negative?
+        let (must_shift_b) = is_le(b.value, -1)
+        if must_shift_a == 1:
+            a_offset = a.value + (2 * SHIFT)
+        else:
+            a_offset = a.value
+        end
+        if must_shift_b == 1:
+            b_offset = b.value + (2 * SHIFT)
+        else:
+            b_offset = b.value
+        end
+        let (res_value) = bitwise_or(a_offset, b_offset)
+        let (must_shift) = is_le(SHIFT, res_value)
+        if must_shift == 1:
+            return (Int(res_value - (2 * SHIFT)))
+        else:
+            return (Int(res_value))
+        end
+    end
+
+    # # bitwise AND
+    func and{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(a : Int, b : Int) -> (res : Int):
+        alloc_locals
+        local res_value : felt
+        local a_offset : felt
+        local b_offset : felt
+        let (must_shift_a) = is_le(a.value, -1)  # are a or b negative?
+        let (must_shift_b) = is_le(b.value, -1)
+        if must_shift_a == 1:
+            a_offset = a.value + (2 * SHIFT)
+        else:
+            a_offset = a.value
+        end
+        if must_shift_b == 1:
+            b_offset = b.value + (2 * SHIFT)
+        else:
+            b_offset = b.value
+        end
+        let (res_value) = bitwise_and(a_offset, b_offset)
+        let (must_shift) = is_le(SHIFT, res_value)
+        if must_shift == 1:
+            return (Int(res_value - (2 * SHIFT)))
+        else:
+            return (Int(res_value))
+        end
+    end
+
+    # Computes the logical left shift of an int.
+    # Note: "fast" bitwise operations aren't available because in the Cairo abstract machine the primitive numerical datatype is a raw field element, not a raw bitstring
+    func shl__slow{range_check_ptr}(a : Int, b : felt) -> (res : Int):
+        let (b_is_in_range) = is_in_range(b, 0, BIT_LENGTH - 1)
+        if b_is_in_range == 1:
+            let (two_pow_b) = pow(2, b)
+            let (res, _) = mul(a, Int(two_pow_b))
+            return (res)
+        end
+        return (Int(0))
+    end
+
+    # Computes the logical right shift of an int.
+    # Note: "fast" bitwise operations aren't available because in the Cairo abstract machine the primitive numerical datatype is a raw field element, not a raw bitstring
+    func shr__slow{range_check_ptr}(a : Int, b : felt) -> (res : Int):
+        alloc_locals
+        if b == 0:
+            return (a)
+        end
+        let (b_is_in_range) = is_in_range(b, 1, BIT_LENGTH - 1)
+        # a_sign == -1 or +1
+        let (a_abs, a_sign) = felt_abs(a.value)
+        if b_is_in_range == 0:
+            # -1 if a is negative, 0 if a is nonnegative
+            return (Int((a_sign - 1) / 2))
+        end
+        let (two_pow_b) = pow(2, b)
+        if a_sign == -1:
+            let (res, _) = div_rem(Int(a_abs - 1), Int(two_pow_b))
+            return (Int((-res.value) - 1))
+        else:
+            let (res, _) = div_rem(a, Int(two_pow_b))
+            return (res)
+        end
+    end
+end
+# end namespace

--- a/tests/MRAC/test_controller.py
+++ b/tests/MRAC/test_controller.py
@@ -1,0 +1,57 @@
+from typing import NamedTuple, List
+
+import pytest
+
+from conftest import DEFAULT_MRAC_PARAMETERS, SCALE, MRACParameters
+
+
+Int125 = NamedTuple("Int125", [("value", int)])
+
+
+def to_pyparams(cairo_params: List[Int125]) -> MRACParameters:
+    """
+    Converts mrac.cairo Parameters (a struct of Int125)
+    to the namedtuple MRACParameters used in Python code.
+    """
+    return MRACParameters(*[p.value for p in cairo_params])
+
+
+@pytest.mark.asyncio
+async def test_constructor(mrac_controller):
+    tx = mrac_controller.deploy_execution_info
+    assert len(tx.raw_events) == 1
+    event = tx.raw_events[0]
+    assert event.data == list(DEFAULT_MRAC_PARAMETERS)
+
+    tx = await mrac_controller.get_parameters().invoke()
+    init_params = to_pyparams(tx.result.parameters)
+    assert init_params == DEFAULT_MRAC_PARAMETERS
+
+
+@pytest.mark.asyncio
+async def test_adjust_parameters(mrac_controller):
+    p = 42 * SCALE
+    params = [p, p, p, p, p]
+    tx = await mrac_controller.adjust_parameters(*params).invoke()
+
+    assert len(tx.raw_events) == 1
+    event = tx.raw_events[0]
+    adjusted = MRACParameters(*event.data)
+    assert adjusted.r == p
+    assert adjusted.theta_underline == p
+    assert adjusted.theta_bar == p
+    assert adjusted.gamma == p
+    assert adjusted.T == p
+
+    tx = await mrac_controller.get_parameters().invoke()
+    params = tx.result.parameters
+    params = to_pyparams(params)
+
+    assert params.r == p
+    assert params.theta_underline == p
+    assert params.theta_bar == p
+    assert params.gamma == p
+    assert params.T == p
+
+
+# TODO: test calculate_new_parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import namedtuple
 import os
 
 from utils import Signer
@@ -7,6 +8,15 @@ import pytest
 from starkware.starknet.services.api.contract_definition import ContractDefinition
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starknet.testing.starknet import Starknet, StarknetContract
+
+
+MRACParameters = namedtuple(
+    "MRACParameters", ["u", "r", "y", "theta", "theta_underline", "theta_bar", "gamma", "T"]
+)
+
+SCALE = 10 ** 18
+
+DEFAULT_MRAC_PARAMETERS = MRACParameters(*[int(i * SCALE) for i in (0, 1.5, 0, 0, 0, 2, 0.1, 1)])
 
 
 def here() -> str:
@@ -77,4 +87,12 @@ async def usda(starknet, users) -> StarknetContract:
     _, owner = await users("owner")
     return await starknet.deploy(
         contract_def=contract, constructor_calldata=[owner.contract_address]
+    )
+
+
+@pytest.fixture
+async def mrac_controller(starknet) -> StarknetContract:
+    contract = compile_contract("MRAC/controller.cairo")
+    return await starknet.deploy(
+        contract_def=contract, constructor_calldata=[*DEFAULT_MRAC_PARAMETERS]
     )


### PR DESCRIPTION
Initial implementation of the Model Reference Adaptive Control controller from the whitepaper in Cairo. The contract is, so far, quite simple and not integrated (because there's nothing to integrate it with yet 😆), but the core is there.

The commit includes a `Int125` lib from the awesome [cairo-integer-types](https://github.com/bellissimogiorno/cairo-integer-types) library. It helps in dealing with negative numbers in Cairo.

The controller exposes a `adjust_parameters` function which can be used to alter `r`, `theta_underline`, `theta_bar`, `gamma` and `T` parameters.

It's completely missing any kind of auth / ownable so far.