### PR TITLE
chore: bump cairo-lang to 0.8.1

### DIFF
--- a/contracts/MRAC/controller.cairo
+++ b/contracts/MRAC/controller.cairo
@@ -53,7 +53,8 @@ end
 # TODO: ownable or some kind of auth, apply the check to the contract
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        params : Parameters):
+    params : Parameters
+):
     # params must be scaled by SCALE
     # TODO: do a check for it? how?
     parameters.write(params)
@@ -64,15 +65,16 @@ end
 
 @view
 func get_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        parameters : Parameters):
+    parameters : Parameters
+):
     let (params) = parameters.read()
     return (params)
 end
 
 @external
 func adjust_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        new_r : felt, new_theta_underline : felt, new_theta_bar : felt, new_gamma : felt,
-        new_T : felt):
+    new_r : felt, new_theta_underline : felt, new_theta_bar : felt, new_gamma : felt, new_T : felt
+):
     # TODO: check if the new_params are already scaled?
     let (params) = parameters.read()
     let new_params = Parameters(
@@ -83,7 +85,8 @@ func adjust_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_c
         theta_underline=Int125.Int(new_theta_underline),
         theta_bar=Int125.Int(new_theta_bar),
         gamma=Int125.Int(new_gamma),
-        T=Int125.Int(new_T))
+        T=Int125.Int(new_T),
+    )
 
     parameters.write(new_params)
     Parameters_changed.emit(new_params)
@@ -95,7 +98,8 @@ end
 # u(k) = theta(k)
 # theta(k+1) = theta(k) + T * gamma * (theta(k) - theta_underline(k)) * (theta_bar(k) - theta(k)) * (r(k) - y(k))
 func calculate_new_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        params : Parameters, new_util_rate : felt) -> (params : Parameters):
+    params : Parameters, new_util_rate : felt
+) -> (params : Parameters):
     let new_y = Int125.Int(new_util_rate * SCALE)
 
     let (Tg) = Int125_mul_scaled(params.T, params.gamma)
@@ -117,7 +121,8 @@ func calculate_new_parameters{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
         theta_underline=params.theta_underline,
         theta_bar=params.theta_bar,
         gamma=params.gamma,
-        T=params.T)
+        T=params.T,
+    )
 
     return (new_params)
 end

--- a/contracts/USDa/USDa.cairo
+++ b/contracts/USDa/USDa.cairo
@@ -7,9 +7,20 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
 from contracts.lib.openzeppelin.token.erc20.library import (
-    ERC20_name, ERC20_symbol, ERC20_totalSupply, ERC20_decimals, ERC20_balanceOf, ERC20_allowance,
-    ERC20_initializer, ERC20_approve, ERC20_increaseAllowance, ERC20_decreaseAllowance,
-    ERC20_transfer, ERC20_transferFrom, ERC20_mint)
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+    ERC20_mint,
+)
 
 from contracts.lib.openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
 
@@ -40,28 +51,32 @@ end
 
 @view
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        totalSupply : Uint256):
+    totalSupply : Uint256
+):
     let (totalSupply : Uint256) = ERC20_totalSupply()
     return (totalSupply)
 end
 
 @view
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        decimals : felt):
+    decimals : felt
+):
     let (decimals) = ERC20_decimals()
     return (decimals)
 end
 
 @view
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        account : felt) -> (balance : Uint256):
+    account : felt
+) -> (balance : Uint256):
     let (balance : Uint256) = ERC20_balanceOf(account)
     return (balance)
 end
 
 @view
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt, spender : felt) -> (remaining : Uint256):
+    owner : felt, spender : felt
+) -> (remaining : Uint256):
     let (remaining : Uint256) = ERC20_allowance(owner, spender)
     return (remaining)
 end
@@ -72,42 +87,48 @@ end
 
 @external
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        recipient : felt, amount : Uint256) -> (success : felt):
+    recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transfer(recipient, amount)
     return (TRUE)
 end
 
 @external
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        sender : felt, recipient : felt, amount : Uint256) -> (success : felt):
+    sender : felt, recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transferFrom(sender, recipient, amount)
     return (TRUE)
 end
 
 @external
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        spender : felt, amount : Uint256) -> (success : felt):
+    spender : felt, amount : Uint256
+) -> (success : felt):
     ERC20_approve(spender, amount)
     return (TRUE)
 end
 
 @external
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        spender : felt, added_value : Uint256) -> (success : felt):
+    spender : felt, added_value : Uint256
+) -> (success : felt):
     ERC20_increaseAllowance(spender, added_value)
     return (TRUE)
 end
 
 @external
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        spender : felt, subtracted_value : Uint256) -> (success : felt):
+    spender : felt, subtracted_value : Uint256
+) -> (success : felt):
     ERC20_decreaseAllowance(spender, subtracted_value)
     return (TRUE)
 end
 
 @external
 func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        to : felt, amount : Uint256):
+    to : felt, amount : Uint256
+):
     Ownable_only_owner()
     ERC20_mint(to, amount)
     return ()

--- a/contracts/lib/int125/Int125.cairo
+++ b/contracts/lib/int125/Int125.cairo
@@ -7,7 +7,13 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 
 # https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/math.cairo
 from starkware.cairo.common.math import (
-    assert_le, assert_nn_le, assert_not_zero, assert_in_range, assert_not_equal, assert_nn)
+    assert_le,
+    assert_nn_le,
+    assert_not_zero,
+    assert_in_range,
+    assert_not_equal,
+    assert_nn,
+)
 # https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/math_cmp.cairo
 from starkware.cairo.common.math_cmp import is_nn, is_le, is_in_range
 # https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/pow.cairo

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cairo-lang==0.7.1
+cairo-lang==0.8.1
 ecdsa==0.17.0
 fastecdsa==2.2.1
 pytest==6.2.5

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ from starkware.cairo.common.hash_state import compute_hash_on_elements
 from starkware.crypto.signature.signature import private_to_stark_key, sign
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starkware_utils.error_handling import StarkException
-from starkware.starknet.business_logic.transaction_execution_objects import Event
+from starkware.starknet.business_logic.execution.objects import Event
 
 
 MAX_UINT256 = (2 ** 128 - 1, 2 ** 128 - 1)


### PR DESCRIPTION
Starkware just released [cairo v0.8.1](https://github.com/starkware-libs/cairo-lang/releases/tag/v0.8.1).

It contains a change to the default formatter. It separates stuff into multiple line (single item per line), which is opinionated, but helps with diffs for one. This PR applies the formatting changes to our codebase and freezes the dev requirements to the latest cairo-lang version.