### PR TITLE
lint: cairo-format all cairo files in repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,5 @@ jobs:
       - name: Env setup
         run: pip install -r requirements-dev.txt
 
-      # excluding openzeppelin libs from lint check to make
-      # updating (copy-paste) in the future easier to review
       - name: Lint Cairo code
-        run: find contracts -not \( -path '*lib/openzeppelin*' \) -type f -name '*.cairo' | xargs cairo-format -c
+        run: find contracts -type f -name '*.cairo' | xargs cairo-format -c

--- a/contracts/lib/openzeppelin/access/ownable.cairo
+++ b/contracts/lib/openzeppelin/access/ownable.cairo
@@ -7,43 +7,33 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 
 @storage_var
-func Ownable_owner() -> (owner: felt):
+func Ownable_owner() -> (owner : felt):
 end
 
-func Ownable_initializer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(owner: felt):
+func Ownable_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    owner : felt
+):
     Ownable_owner.write(owner)
     return ()
 end
 
-func Ownable_only_owner{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
+func Ownable_only_owner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     let (owner) = Ownable_owner.read()
     let (caller) = get_caller_address()
     assert owner = caller
     return ()
 end
 
-func Ownable_get_owner{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (owner: felt):
+func Ownable_get_owner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    owner : felt
+):
     let (owner) = Ownable_owner.read()
     return (owner=owner)
 end
 
-func Ownable_transfer_ownership{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(new_owner: felt) -> (new_owner: felt):
+func Ownable_transfer_ownership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    new_owner : felt
+) -> (new_owner : felt):
     Ownable_only_owner()
     Ownable_owner.write(new_owner)
     return (new_owner=new_owner)

--- a/contracts/lib/openzeppelin/account/Account.cairo
+++ b/contracts/lib/openzeppelin/account/Account.cairo
@@ -11,41 +11,33 @@ from openzeppelin.account.library import (
     Account_initializer,
     Account_get_public_key,
     Account_set_public_key,
-    Account_is_valid_signature
+    Account_is_valid_signature,
 )
 
-from openzeppelin.introspection.ERC165 import ERC165_supports_interface 
+from openzeppelin.introspection.ERC165 import ERC165_supports_interface
 
 #
 # Getters
 #
 
 @view
-func get_public_key{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (res: felt):
+func get_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    res : felt
+):
     let (res) = Account_get_public_key()
     return (res=res)
 end
 
 @view
-func get_nonce{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (res: felt):
+func get_nonce{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (res : felt):
     let (res) = Account_get_nonce()
     return (res=res)
 end
 
 @view
-func supportsInterface{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (interfaceId: felt) -> (success: felt):
+func supportsInterface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    interfaceId : felt
+) -> (success : felt):
     let (success) = ERC165_supports_interface(interfaceId)
     return (success)
 end
@@ -55,11 +47,9 @@ end
 #
 
 @external
-func set_public_key{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(new_public_key: felt):
+func set_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    new_public_key : felt
+):
     Account_set_public_key(new_public_key)
     return ()
 end
@@ -69,11 +59,9 @@ end
 #
 
 @constructor
-func constructor{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(public_key: felt):
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    public_key : felt
+):
     Account_initializer(public_key)
     return ()
 end
@@ -84,38 +72,24 @@ end
 
 @view
 func is_valid_signature{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr, 
-        ecdsa_ptr: SignatureBuiltin*
-    }(
-        hash: felt,
-        signature_len: felt,
-        signature: felt*
-    ) -> ():
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, ecdsa_ptr : SignatureBuiltin*
+}(hash : felt, signature_len : felt, signature : felt*) -> ():
     Account_is_valid_signature(hash, signature_len, signature)
     return ()
 end
 
 @external
 func __execute__{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr, 
-        ecdsa_ptr: SignatureBuiltin*
-    }(
-        call_array_len: felt,
-        call_array: AccountCallArray*,
-        calldata_len: felt,
-        calldata: felt*,
-        nonce: felt
-    ) -> (response_len: felt, response: felt*):
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, ecdsa_ptr : SignatureBuiltin*
+}(
+    call_array_len : felt,
+    call_array : AccountCallArray*,
+    calldata_len : felt,
+    calldata : felt*,
+    nonce : felt,
+) -> (response_len : felt, response : felt*):
     let (response_len, response) = Account_execute(
-        call_array_len,
-        call_array,
-        calldata_len,
-        calldata,
-        nonce
+        call_array_len, call_array, calldata_len, calldata, nonce
     )
     return (response_len=response_len, response=response)
 end

--- a/contracts/lib/openzeppelin/account/AddressRegistry.cairo
+++ b/contracts/lib/openzeppelin/account/AddressRegistry.cairo
@@ -7,25 +7,21 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 
 @storage_var
-func L1_address(L2_address: felt) -> (res: felt):
+func L1_address(L2_address : felt) -> (res : felt):
 end
 
 @external
-func get_L1_address{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(L2_address: felt) -> (res: felt):
+func get_L1_address{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    L2_address : felt
+) -> (res : felt):
     let (res) = L1_address.read(L2_address)
     return (res=res)
 end
 
 @external
-func set_L1_address{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(new_L1_address: felt):
+func set_L1_address{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    new_L1_address : felt
+):
     let (caller) = get_caller_address()
     L1_address.write(caller, new_L1_address)
     return ()

--- a/contracts/lib/openzeppelin/account/IAccount.cairo
+++ b/contracts/lib/openzeppelin/account/IAccount.cairo
@@ -7,7 +7,6 @@ from openzeppelin.account.Account import AccountCallArray
 
 @contract_interface
 namespace IAccount:
-
     #
     # Getters
     #
@@ -19,19 +18,15 @@ namespace IAccount:
     # Business logic
     #
 
-    func is_valid_signature(
-            hash: felt,
-            signature_len: felt,
-            signature: felt*
-        ):
+    func is_valid_signature(hash : felt, signature_len : felt, signature : felt*):
     end
 
     func __execute__(
-            call_array_len: felt,
-            call_array: AccountCallArray*,
-            calldata_len: felt,
-            calldata: felt*,
-            nonce: felt
-        ) -> (response_len: felt, response: felt*):
+        call_array_len : felt,
+        call_array : AccountCallArray*,
+        calldata_len : felt,
+        calldata : felt*,
+        nonce : felt,
+    ) -> (response_len : felt, response : felt*):
     end
 end

--- a/contracts/lib/openzeppelin/account/library.cairo
+++ b/contracts/lib/openzeppelin/account/library.cairo
@@ -8,43 +8,43 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 from starkware.starknet.common.syscalls import call_contract, get_caller_address, get_tx_info
 from starkware.cairo.common.hash_state import (
-    hash_init, hash_finalize, hash_update, hash_update_single
+    hash_init,
+    hash_finalize,
+    hash_update,
+    hash_update_single,
 )
 
-from openzeppelin.introspection.ERC165 import (
-    ERC165_supports_interface, 
-    ERC165_register_interface
-)
+from openzeppelin.introspection.ERC165 import ERC165_supports_interface, ERC165_register_interface
 
-from openzeppelin.utils.constants import PREFIX_TRANSACTION 
+from openzeppelin.utils.constants import PREFIX_TRANSACTION
 
 #
 # Structs
 #
 
 struct MultiCall:
-    member account: felt
-    member calls_len: felt
-    member calls: Call*
-    member nonce: felt
-    member max_fee: felt
-    member version: felt
+    member account : felt
+    member calls_len : felt
+    member calls : Call*
+    member nonce : felt
+    member max_fee : felt
+    member version : felt
 end
 
 struct Call:
-    member to: felt
-    member selector: felt
-    member calldata_len: felt
-    member calldata: felt*
+    member to : felt
+    member selector : felt
+    member calldata_len : felt
+    member calldata : felt*
 end
 
 # Tmp struct introduced while we wait for Cairo
 # to support passing `[AccountCall]` to __execute__
 struct AccountCallArray:
-    member to: felt
-    member selector: felt
-    member data_offset: felt
-    member data_len: felt
+    member to : felt
+    member selector : felt
+    member data_offset : felt
+    member data_len : felt
 end
 
 #
@@ -52,11 +52,11 @@ end
 #
 
 @storage_var
-func Account_current_nonce() -> (res: felt):
+func Account_current_nonce() -> (res : felt):
 end
 
 @storage_var
-func Account_public_key() -> (res: felt):
+func Account_public_key() -> (res : felt):
 end
 
 #
@@ -74,20 +74,15 @@ end
 # Getters
 #
 
-func Account_get_public_key{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (res: felt):
+func Account_get_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    ) -> (res : felt):
     let (res) = Account_public_key.read()
     return (res=res)
 end
 
-func Account_get_nonce{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (res: felt):
+func Account_get_nonce{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    res : felt
+):
     let (res) = Account_current_nonce.read()
     return (res=res)
 end
@@ -96,11 +91,9 @@ end
 # Setters
 #
 
-func Account_set_public_key{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(new_public_key: felt):
+func Account_set_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    new_public_key : felt
+):
     Account_assert_only_self()
     Account_public_key.write(new_public_key)
     return ()
@@ -110,15 +103,13 @@ end
 # Initializer
 #
 
-func Account_initializer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(_public_key: felt):
+func Account_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    _public_key : felt
+):
     Account_public_key.write(_public_key)
     # Account magic value derived from ERC165 calculation of IAccount
     ERC165_register_interface(0xf10dbd44)
-    return()
+    return ()
 end
 
 #
@@ -127,15 +118,8 @@ end
 
 @view
 func Account_is_valid_signature{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr, 
-        ecdsa_ptr: SignatureBuiltin*
-    }(
-        hash: felt,
-        signature_len: felt,
-        signature: felt*
-    ) -> ():
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, ecdsa_ptr : SignatureBuiltin*
+}(hash : felt, signature_len : felt, signature : felt*) -> ():
     let (_public_key) = Account_public_key.read()
 
     # This interface expects a signature pointer and length to make
@@ -145,27 +129,21 @@ func Account_is_valid_signature{
     let sig_s = signature[1]
 
     verify_ecdsa_signature(
-        message=hash,
-        public_key=_public_key,
-        signature_r=sig_r,
-        signature_s=sig_s)
+        message=hash, public_key=_public_key, signature_r=sig_r, signature_s=sig_s
+    )
 
     return ()
 end
 
-
 func Account_execute{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr, 
-        ecdsa_ptr: SignatureBuiltin*
-    }(
-        call_array_len: felt,
-        call_array: AccountCallArray*,
-        calldata_len: felt,
-        calldata: felt*,
-        nonce: felt
-    ) -> (response_len: felt, response: felt*):
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, ecdsa_ptr : SignatureBuiltin*
+}(
+    call_array_len : felt,
+    call_array : AccountCallArray*,
+    calldata_len : felt,
+    calldata : felt*,
+    nonce : felt,
+) -> (response_len : felt, response : felt*):
     alloc_locals
 
     let (__fp__, _) = get_fp_and_pc()
@@ -180,14 +158,14 @@ func Account_execute{
     from_call_array_to_call(call_array_len, call_array, calldata, calls)
     let calls_len = call_array_len
 
-    local multicall: MultiCall = MultiCall(
+    local multicall : MultiCall = MultiCall(
         tx_info.account_contract_address,
         calls_len,
         calls,
         _current_nonce,
         tx_info.max_fee,
         tx_info.version
-    )
+        )
 
     # validate transaction
     let (hash) = hash_multicall(&multicall)
@@ -203,25 +181,23 @@ func Account_execute{
     return (response_len=response_len, response=response)
 end
 
-func execute_list{syscall_ptr: felt*}(
-        calls_len: felt,
-        calls: Call*,
-        response: felt*
-    ) -> (response_len: felt):
+func execute_list{syscall_ptr : felt*}(calls_len : felt, calls : Call*, response : felt*) -> (
+    response_len : felt
+):
     alloc_locals
 
     # if no more calls
     if calls_len == 0:
-       return (0)
+        return (0)
     end
-    
+
     # do the current call
-    let this_call: Call = [calls]
+    let this_call : Call = [calls]
     let res = call_contract(
         contract_address=this_call.to,
         function_selector=this_call.selector,
         calldata_size=this_call.calldata_len,
-        calldata=this_call.calldata
+        calldata=this_call.calldata,
     )
     # copy the result in response
     memcpy(response, res.retdata, res.retdata_size)
@@ -230,12 +206,9 @@ func execute_list{syscall_ptr: felt*}(
     return (response_len + res.retdata_size)
 end
 
-func hash_multicall{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*
-    } (
-        multicall: MultiCall*
-    ) -> (res: felt):
+func hash_multicall{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*}(multicall : MultiCall*) -> (
+    res : felt
+):
     alloc_locals
     let (calls_hash) = hash_call_array(multicall.calls_len, multicall.calls)
     let hash_ptr = pedersen_ptr
@@ -253,10 +226,7 @@ func hash_multicall{
     end
 end
 
-func hash_call_array{pedersen_ptr: HashBuiltin*}(
-        calls_len: felt,
-        calls: Call*
-    ) -> (res: felt):
+func hash_call_array{pedersen_ptr : HashBuiltin*}(calls_len : felt, calls : Call*) -> (res : felt):
     alloc_locals
 
     # convert [call] to [Hash(call)]
@@ -274,11 +244,9 @@ func hash_call_array{pedersen_ptr: HashBuiltin*}(
     end
 end
 
-func hash_call_loop{pedersen_ptr: HashBuiltin*}(
-        calls_len: felt,
-        calls: Call*,
-        hash_array: felt*
-    ):
+func hash_call_loop{pedersen_ptr : HashBuiltin*}(
+    calls_len : felt, calls : Call*, hash_array : felt*
+):
     if calls_len == 0:
         return ()
     end
@@ -295,47 +263,41 @@ func hash_call_loop{pedersen_ptr: HashBuiltin*}(
         assert [hash_array] = res
     end
     hash_call_loop(calls_len - 1, calls + Call.SIZE, hash_array + 1)
-    return()
+    return ()
 end
 
-func hash_calldata{pedersen_ptr: HashBuiltin*}(
-        calldata_len: felt,
-        calldata: felt*
-    ) -> (res: felt):
+func hash_calldata{pedersen_ptr : HashBuiltin*}(calldata_len : felt, calldata : felt*) -> (
+    res : felt
+):
     let hash_ptr = pedersen_ptr
     with hash_ptr:
         let (hash_state_ptr) = hash_init()
-        let (hash_state_ptr) = hash_update(
-            hash_state_ptr,
-            calldata,
-            calldata_len
-        )
+        let (hash_state_ptr) = hash_update(hash_state_ptr, calldata, calldata_len)
         let (res) = hash_finalize(hash_state_ptr)
         let pedersen_ptr = hash_ptr
         return (res=res)
     end
 end
 
-func from_call_array_to_call{syscall_ptr: felt*}(
-        call_array_len: felt,
-        call_array: AccountCallArray*,
-        calldata: felt*,
-        calls: Call*
-    ):
+func from_call_array_to_call{syscall_ptr : felt*}(
+    call_array_len : felt, call_array : AccountCallArray*, calldata : felt*, calls : Call*
+):
     # if no more calls
     if call_array_len == 0:
-       return ()
+        return ()
     end
-    
+
     # parse the current call
     assert [calls] = Call(
-            to=[call_array].to,
-            selector=[call_array].selector,
-            calldata_len=[call_array].data_len,
-            calldata=calldata + [call_array].data_offset
+        to=[call_array].to,
+        selector=[call_array].selector,
+        calldata_len=[call_array].data_len,
+        calldata=calldata + [call_array].data_offset
         )
-    
+
     # parse the remaining calls recursively
-    from_call_array_to_call(call_array_len - 1, call_array + AccountCallArray.SIZE, calldata, calls + Call.SIZE)
+    from_call_array_to_call(
+        call_array_len - 1, call_array + AccountCallArray.SIZE, calldata, calls + Call.SIZE
+    )
     return ()
 end

--- a/contracts/lib/openzeppelin/introspection/ERC165.cairo
+++ b/contracts/lib/openzeppelin/introspection/ERC165.cairo
@@ -9,14 +9,12 @@ from starkware.cairo.common.math import assert_not_equal
 from openzeppelin.utils.constants import TRUE
 
 @storage_var
-func ERC165_supported_interfaces(interface_id: felt) -> (is_supported: felt):
-end 
+func ERC165_supported_interfaces(interface_id : felt) -> (is_supported : felt):
+end
 
-func ERC165_supports_interface{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*, 
-        range_check_ptr
-    } (interface_id: felt) -> (success: felt):
+func ERC165_supports_interface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    interface_id : felt
+) -> (success : felt):
     # 165
     if interface_id == 0x01ffc9a7:
         return (TRUE)
@@ -27,11 +25,9 @@ func ERC165_supports_interface{
     return (is_supported)
 end
 
-func ERC165_register_interface{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*, 
-        range_check_ptr
-    } (interface_id: felt):
+func ERC165_register_interface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    interface_id : felt
+):
     # Ensures interface_id is not the invalid interface_id
     assert_not_equal(interface_id, 0xffffffff)
     ERC165_supported_interfaces.write(interface_id, TRUE)

--- a/contracts/lib/openzeppelin/introspection/IERC165.cairo
+++ b/contracts/lib/openzeppelin/introspection/IERC165.cairo
@@ -5,6 +5,6 @@
 
 @contract_interface
 namespace IERC165:
-    func supportsInterface(interfaceId: felt) -> (success: felt):
+    func supportsInterface(interfaceId : felt) -> (success : felt):
     end
 end

--- a/contracts/lib/openzeppelin/security/initializable.cairo
+++ b/contracts/lib/openzeppelin/security/initializable.cairo
@@ -8,25 +8,19 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from openzeppelin.utils.constants import TRUE, FALSE
 
 @storage_var
-func _initialized() -> (res: felt):
+func _initialized() -> (res : felt):
 end
 
 @external
-func initialized{ 
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (res: felt):
+func initialized{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    res : felt
+):
     let (res) = _initialized.read()
     return (res=res)
 end
 
 @external
-func initialize{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
+func initialize{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     let (initialized) = _initialized.read()
     assert initialized = FALSE
     _initialized.write(TRUE)

--- a/contracts/lib/openzeppelin/security/pausable.cairo
+++ b/contracts/lib/openzeppelin/security/pausable.cairo
@@ -9,44 +9,28 @@ from starkware.starknet.common.syscalls import get_caller_address
 from openzeppelin.utils.constants import TRUE, FALSE
 
 @storage_var
-func Pausable_paused() -> (paused: felt):
+func Pausable_paused() -> (paused : felt):
 end
 
-func Pausable_when_not_paused{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
+func Pausable_when_not_paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     let (is_paused) = Pausable_paused.read()
     assert is_paused = FALSE
     return ()
 end
 
-func Pausable_when_paused{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
+func Pausable_when_paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     let (is_paused) = Pausable_paused.read()
     assert is_paused = TRUE
     return ()
 end
 
-func Pausable_pause{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
+func Pausable_pause{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     Pausable_when_not_paused()
     Pausable_paused.write(TRUE)
     return ()
 end
 
-func Pausable_unpause{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }():
+func Pausable_unpause{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     Pausable_when_paused()
     Pausable_paused.write(FALSE)
     return ()

--- a/contracts/lib/openzeppelin/security/safemath.cairo
+++ b/contracts/lib/openzeppelin/security/safemath.cairo
@@ -6,65 +6,64 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.uint256 import (
-    Uint256, uint256_check, uint256_add, uint256_sub, uint256_mul, 
-    uint256_unsigned_div_rem, uint256_le, uint256_lt, uint256_eq
+    Uint256,
+    uint256_check,
+    uint256_add,
+    uint256_sub,
+    uint256_mul,
+    uint256_unsigned_div_rem,
+    uint256_le,
+    uint256_lt,
+    uint256_eq,
 )
 from openzeppelin.utils.constants import TRUE, FALSE
 
-# Adds two integers. 
+# Adds two integers.
 # Reverts if the sum overflows.
-func uint256_checked_add{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*, 
-        range_check_ptr
-    } (a: Uint256, b: Uint256) -> (c: Uint256):
+func uint256_checked_add{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    a : Uint256, b : Uint256
+) -> (c : Uint256):
     uint256_check(a)
     uint256_check(b)
-    let (c: Uint256, is_overflow) = uint256_add(a, b)
+    let (c : Uint256, is_overflow) = uint256_add(a, b)
     assert is_overflow = FALSE
     return (c)
 end
 
 # Subtracts two integers.
 # Reverts if minuend (`b`) is greater than subtrahend (`a`).
-func uint256_checked_sub_le{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*, 
-        range_check_ptr
-    } (a: Uint256, b: Uint256) -> (c: Uint256):
+func uint256_checked_sub_le{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    a : Uint256, b : Uint256
+) -> (c : Uint256):
     alloc_locals
     uint256_check(a)
     uint256_check(b)
     let (is_le) = uint256_le(b, a)
     assert is_le = TRUE
-    let (c: Uint256) = uint256_sub(a, b)
+    let (c : Uint256) = uint256_sub(a, b)
     return (c)
 end
 
 # Subtracts two integers.
 # Reverts if minuend (`b`) is greater than or equal to subtrahend (`a`).
-func uint256_checked_sub_lt{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*, 
-        range_check_ptr
-    } (a: Uint256, b: Uint256) -> (c: Uint256):
+func uint256_checked_sub_lt{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    a : Uint256, b : Uint256
+) -> (c : Uint256):
     alloc_locals
     uint256_check(a)
     uint256_check(b)
 
     let (is_lt) = uint256_lt(b, a)
     assert is_lt = TRUE
-    let (c: Uint256) = uint256_sub(a, b)
+    let (c : Uint256) = uint256_sub(a, b)
     return (c)
 end
 
 # Multiplies two integers.
 # Reverts if product is greater than 2^256.
-func uint256_checked_mul{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*, 
-        range_check_ptr
-    } (a: Uint256, b: Uint256) -> (c: Uint256):
+func uint256_checked_mul{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    a : Uint256, b : Uint256
+) -> (c : Uint256):
     alloc_locals
     uint256_check(a)
     uint256_check(b)
@@ -78,7 +77,7 @@ func uint256_checked_mul{
         return (b)
     end
 
-    let (c: Uint256, overflow: Uint256) = uint256_mul(a, b)
+    let (c : Uint256, overflow : Uint256) = uint256_mul(a, b)
     with_attr error_message("Safemath: multiplication overflow"):
         assert overflow = Uint256(0, 0)
     end
@@ -90,20 +89,18 @@ end
 # Cairo's `uint256_unsigned_div_rem` already checks:
 #    remainder < divisor
 #    quotient * divisor + remainder == dividend
-func uint256_checked_div_rem{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*, 
-        range_check_ptr
-    } (a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256):
+func uint256_checked_div_rem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    a : Uint256, b : Uint256
+) -> (c : Uint256, rem : Uint256):
     alloc_locals
     uint256_check(a)
     uint256_check(b)
-    
+
     let (is_zero) = uint256_eq(b, Uint256(0, 0))
     with_attr error_message("Safemath: divisor cannot be zero"):
         assert is_zero = FALSE
     end
 
-    let (c: Uint256, rem: Uint256) = uint256_unsigned_div_rem(a, b)
+    let (c : Uint256, rem : Uint256) = uint256_unsigned_div_rem(a, b)
     return (c, rem)
 end

--- a/contracts/lib/openzeppelin/token/erc20/ERC20.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20.cairo
@@ -13,30 +13,21 @@ from openzeppelin.token.erc20.library import (
     ERC20_decimals,
     ERC20_balanceOf,
     ERC20_allowance,
-
     ERC20_initializer,
     ERC20_approve,
     ERC20_increaseAllowance,
     ERC20_decreaseAllowance,
     ERC20_transfer,
     ERC20_transferFrom,
-    ERC20_mint
+    ERC20_mint,
 )
 
 from openzeppelin.utils.constants import TRUE
 
 @constructor
-func constructor{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(
-        name: felt,
-        symbol: felt,
-        decimals: felt,
-        initial_supply: Uint256,
-        recipient: felt
-    ):
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    name : felt, symbol : felt, decimals : felt, initial_supply : Uint256, recipient : felt
+):
     ERC20_initializer(name, symbol, decimals)
     ERC20_mint(recipient, initial_supply)
     return ()
@@ -47,62 +38,46 @@ end
 #
 
 @view
-func name{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (name: felt):
+func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
     let (name) = ERC20_name()
     return (name)
 end
 
 @view
-func symbol{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (symbol: felt):
+func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
     let (symbol) = ERC20_symbol()
     return (symbol)
 end
 
 @view
-func totalSupply{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (totalSupply: Uint256):
-    let (totalSupply: Uint256) = ERC20_totalSupply()
+func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    totalSupply : Uint256
+):
+    let (totalSupply : Uint256) = ERC20_totalSupply()
     return (totalSupply)
 end
 
 @view
-func decimals{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (decimals: felt):
+func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    decimals : felt
+):
     let (decimals) = ERC20_decimals()
     return (decimals)
 end
 
 @view
-func balanceOf{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(account: felt) -> (balance: Uint256):
-    let (balance: Uint256) = ERC20_balanceOf(account)
+func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    account : felt
+) -> (balance : Uint256):
+    let (balance : Uint256) = ERC20_balanceOf(account)
     return (balance)
 end
 
 @view
-func allowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(owner: felt, spender: felt) -> (remaining: Uint256):
-    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    owner : felt, spender : felt
+) -> (remaining : Uint256):
+    let (remaining : Uint256) = ERC20_allowance(owner, spender)
     return (remaining)
 end
 
@@ -111,55 +86,41 @@ end
 #
 
 @external
-func transfer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(recipient: felt, amount: Uint256) -> (success: felt):
+func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transfer(recipient, amount)
     return (TRUE)
 end
 
 @external
-func transferFrom{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(
-        sender: felt, 
-        recipient: felt, 
-        amount: Uint256
-    ) -> (success: felt):
+func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    sender : felt, recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transferFrom(sender, recipient, amount)
     return (TRUE)
 end
 
 @external
-func approve{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, amount: Uint256) -> (success: felt):
+func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, amount : Uint256
+) -> (success : felt):
     ERC20_approve(spender, amount)
     return (TRUE)
 end
 
 @external
-func increaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, added_value: Uint256) -> (success: felt):
+func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, added_value : Uint256
+) -> (success : felt):
     ERC20_increaseAllowance(spender, added_value)
     return (TRUE)
 end
 
 @external
-func decreaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, subtracted_value : Uint256
+) -> (success : felt):
     ERC20_decreaseAllowance(spender, subtracted_value)
     return (TRUE)
 end

--- a/contracts/lib/openzeppelin/token/erc20/ERC20_Mintable.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20_Mintable.cairo
@@ -13,36 +13,28 @@ from openzeppelin.token.erc20.library import (
     ERC20_decimals,
     ERC20_balanceOf,
     ERC20_allowance,
-
     ERC20_initializer,
     ERC20_approve,
     ERC20_increaseAllowance,
     ERC20_decreaseAllowance,
     ERC20_transfer,
     ERC20_transferFrom,
-    ERC20_mint
+    ERC20_mint,
 )
 
-from openzeppelin.access.ownable import (
-    Ownable_initializer,
-    Ownable_only_owner
-)
+from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
 
 from openzeppelin.utils.constants import TRUE
 
 @constructor
-func constructor{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(
-        name: felt,
-        symbol: felt,
-        decimals: felt,
-        initial_supply: Uint256,
-        recipient: felt,
-        owner: felt
-    ):
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    name : felt,
+    symbol : felt,
+    decimals : felt,
+    initial_supply : Uint256,
+    recipient : felt,
+    owner : felt,
+):
     ERC20_initializer(name, symbol, decimals)
     ERC20_mint(recipient, initial_supply)
     Ownable_initializer(owner)
@@ -54,62 +46,46 @@ end
 #
 
 @view
-func name{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (name: felt):
+func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
     let (name) = ERC20_name()
     return (name)
 end
 
 @view
-func symbol{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (symbol: felt):
+func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
     let (symbol) = ERC20_symbol()
     return (symbol)
 end
 
 @view
-func totalSupply{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (totalSupply: Uint256):
-    let (totalSupply: Uint256) = ERC20_totalSupply()
+func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    totalSupply : Uint256
+):
+    let (totalSupply : Uint256) = ERC20_totalSupply()
     return (totalSupply)
 end
 
 @view
-func decimals{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (decimals: felt):
+func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    decimals : felt
+):
     let (decimals) = ERC20_decimals()
     return (decimals)
 end
 
 @view
-func balanceOf{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(account: felt) -> (balance: Uint256):
-    let (balance: Uint256) = ERC20_balanceOf(account)
+func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    account : felt
+) -> (balance : Uint256):
+    let (balance : Uint256) = ERC20_balanceOf(account)
     return (balance)
 end
 
 @view
-func allowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(owner: felt, spender: felt) -> (remaining: Uint256):
-    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    owner : felt, spender : felt
+) -> (remaining : Uint256):
+    let (remaining : Uint256) = ERC20_allowance(owner, spender)
     return (remaining)
 end
 
@@ -118,65 +94,49 @@ end
 #
 
 @external
-func transfer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(recipient: felt, amount: Uint256) -> (success: felt):
+func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transfer(recipient, amount)
     return (TRUE)
 end
 
 @external
-func transferFrom{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(
-        sender: felt, 
-        recipient: felt, 
-        amount: Uint256
-    ) -> (success: felt):
+func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    sender : felt, recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transferFrom(sender, recipient, amount)
     return (TRUE)
 end
 
 @external
-func approve{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, amount: Uint256) -> (success: felt):
+func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, amount : Uint256
+) -> (success : felt):
     ERC20_approve(spender, amount)
     return (TRUE)
 end
 
 @external
-func increaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, added_value: Uint256) -> (success: felt):
+func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, added_value : Uint256
+) -> (success : felt):
     ERC20_increaseAllowance(spender, added_value)
     return (TRUE)
 end
 
 @external
-func decreaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, subtracted_value : Uint256
+) -> (success : felt):
     ERC20_decreaseAllowance(spender, subtracted_value)
     return (TRUE)
 end
 
 @external
-func mint{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(to: felt, amount: Uint256):
+func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    to : felt, amount : Uint256
+):
     Ownable_only_owner()
     ERC20_mint(to, amount)
     return ()

--- a/contracts/lib/openzeppelin/token/erc20/ERC20_Pausable.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20_Pausable.cairo
@@ -13,43 +13,35 @@ from openzeppelin.token.erc20.library import (
     ERC20_decimals,
     ERC20_balanceOf,
     ERC20_allowance,
-
     ERC20_initializer,
     ERC20_approve,
     ERC20_increaseAllowance,
     ERC20_decreaseAllowance,
     ERC20_transfer,
     ERC20_transferFrom,
-    ERC20_mint
+    ERC20_mint,
 )
 
-from openzeppelin.access.ownable import (
-    Ownable_initializer,
-    Ownable_only_owner
-)
+from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
 
 from openzeppelin.security.pausable import (
     Pausable_paused,
     Pausable_pause,
     Pausable_unpause,
-    Pausable_when_not_paused
+    Pausable_when_not_paused,
 )
 
 from openzeppelin.utils.constants import TRUE
 
 @constructor
-func constructor{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(
-        name: felt,
-        symbol: felt,
-        decimals: felt,
-        initial_supply: Uint256,
-        recipient: felt,
-        owner: felt
-    ):
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    name : felt,
+    symbol : felt,
+    decimals : felt,
+    initial_supply : Uint256,
+    recipient : felt,
+    owner : felt,
+):
     ERC20_initializer(name, symbol, decimals)
     ERC20_mint(recipient, initial_supply)
     Ownable_initializer(owner)
@@ -61,71 +53,51 @@ end
 #
 
 @view
-func name{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (name: felt):
+func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
     let (name) = ERC20_name()
     return (name)
 end
 
 @view
-func symbol{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (symbol: felt):
+func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
     let (symbol) = ERC20_symbol()
     return (symbol)
 end
 
 @view
-func totalSupply{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (totalSupply: Uint256):
-    let (totalSupply: Uint256) = ERC20_totalSupply()
+func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    totalSupply : Uint256
+):
+    let (totalSupply : Uint256) = ERC20_totalSupply()
     return (totalSupply)
 end
 
 @view
-func decimals{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (decimals: felt):
+func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    decimals : felt
+):
     let (decimals) = ERC20_decimals()
     return (decimals)
 end
 
 @view
-func balanceOf{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(account: felt) -> (balance: Uint256):
-    let (balance: Uint256) = ERC20_balanceOf(account)
+func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    account : felt
+) -> (balance : Uint256):
+    let (balance : Uint256) = ERC20_balanceOf(account)
     return (balance)
 end
 
 @view
-func allowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(owner: felt, spender: felt) -> (remaining: Uint256):
-    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    owner : felt, spender : felt
+) -> (remaining : Uint256):
+    let (remaining : Uint256) = ERC20_allowance(owner, spender)
     return (remaining)
 end
 
 @view
-func paused{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }() -> (paused: felt):
+func paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (paused : felt):
     let (paused) = Pausable_paused.read()
     return (paused)
 end
@@ -135,81 +107,59 @@ end
 #
 
 @external
-func transfer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(recipient: felt, amount: Uint256) -> (success: felt):
+func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    recipient : felt, amount : Uint256
+) -> (success : felt):
     Pausable_when_not_paused()
     ERC20_transfer(recipient, amount)
     return (TRUE)
 end
 
 @external
-func transferFrom{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(
-        sender: felt, 
-        recipient: felt, 
-        amount: Uint256
-    ) -> (success: felt):
+func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    sender : felt, recipient : felt, amount : Uint256
+) -> (success : felt):
     Pausable_when_not_paused()
     ERC20_transferFrom(sender, recipient, amount)
     return (TRUE)
 end
 
 @external
-func approve{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, amount: Uint256) -> (success: felt):
+func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, amount : Uint256
+) -> (success : felt):
     Pausable_when_not_paused()
     ERC20_approve(spender, amount)
     return (TRUE)
 end
 
 @external
-func increaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, added_value: Uint256) -> (success: felt):
+func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, added_value : Uint256
+) -> (success : felt):
     Pausable_when_not_paused()
     ERC20_increaseAllowance(spender, added_value)
     return (TRUE)
 end
 
 @external
-func decreaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, subtracted_value : Uint256
+) -> (success : felt):
     Pausable_when_not_paused()
     ERC20_decreaseAllowance(spender, subtracted_value)
     return (TRUE)
 end
 
 @external
-func pause{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }():
+func pause{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     Ownable_only_owner()
     Pausable_pause()
     return ()
 end
 
 @external
-func unpause{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }():
+func unpause{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     Ownable_only_owner()
     Pausable_unpause()
     return ()

--- a/contracts/lib/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
@@ -14,20 +14,19 @@ from openzeppelin.token.erc20.library import (
     ERC20_decimals,
     ERC20_balanceOf,
     ERC20_allowance,
-
     ERC20_initializer,
     ERC20_approve,
     ERC20_increaseAllowance,
     ERC20_decreaseAllowance,
     ERC20_transfer,
     ERC20_transferFrom,
-    ERC20_mint
+    ERC20_mint,
 )
 
 from openzeppelin.upgrades.library import (
     Proxy_initializer,
     Proxy_only_admin,
-    Proxy_set_implementation
+    Proxy_set_implementation,
 )
 
 from openzeppelin.utils.constants import TRUE
@@ -37,18 +36,14 @@ from openzeppelin.utils.constants import TRUE
 #
 
 @external
-func initializer{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(
-        name: felt,
-        symbol: felt,
-        decimals: felt,
-        initial_supply: Uint256,
-        recipient: felt,
-        proxy_admin: felt
-    ):
+func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    name : felt,
+    symbol : felt,
+    decimals : felt,
+    initial_supply : Uint256,
+    recipient : felt,
+    proxy_admin : felt,
+):
     ERC20_initializer(name, symbol, decimals)
     ERC20_mint(recipient, initial_supply)
     Proxy_initializer(proxy_admin)
@@ -56,11 +51,9 @@ func initializer{
 end
 
 @external
-func upgrade{
-        syscall_ptr: felt*, 
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(new_implementation: felt):
+func upgrade{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    new_implementation : felt
+):
     Proxy_only_admin()
     Proxy_set_implementation(new_implementation)
     return ()
@@ -71,62 +64,46 @@ end
 #
 
 @view
-func name{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (name: felt):
+func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
     let (name) = ERC20_name()
     return (name)
 end
 
 @view
-func symbol{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (symbol: felt):
+func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
     let (symbol) = ERC20_symbol()
     return (symbol)
 end
 
 @view
-func totalSupply{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (totalSupply: Uint256):
-    let (totalSupply: Uint256) = ERC20_totalSupply()
+func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    totalSupply : Uint256
+):
+    let (totalSupply : Uint256) = ERC20_totalSupply()
     return (totalSupply)
 end
 
 @view
-func decimals{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (decimals: felt):
+func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    decimals : felt
+):
     let (decimals) = ERC20_decimals()
     return (decimals)
 end
 
 @view
-func balanceOf{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(account: felt) -> (balance: Uint256):
-    let (balance: Uint256) = ERC20_balanceOf(account)
+func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    account : felt
+) -> (balance : Uint256):
+    let (balance : Uint256) = ERC20_balanceOf(account)
     return (balance)
 end
 
 @view
-func allowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(owner: felt, spender: felt) -> (remaining: Uint256):
-    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    owner : felt, spender : felt
+) -> (remaining : Uint256):
+    let (remaining : Uint256) = ERC20_allowance(owner, spender)
     return (remaining)
 end
 
@@ -135,55 +112,41 @@ end
 #
 
 @external
-func transfer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(recipient: felt, amount: Uint256) -> (success: felt):
+func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transfer(recipient, amount)
     return (TRUE)
 end
 
 @external
-func transferFrom{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(
-        sender: felt, 
-        recipient: felt, 
-        amount: Uint256
-    ) -> (success: felt):
+func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    sender : felt, recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transferFrom(sender, recipient, amount)
     return (TRUE)
 end
 
 @external
-func approve{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, amount: Uint256) -> (success: felt):
+func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, amount : Uint256
+) -> (success : felt):
     ERC20_approve(spender, amount)
     return (TRUE)
 end
 
 @external
-func increaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, added_value: Uint256) -> (success: felt):
+func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, added_value : Uint256
+) -> (success : felt):
     ERC20_increaseAllowance(spender, added_value)
     return (TRUE)
 end
 
 @external
-func decreaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, subtracted_value : Uint256
+) -> (success : felt):
     ERC20_decreaseAllowance(spender, subtracted_value)
     return (TRUE)
 end

--- a/contracts/lib/openzeppelin/token/erc20/interfaces/IERC20.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/interfaces/IERC20.cairo
@@ -7,35 +7,30 @@ from starkware.cairo.common.uint256 import Uint256
 
 @contract_interface
 namespace IERC20:
-    func name() -> (name: felt):
+    func name() -> (name : felt):
     end
 
-    func symbol() -> (symbol: felt):
+    func symbol() -> (symbol : felt):
     end
 
-    func decimals() -> (decimals: felt):
+    func decimals() -> (decimals : felt):
     end
 
-    func totalSupply() -> (totalSupply: Uint256):
+    func totalSupply() -> (totalSupply : Uint256):
     end
 
-    func balanceOf(account: felt) -> (balance: Uint256):
+    func balanceOf(account : felt) -> (balance : Uint256):
     end
 
-    func allowance(owner: felt, spender: felt) -> (remaining: Uint256):
+    func allowance(owner : felt, spender : felt) -> (remaining : Uint256):
     end
 
-    func transfer(recipient: felt, amount: Uint256) -> (success: felt):
+    func transfer(recipient : felt, amount : Uint256) -> (success : felt):
     end
 
-    func transferFrom(
-            sender: felt, 
-            recipient: felt, 
-            amount: Uint256
-        ) -> (success: felt):
+    func transferFrom(sender : felt, recipient : felt, amount : Uint256) -> (success : felt):
     end
 
-    func approve(spender: felt, amount: Uint256) -> (success: felt):
+    func approve(spender : felt, amount : Uint256) -> (success : felt):
     end
 end
-

--- a/contracts/lib/openzeppelin/token/erc20/library.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/library.cairo
@@ -7,7 +7,12 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.math import assert_not_zero, assert_lt
 from starkware.cairo.common.uint256 import (
-    Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt, uint256_check
+    Uint256,
+    uint256_add,
+    uint256_sub,
+    uint256_le,
+    uint256_lt,
+    uint256_check,
 )
 
 from openzeppelin.utils.constants import UINT8_MAX
@@ -17,11 +22,11 @@ from openzeppelin.utils.constants import UINT8_MAX
 #
 
 @event
-func Transfer(_from: felt, to: felt, value: Uint256):
+func Transfer(_from : felt, to : felt, value : Uint256):
 end
 
 @event
-func Approval(owner: felt, spender: felt, value: Uint256):
+func Approval(owner : felt, spender : felt, value : Uint256):
 end
 
 #
@@ -29,42 +34,36 @@ end
 #
 
 @storage_var
-func ERC20_name_() -> (name: felt):
+func ERC20_name_() -> (name : felt):
 end
 
 @storage_var
-func ERC20_symbol_() -> (symbol: felt):
+func ERC20_symbol_() -> (symbol : felt):
 end
 
 @storage_var
-func ERC20_decimals_() -> (decimals: felt):
+func ERC20_decimals_() -> (decimals : felt):
 end
 
 @storage_var
-func ERC20_total_supply() -> (total_supply: Uint256):
+func ERC20_total_supply() -> (total_supply : Uint256):
 end
 
 @storage_var
-func ERC20_balances(account: felt) -> (balance: Uint256):
+func ERC20_balances(account : felt) -> (balance : Uint256):
 end
 
 @storage_var
-func ERC20_allowances(owner: felt, spender: felt) -> (allowance: Uint256):
+func ERC20_allowances(owner : felt, spender : felt) -> (allowance : Uint256):
 end
 
 #
 # Constructor
 #
 
-func ERC20_initializer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(
-        name: felt,
-        symbol: felt,
-        decimals: felt
-    ):
+func ERC20_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    name : felt, symbol : felt, decimals : felt
+):
     ERC20_name_.write(name)
     ERC20_symbol_.write(symbol)
     assert_lt(decimals, UINT8_MAX)
@@ -72,100 +71,78 @@ func ERC20_initializer{
     return ()
 end
 
-func ERC20_name{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (name: felt):
+func ERC20_name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    name : felt
+):
     let (name) = ERC20_name_.read()
     return (name)
 end
 
-func ERC20_symbol{
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (symbol: felt):
+func ERC20_symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    symbol : felt
+):
     let (symbol) = ERC20_symbol_.read()
     return (symbol)
 end
 
-func ERC20_totalSupply{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (totalSupply: Uint256):
-    let (totalSupply: Uint256) = ERC20_total_supply.read()
+func ERC20_totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    totalSupply : Uint256
+):
+    let (totalSupply : Uint256) = ERC20_total_supply.read()
     return (totalSupply)
 end
 
-func ERC20_decimals{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }() -> (decimals: felt):
+func ERC20_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    decimals : felt
+):
     let (decimals) = ERC20_decimals_.read()
     return (decimals)
 end
 
-func ERC20_balanceOf{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(account: felt) -> (balance: Uint256):
-    let (balance: Uint256) = ERC20_balances.read(account)
+func ERC20_balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    account : felt
+) -> (balance : Uint256):
+    let (balance : Uint256) = ERC20_balances.read(account)
     return (balance)
 end
 
-func ERC20_allowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(owner: felt, spender: felt) -> (remaining: Uint256):
-    let (remaining: Uint256) = ERC20_allowances.read(owner, spender)
+func ERC20_allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    owner : felt, spender : felt
+) -> (remaining : Uint256):
+    let (remaining : Uint256) = ERC20_allowances.read(owner, spender)
     return (remaining)
 end
 
-func ERC20_transfer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(recipient: felt, amount: Uint256):
+func ERC20_transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    recipient : felt, amount : Uint256
+):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
     return ()
 end
 
-func ERC20_transferFrom{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(
-        sender: felt, 
-        recipient: felt, 
-        amount: Uint256
-    ) -> ():
+func ERC20_transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    sender : felt, recipient : felt, amount : Uint256
+) -> ():
     alloc_locals
     let (caller) = get_caller_address()
-    let (caller_allowance: Uint256) = ERC20_allowances.read(owner=sender, spender=caller)
+    let (caller_allowance : Uint256) = ERC20_allowances.read(owner=sender, spender=caller)
 
-    # validates amount <= caller_allowance and returns 1 if true   
+    # validates amount <= caller_allowance and returns 1 if true
     let (enough_allowance) = uint256_le(amount, caller_allowance)
     assert_not_zero(enough_allowance)
 
     _transfer(sender, recipient, amount)
 
     # subtract allowance
-    let (new_allowance: Uint256) = uint256_sub(caller_allowance, amount)
+    let (new_allowance : Uint256) = uint256_sub(caller_allowance, amount)
     ERC20_allowances.write(sender, caller, new_allowance)
     return ()
 end
 
-func ERC20_approve{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, amount: Uint256):
+func ERC20_approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, amount : Uint256
+):
     let (caller) = get_caller_address()
     assert_not_zero(caller)
     assert_not_zero(spender)
@@ -175,35 +152,31 @@ func ERC20_approve{
     return ()
 end
 
-func ERC20_increaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, added_value: Uint256) -> ():
+func ERC20_increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, added_value : Uint256
+) -> ():
     uint256_check(added_value)
     let (caller) = get_caller_address()
-    let (current_allowance: Uint256) = ERC20_allowances.read(caller, spender)
+    let (current_allowance : Uint256) = ERC20_allowances.read(caller, spender)
 
     # add allowance
-    let (new_allowance: Uint256, is_overflow) = uint256_add(current_allowance, added_value)
+    let (new_allowance : Uint256, is_overflow) = uint256_add(current_allowance, added_value)
     assert (is_overflow) = 0
 
     ERC20_approve(spender, new_allowance)
     return ()
 end
 
-func ERC20_decreaseAllowance{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(spender: felt, subtracted_value: Uint256) -> ():
+func ERC20_decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    spender : felt, subtracted_value : Uint256
+) -> ():
     alloc_locals
     uint256_check(subtracted_value)
     let (caller) = get_caller_address()
-    let (current_allowance: Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
-    let (new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
+    let (current_allowance : Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
+    let (new_allowance : Uint256) = uint256_sub(current_allowance, subtracted_value)
 
-    # validates new_allowance < current_allowance and returns 1 if true   
+    # validates new_allowance < current_allowance and returns 1 if true
     let (enough_allowance) = uint256_lt(new_allowance, current_allowance)
     assert_not_zero(enough_allowance)
 
@@ -211,22 +184,20 @@ func ERC20_decreaseAllowance{
     return ()
 end
 
-func ERC20_mint{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(recipient: felt, amount: Uint256):
+func ERC20_mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    recipient : felt, amount : Uint256
+):
     assert_not_zero(recipient)
     uint256_check(amount)
 
-    let (balance: Uint256) = ERC20_balances.read(account=recipient)
+    let (balance : Uint256) = ERC20_balances.read(account=recipient)
     # overflow is not possible because sum is guaranteed to be less than total supply
     # which we check for overflow below
-    let (new_balance, _: Uint256) = uint256_add(balance, amount)
+    let (new_balance, _ : Uint256) = uint256_add(balance, amount)
     ERC20_balances.write(recipient, new_balance)
 
-    let (supply: Uint256) = ERC20_total_supply.read()
-    let (new_supply: Uint256, is_overflow) = uint256_add(supply, amount)
+    let (supply : Uint256) = ERC20_total_supply.read()
+    let (new_supply : Uint256, is_overflow) = uint256_add(supply, amount)
     assert (is_overflow) = 0
 
     ERC20_total_supply.write(new_supply)
@@ -234,25 +205,23 @@ func ERC20_mint{
     return ()
 end
 
-func ERC20_burn{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(account: felt, amount: Uint256):
+func ERC20_burn{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    account : felt, amount : Uint256
+):
     alloc_locals
     assert_not_zero(account)
     uint256_check(amount)
 
-    let (balance: Uint256) = ERC20_balances.read(account)
+    let (balance : Uint256) = ERC20_balances.read(account)
     # validates amount <= balance and returns 1 if true
     let (enough_balance) = uint256_le(amount, balance)
     assert_not_zero(enough_balance)
-    
-    let (new_balance: Uint256) = uint256_sub(balance, amount)
+
+    let (new_balance : Uint256) = uint256_sub(balance, amount)
     ERC20_balances.write(account, new_balance)
 
-    let (supply: Uint256) = ERC20_total_supply.read()
-    let (new_supply: Uint256) = uint256_sub(supply, amount)
+    let (supply : Uint256) = ERC20_total_supply.read()
+    let (new_supply : Uint256) = uint256_sub(supply, amount)
     ERC20_total_supply.write(new_supply)
     Transfer.emit(account, 0, amount)
     return ()
@@ -262,30 +231,28 @@ end
 # Internal
 #
 
-func _transfer{
-        syscall_ptr : felt*, 
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(sender: felt, recipient: felt, amount: Uint256):
+func _transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    sender : felt, recipient : felt, amount : Uint256
+):
     alloc_locals
     assert_not_zero(sender)
     assert_not_zero(recipient)
-    uint256_check(amount) # almost surely not needed, might remove after confirmation
+    uint256_check(amount)  # almost surely not needed, might remove after confirmation
 
-    let (sender_balance: Uint256) = ERC20_balances.read(account=sender)
+    let (sender_balance : Uint256) = ERC20_balances.read(account=sender)
 
     # validates amount <= sender_balance and returns 1 if true
     let (enough_balance) = uint256_le(amount, sender_balance)
     assert_not_zero(enough_balance)
 
     # subtract from sender
-    let (new_sender_balance: Uint256) = uint256_sub(sender_balance, amount)
+    let (new_sender_balance : Uint256) = uint256_sub(sender_balance, amount)
     ERC20_balances.write(sender, new_sender_balance)
 
     # add to recipient
-    let (recipient_balance: Uint256) = ERC20_balances.read(account=recipient)
+    let (recipient_balance : Uint256) = ERC20_balances.read(account=recipient)
     # overflow is not possible because sum is guaranteed by mint to be less than total supply
-    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, amount)
+    let (new_recipient_balance, _ : Uint256) = uint256_add(recipient_balance, amount)
     ERC20_balances.write(recipient, new_recipient_balance)
     Transfer.emit(sender, recipient, amount)
     return ()

--- a/contracts/lib/openzeppelin/upgrades/Proxy.cairo
+++ b/contracts/lib/openzeppelin/upgrades/Proxy.cairo
@@ -5,21 +5,16 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import delegate_l1_handler, delegate_call
-from openzeppelin.upgrades.library import (
-    Proxy_implementation_address,
-    Proxy_set_implementation
-)
+from openzeppelin.upgrades.library import Proxy_implementation_address, Proxy_set_implementation
 
 #
 # Constructor
 #
 
 @constructor
-func constructor{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(implementation_address: felt):
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    implementation_address : felt
+):
     Proxy_set_implementation(implementation_address)
     return ()
 end
@@ -31,25 +26,16 @@ end
 @external
 @raw_input
 @raw_output
-func __default__{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(
-        selector: felt,
-        calldata_size: felt,
-        calldata: felt*
-    ) -> (
-        retdata_size: felt,
-        retdata: felt*
-    ):
+func __default__{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    selector : felt, calldata_size : felt, calldata : felt*
+) -> (retdata_size : felt, retdata : felt*):
     let (address) = Proxy_implementation_address.read()
 
-    let (retdata_size: felt, retdata: felt*) = delegate_call(
+    let (retdata_size : felt, retdata : felt*) = delegate_call(
         contract_address=address,
         function_selector=selector,
         calldata_size=calldata_size,
-        calldata=calldata
+        calldata=calldata,
     )
 
     return (retdata_size=retdata_size, retdata=retdata)
@@ -57,22 +43,16 @@ end
 
 @l1_handler
 @raw_input
-func __l1_default__{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(
-        selector: felt,
-        calldata_size: felt,
-        calldata: felt*
-    ):
+func __l1_default__{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    selector : felt, calldata_size : felt, calldata : felt*
+):
     let (address) = Proxy_implementation_address.read()
 
     delegate_l1_handler(
         contract_address=address,
         function_selector=selector,
         calldata_size=calldata_size,
-        calldata=calldata
+        calldata=calldata,
     )
 
     return ()

--- a/contracts/lib/openzeppelin/upgrades/library.cairo
+++ b/contracts/lib/openzeppelin/upgrades/library.cairo
@@ -12,7 +12,7 @@ from openzeppelin.utils.constants import TRUE, FALSE
 #
 
 @event
-func Upgraded(implementation: felt):
+func Upgraded(implementation : felt):
 end
 
 #
@@ -20,26 +20,24 @@ end
 #
 
 @storage_var
-func Proxy_implementation_address() -> (implementation_address: felt):
+func Proxy_implementation_address() -> (implementation_address : felt):
 end
 
 @storage_var
-func Proxy_admin() -> (proxy_admin: felt):
+func Proxy_admin() -> (proxy_admin : felt):
 end
 
 @storage_var
-func Proxy_initialized() -> (initialized: felt):
+func Proxy_initialized() -> (initialized : felt):
 end
 
 #
 # Initializer
 #
 
-func Proxy_initializer{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(proxy_admin: felt):
+func Proxy_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    proxy_admin : felt
+):
     let (initialized) = Proxy_initialized.read()
     with_attr error_message("Proxy: contract already initialized"):
         assert initialized = FALSE
@@ -54,11 +52,9 @@ end
 # Upgrades
 #
 
-func Proxy_set_implementation{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(new_implementation: felt):
+func Proxy_set_implementation{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    new_implementation : felt
+):
     Proxy_implementation_address.write(new_implementation)
     Upgraded.emit(new_implementation)
     return ()
@@ -68,11 +64,7 @@ end
 # Guards
 #
 
-func Proxy_only_admin{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }():
+func Proxy_only_admin{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     let (caller) = get_caller_address()
     let (admin) = Proxy_admin.read()
     with_attr error_message("Proxy: caller is not admin"):
@@ -85,33 +77,26 @@ end
 # Getters
 #
 
-func Proxy_get_admin{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }() -> (admin: felt):
+func Proxy_get_admin{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    admin : felt
+):
     let (admin) = Proxy_admin.read()
     return (admin)
-end 
+end
 
-func Proxy_get_implementation{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }() -> (implementation: felt):
+func Proxy_get_implementation{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    ) -> (implementation : felt):
     let (implementation) = Proxy_implementation_address.read()
     return (implementation)
-end 
+end
 
 #
 # Setters
 #
 
-func Proxy_set_admin{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(new_admin: felt):
+func Proxy_set_admin{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    new_admin : felt
+):
     Proxy_admin.write(new_admin)
     return ()
-end 
+end


### PR DESCRIPTION
I decided we should lint the OZ library as well. It's still immature and missing things we will need so we'll have to make our own changes to it. That's why I'd rather have it linted, to have a standardized format.