### PR TITLE
style: storage_var convention

### DIFF
--- a/docs/CairoConventions.md
+++ b/docs/CairoConventions.md
@@ -22,19 +22,31 @@ from contracts.module.submodule.file_name import function
 
 This prevents any issues when compiling contracts.
 
-## Getters
+## @storage_var naming
 
-`@view` functions that retrieve a `@storage_var` (essentailly getters) should be named `get_FOO`:
+To prevent [`@storage_var` conflicts](https://github.com/crytic/amarna/issues/10) and clearly distinguish between a local variable and a storage container, a `@storage_var` should be named using the following template: `ModuleName_variable_name_storage` - that is, the variable name is prefixed by the module name and suffixed by the string `storage`, separated by underscores.
+
+An example of a variable named `balance` inside a module called `Treasury`:
 
 ```cairo
 @storage_var
-func amount() -> (amount : felt):
+func Treasury_balance_storage() -> (balance : felt):
+end
+```
+
+## Getters
+
+A `@view` function that retrieve a `@storage_var` (essentailly a getter) should be named `get_FOO`:
+
+```cairo
+@storage_var
+func Module_amount_storage() -> (amount : felt):
 end
 
 @view
 func get_amount{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (amount : felt):
-    let (amount_ : felt) = amount.read()
-    return (amount_)
+    let (amount : felt) = Module_amount_storage.read()
+    return (amount)
 end
 ```
 


### PR DESCRIPTION
Resolves #10 

The proposed convention is to use `ModuleName_variable_name_storage` as a template to declare `@storage_var`s, see the contents of the PR for details.

I'm not quite sold on the `_storage` suffix, it makes it rather verbose, but it's explicit.

Happy to discuss further if anyone has more input.