### PR TITLE
dev: Account class for test accounts

### DIFF
--- a/tests/account.py
+++ b/tests/account.py
@@ -1,0 +1,83 @@
+from utils import compile_contract, str_to_felt, Calldata, Call
+from starkware.cairo.common.hash_state import compute_hash_on_elements
+from starkware.crypto.signature.signature import private_to_stark_key, sign
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.services.api.contract_definition import ContractDefinition
+from starkware.starknet.testing.starknet import Starknet
+
+# IDEA:
+# create a context manager out of the account
+# with acc.using(token_addr) as sender:
+#     tx = await sender.mint(1000)
+
+
+class Account:
+    """
+    Combines a signer and a deployed account contract into a single object
+    to simplify sending TXs in tests.
+    """
+
+    compiled_acconut_contract: ContractDefinition = compile_contract(
+        "contracts/lib/openzeppelin/account/Account.cairo"
+    )
+
+    def __init__(self, name):
+        self.private_key = abs(hash(name))
+        self.public_key = private_to_stark_key(self.private_key)
+        self.nonce = 0
+        self.contract = None
+
+    @property
+    def address(self) -> str:
+        assert self.contract is not None, "Account contract was not deployed"
+        return self.contract.contract_address
+
+    async def deploy(self, starknet: Starknet):
+        self.contract = await starknet.deploy(
+            contract_def=Account.compiled_acconut_contract, constructor_calldata=[self.public_key]
+        )
+
+    async def send_tx(self, to: int, selector: str, calldata: Calldata, max_fee=0):
+        self.send_txs([to, selector, calldata], max_fee)
+
+    async def send_txs(self, calls: list[Call], max_fee=0):
+        calls_with_selector = [(c[0], get_selector_from_name(c[1]), c[2]) for c in calls]
+        call_array, calldata = from_call_to_call_array(calls)
+
+        nonce = self.nonce
+        self.nonce += 1
+
+        message_hash = hash_multicall(self.address, calls_with_selector, nonce, max_fee)
+        sig_r, sig_s = sign(message_hash, self.private_key)
+
+        return await self.contract.__execute__(call_array, calldata, nonce).invoke(
+            signature=[sig_r, sig_s]
+        )
+
+
+def from_call_to_call_array(calls):
+    call_array = []
+    calldata = []
+    for call in calls:
+        assert len(call) == 3, "Invalid call parameters"
+        entry = (call[0], get_selector_from_name(call[1]), len(calldata), len(call[2]))
+        call_array.append(entry)
+        calldata.extend(call[2])
+    return (call_array, calldata)
+
+
+def hash_multicall(sender, calls, nonce, max_fee):
+    hash_array = []
+    for call in calls:
+        call_elements = [call[0], call[1], compute_hash_on_elements(call[2])]
+        hash_array.append(compute_hash_on_elements(call_elements))
+
+    message = [
+        str_to_felt('StarkNet Transaction'),
+        sender,
+        compute_hash_on_elements(hash_array),
+        nonce,
+        max_fee,
+        0,  # transaction version
+    ]
+    return compute_hash_on_elements(message)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,13 @@
 """Utilities for testing Cairo contracts."""
 
-from starkware.cairo.common.hash_state import compute_hash_on_elements
-from starkware.crypto.signature.signature import private_to_stark_key, sign
+from functools import cache
+import os
+
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.business_logic.execution.objects import Event
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.services.api.contract_definition import ContractDefinition
 
 
 MAX_UINT256 = (2 ** 128 - 1, 2 ** 128 - 1)
@@ -12,7 +15,10 @@ ZERO_ADDRESS = 0
 TRUE = 1
 FALSE = 0
 
-TRANSACTION_VERSION = 0
+
+Uint256 = tuple[int, int]
+Calldata = list[int]  # payload arguments sent with a function call
+Call = tuple[int, str, Calldata]  # receiver address, selector (still as string) and payload
 
 
 def str_to_felt(text: str) -> int:
@@ -25,12 +31,12 @@ def felt_to_str(felt: int) -> str:
     return b_felt.decode()
 
 
-def to_uint(a):
+def to_uint(a: int) -> Uint256:
     """Takes in value, returns uint256-ish tuple."""
     return (a & ((1 << 128) - 1), a >> 128)
 
 
-def from_uint(uint):
+def from_uint(uint: Uint256) -> int:
     """Takes in uint256-ish tuple, returns value."""
     return uint[0] + (uint[1] << 128)
 
@@ -46,84 +52,21 @@ def assert_event_emitted(tx_exec_info, from_address, name, data):
     )
 
 
-class Signer:
-    """
-    Utility for sending signed transactions to an Account on Starknet.
-
-    Parameters
-    ----------
-
-    private_key : int
-
-    Examples
-    ---------
-    Constructing a Signer object
-
-    >>> signer = Signer(1234)
-
-    Sending a transaction
-
-    >>> await signer.send_transaction(account,
-                                      account.contract_address,
-                                      'set_public_key',
-                                      [other.public_key]
-                                     )
-
-    """
-
-    def __init__(self, private_key):
-        self.private_key = private_key
-        self.public_key = private_to_stark_key(private_key)
-
-    def sign(self, message_hash):
-        return sign(msg_hash=message_hash, priv_key=self.private_key)
-
-    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
-        return await self.send_transactions(
-            account, [(to, selector_name, calldata)], nonce, max_fee
-        )
-
-    async def send_transactions(self, account, calls, nonce=None, max_fee=0):
-        if nonce is None:
-            execution_info = await account.get_nonce().call()
-            (nonce,) = execution_info.result
-
-        calls_with_selector = [
-            (call[0], get_selector_from_name(call[1]), call[2]) for call in calls
-        ]
-        (call_array, calldata) = from_call_to_call_array(calls)
-
-        message_hash = hash_multicall(account.contract_address, calls_with_selector, nonce, max_fee)
-        sig_r, sig_s = self.sign(message_hash)
-
-        return await account.__execute__(call_array, calldata, nonce).invoke(
-            signature=[sig_r, sig_s]
-        )
+def here() -> str:
+    return os.path.abspath(os.path.dirname(__file__))
 
 
-def from_call_to_call_array(calls):
-    call_array = []
-    calldata = []
-    for i, call in enumerate(calls):
-        assert len(call) == 3, "Invalid call parameters"
-        entry = (call[0], get_selector_from_name(call[1]), len(calldata), len(call[2]))
-        call_array.append(entry)
-        calldata.extend(call[2])
-    return (call_array, calldata)
+def contract_path(rel_contract_path: str) -> str:
+    return os.path.join(here(), "..", rel_contract_path)
 
 
-def hash_multicall(sender, calls, nonce, max_fee):
-    hash_array = []
-    for call in calls:
-        call_elements = [call[0], call[1], compute_hash_on_elements(call[2])]
-        hash_array.append(compute_hash_on_elements(call_elements))
-
-    message = [
-        str_to_felt('StarkNet Transaction'),
-        sender,
-        compute_hash_on_elements(hash_array),
-        nonce,
-        max_fee,
-        TRANSACTION_VERSION,
-    ]
-    return compute_hash_on_elements(message)
+@cache
+def compile_contract(rel_contract_path: str) -> ContractDefinition:
+    contract_src = contract_path(rel_contract_path)
+    tld = os.path.join(here(), "..")
+    return compile_starknet_files(
+        [contract_src],
+        debug_info=True,
+        disable_hint_validation=True,
+        cairo_path=[tld, os.path.join(tld, "contracts", "lib")],
+    )


### PR DESCRIPTION
This PR adds a new `Account` class into the test suite that's handy when simulating various users interacting with contracts. It is based on OZ's Signer class from utils but encapsulates some needless details (I'm assuming the signer will always send a TX through their account contract). Together with the `users` factory in conftest it makes a decent combo for writing tests.

Instead of
```python
signer, account = await users("depositor")

await signer.send_transaction(
    account, token.contract_address, "approve", [aura.contract_address, *(100, 100)]
)
```
we now can
```python
depositor = await users("depositor")

await depositor.send_tx(aura.contract_address, "approve", [*(100, 100)])
```

I think we could even make a fancy context manager around an Account instance, but that's for another day.