### PR TITLE
chore: update OpenZeppelin ERC20 library

### DIFF
--- a/contracts/USDa/USDa.cairo
+++ b/contracts/USDa/USDa.cairo
@@ -8,28 +8,13 @@ from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
-from contracts.lib.openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint,
-    ERC20_burn,
-)
+from contracts.lib.openzeppelin.token.erc20.library import ERC20
 
 from contracts.lib.openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(owner : felt):
-    ERC20_initializer('USDa', 'USDa', 18)
+    ERC20.initializer('USDa', 'USDa', 18)
     Ownable_initializer(owner)
     return ()
 end
@@ -40,13 +25,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC20_name()
+    let (name) = ERC20.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC20_symbol()
+    let (symbol) = ERC20.symbol()
     return (symbol)
 end
 
@@ -54,7 +39,7 @@ end
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     return (totalSupply)
 end
 
@@ -62,7 +47,7 @@ end
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     decimals : felt
 ):
-    let (decimals) = ERC20_decimals()
+    let (decimals) = ERC20.decimals()
     return (decimals)
 end
 
@@ -70,7 +55,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     account : felt
 ) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balanceOf(account)
+    let (balance : Uint256) = ERC20.balance_of(account)
     return (balance)
 end
 
@@ -78,7 +63,7 @@ end
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, spender : felt
 ) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowance(owner, spender)
+    let (remaining : Uint256) = ERC20.allowance(owner, spender)
     return (remaining)
 end
 
@@ -90,7 +75,7 @@ end
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transfer(recipient, amount)
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 
@@ -98,7 +83,7 @@ end
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     sender : felt, recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transferFrom(sender, recipient, amount)
+    ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
 
@@ -106,7 +91,7 @@ end
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_approve(spender, amount)
+    ERC20.approve(spender, amount)
     return (TRUE)
 end
 
@@ -114,7 +99,7 @@ end
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, added_value : Uint256
 ) -> (success : felt):
-    ERC20_increaseAllowance(spender, added_value)
+    ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
 
@@ -122,7 +107,7 @@ end
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, subtracted_value : Uint256
 ) -> (success : felt):
-    ERC20_decreaseAllowance(spender, subtracted_value)
+    ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
 end
 
@@ -131,7 +116,7 @@ func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     to : felt, amount : Uint256
 ) -> (success : felt):
     # Ownable_only_owner()
-    ERC20_mint(to, amount)
+    ERC20._mint(to, amount)
     return (TRUE)
 end
 
@@ -140,6 +125,6 @@ func burn{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, amount : Uint256
 ) -> (success : felt):
     # Ownable_only_owner()
-    ERC20_burn(owner, amount)
+    ERC20._burn(owner, amount)
     return (TRUE)
 end

--- a/contracts/lib/openzeppelin/security/safemath.cairo
+++ b/contracts/lib/openzeppelin/security/safemath.cairo
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Cairo Contracts v0.1.0 (security/safemath.cairo)
+# OpenZeppelin Contracts for Cairo v0.2.0 (security/safemath.cairo)
 
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.uint256 import (
     Uint256,
@@ -16,91 +17,98 @@ from starkware.cairo.common.uint256 import (
     uint256_lt,
     uint256_eq,
 )
-from openzeppelin.utils.constants import TRUE, FALSE
 
-# Adds two integers.
-# Reverts if the sum overflows.
-func uint256_checked_add{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    a : Uint256, b : Uint256
-) -> (c : Uint256):
-    uint256_check(a)
-    uint256_check(b)
-    let (c : Uint256, is_overflow) = uint256_add(a, b)
-    assert is_overflow = FALSE
-    return (c)
-end
-
-# Subtracts two integers.
-# Reverts if minuend (`b`) is greater than subtrahend (`a`).
-func uint256_checked_sub_le{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    a : Uint256, b : Uint256
-) -> (c : Uint256):
-    alloc_locals
-    uint256_check(a)
-    uint256_check(b)
-    let (is_le) = uint256_le(b, a)
-    assert is_le = TRUE
-    let (c : Uint256) = uint256_sub(a, b)
-    return (c)
-end
-
-# Subtracts two integers.
-# Reverts if minuend (`b`) is greater than or equal to subtrahend (`a`).
-func uint256_checked_sub_lt{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    a : Uint256, b : Uint256
-) -> (c : Uint256):
-    alloc_locals
-    uint256_check(a)
-    uint256_check(b)
-
-    let (is_lt) = uint256_lt(b, a)
-    assert is_lt = TRUE
-    let (c : Uint256) = uint256_sub(a, b)
-    return (c)
-end
-
-# Multiplies two integers.
-# Reverts if product is greater than 2^256.
-func uint256_checked_mul{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    a : Uint256, b : Uint256
-) -> (c : Uint256):
-    alloc_locals
-    uint256_check(a)
-    uint256_check(b)
-    let (a_zero) = uint256_eq(a, Uint256(0, 0))
-    if a_zero == TRUE:
-        return (a)
+namespace SafeUint256:
+    # Adds two integers.
+    # Reverts if the sum overflows.
+    func add{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        a : Uint256, b : Uint256
+    ) -> (c : Uint256):
+        uint256_check(a)
+        uint256_check(b)
+        let (c : Uint256, is_overflow) = uint256_add(a, b)
+        with_attr error_message("SafeUint256: addition overflow"):
+            assert is_overflow = FALSE
+        end
+        return (c)
     end
 
-    let (b_zero) = uint256_eq(b, Uint256(0, 0))
-    if b_zero == TRUE:
-        return (b)
+    # Subtracts two integers.
+    # Reverts if minuend (`b`) is greater than subtrahend (`a`).
+    func sub_le{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        a : Uint256, b : Uint256
+    ) -> (c : Uint256):
+        alloc_locals
+        uint256_check(a)
+        uint256_check(b)
+        let (is_le) = uint256_le(b, a)
+        with_attr error_message("SafeUint256: subtraction overflow"):
+            assert is_le = TRUE
+        end
+        let (c : Uint256) = uint256_sub(a, b)
+        return (c)
     end
 
-    let (c : Uint256, overflow : Uint256) = uint256_mul(a, b)
-    with_attr error_message("Safemath: multiplication overflow"):
-        assert overflow = Uint256(0, 0)
-    end
-    return (c)
-end
+    # Subtracts two integers.
+    # Reverts if minuend (`b`) is greater than or equal to subtrahend (`a`).
+    func sub_lt{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        a : Uint256, b : Uint256
+    ) -> (c : Uint256):
+        alloc_locals
+        uint256_check(a)
+        uint256_check(b)
 
-# Integer division of two numbers. Returns uint256 quotient and remainder.
-# Reverts if divisor is zero as per OpenZeppelin's Solidity implementation.
-# Cairo's `uint256_unsigned_div_rem` already checks:
-#    remainder < divisor
-#    quotient * divisor + remainder == dividend
-func uint256_checked_div_rem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    a : Uint256, b : Uint256
-) -> (c : Uint256, rem : Uint256):
-    alloc_locals
-    uint256_check(a)
-    uint256_check(b)
-
-    let (is_zero) = uint256_eq(b, Uint256(0, 0))
-    with_attr error_message("Safemath: divisor cannot be zero"):
-        assert is_zero = FALSE
+        let (is_lt) = uint256_lt(b, a)
+        with_attr error_message("SafeUint256: subtraction overflow or the difference equals zero"):
+            assert is_lt = TRUE
+        end
+        let (c : Uint256) = uint256_sub(a, b)
+        return (c)
     end
 
-    let (c : Uint256, rem : Uint256) = uint256_unsigned_div_rem(a, b)
-    return (c, rem)
+    # Multiplies two integers.
+    # Reverts if product is greater than 2^256.
+    func mul{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        a : Uint256, b : Uint256
+    ) -> (c : Uint256):
+        alloc_locals
+        uint256_check(a)
+        uint256_check(b)
+        let (a_zero) = uint256_eq(a, Uint256(0, 0))
+        if a_zero == TRUE:
+            return (a)
+        end
+
+        let (b_zero) = uint256_eq(b, Uint256(0, 0))
+        if b_zero == TRUE:
+            return (b)
+        end
+
+        let (c : Uint256, overflow : Uint256) = uint256_mul(a, b)
+        with_attr error_message("SafeUint256: multiplication overflow"):
+            assert overflow = Uint256(0, 0)
+        end
+        return (c)
+    end
+
+    # Integer division of two numbers. Returns uint256 quotient and remainder.
+    # Reverts if divisor is zero as per OpenZeppelin's Solidity implementation.
+    # Cairo's `uint256_unsigned_div_rem` already checks:
+    #    remainder < divisor
+    #    quotient * divisor + remainder == dividend
+    func div_rem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        a : Uint256, b : Uint256
+    ) -> (c : Uint256, rem : Uint256):
+        alloc_locals
+        uint256_check(a)
+        uint256_check(b)
+
+        let (is_zero) = uint256_eq(b, Uint256(0, 0))
+        with_attr error_message("SafeUint256: divisor cannot be zero"):
+            assert is_zero = FALSE
+        end
+
+        let (c : Uint256, rem : Uint256) = uint256_unsigned_div_rem(a, b)
+        return (c, rem)
+    end
 end

--- a/contracts/lib/openzeppelin/token/erc20/ERC20.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20.cairo
@@ -1,35 +1,20 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20.cairo)
+# OpenZeppelin Contracts for Cairo v0.2.0 (token/erc20/ERC20.cairo)
 
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint,
-)
-
-from openzeppelin.utils.constants import TRUE
+from openzeppelin.token.erc20.library import ERC20
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     name : felt, symbol : felt, decimals : felt, initial_supply : Uint256, recipient : felt
 ):
-    ERC20_initializer(name, symbol, decimals)
-    ERC20_mint(recipient, initial_supply)
+    ERC20.initializer(name, symbol, decimals)
+    ERC20._mint(recipient, initial_supply)
     return ()
 end
 
@@ -39,13 +24,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC20_name()
+    let (name) = ERC20.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC20_symbol()
+    let (symbol) = ERC20.symbol()
     return (symbol)
 end
 
@@ -53,7 +38,7 @@ end
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     return (totalSupply)
 end
 
@@ -61,7 +46,7 @@ end
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     decimals : felt
 ):
-    let (decimals) = ERC20_decimals()
+    let (decimals) = ERC20.decimals()
     return (decimals)
 end
 
@@ -69,7 +54,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     account : felt
 ) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balanceOf(account)
+    let (balance : Uint256) = ERC20.balance_of(account)
     return (balance)
 end
 
@@ -77,7 +62,7 @@ end
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, spender : felt
 ) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowance(owner, spender)
+    let (remaining : Uint256) = ERC20.allowance(owner, spender)
     return (remaining)
 end
 
@@ -89,7 +74,7 @@ end
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transfer(recipient, amount)
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 
@@ -97,7 +82,7 @@ end
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     sender : felt, recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transferFrom(sender, recipient, amount)
+    ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
 
@@ -105,7 +90,7 @@ end
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_approve(spender, amount)
+    ERC20.approve(spender, amount)
     return (TRUE)
 end
 
@@ -113,7 +98,7 @@ end
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, added_value : Uint256
 ) -> (success : felt):
-    ERC20_increaseAllowance(spender, added_value)
+    ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
 
@@ -121,6 +106,6 @@ end
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, subtracted_value : Uint256
 ) -> (success : felt):
-    ERC20_decreaseAllowance(spender, subtracted_value)
+    ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
 end

--- a/contracts/lib/openzeppelin/token/erc20/ERC20_Mintable.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20_Mintable.cairo
@@ -1,43 +1,20 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20_Mintable.cairo)
+# OpenZeppelin Contracts for Cairo v0.2.0 (token/erc20/ERC20.cairo)
 
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint,
-)
-
-from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
-
-from openzeppelin.utils.constants import TRUE
+from openzeppelin.token.erc20.library import ERC20
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    name : felt,
-    symbol : felt,
-    decimals : felt,
-    initial_supply : Uint256,
-    recipient : felt,
-    owner : felt,
+    name : felt, symbol : felt, decimals : felt, initial_supply : Uint256, recipient : felt
 ):
-    ERC20_initializer(name, symbol, decimals)
-    ERC20_mint(recipient, initial_supply)
-    Ownable_initializer(owner)
+    ERC20.initializer(name, symbol, decimals)
+    ERC20._mint(recipient, initial_supply)
     return ()
 end
 
@@ -47,13 +24,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC20_name()
+    let (name) = ERC20.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC20_symbol()
+    let (symbol) = ERC20.symbol()
     return (symbol)
 end
 
@@ -61,7 +38,7 @@ end
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     return (totalSupply)
 end
 
@@ -69,7 +46,7 @@ end
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     decimals : felt
 ):
-    let (decimals) = ERC20_decimals()
+    let (decimals) = ERC20.decimals()
     return (decimals)
 end
 
@@ -77,7 +54,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     account : felt
 ) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balanceOf(account)
+    let (balance : Uint256) = ERC20.balance_of(account)
     return (balance)
 end
 
@@ -85,7 +62,7 @@ end
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, spender : felt
 ) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowance(owner, spender)
+    let (remaining : Uint256) = ERC20.allowance(owner, spender)
     return (remaining)
 end
 
@@ -97,7 +74,7 @@ end
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transfer(recipient, amount)
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 
@@ -105,7 +82,7 @@ end
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     sender : felt, recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transferFrom(sender, recipient, amount)
+    ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
 
@@ -113,7 +90,7 @@ end
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_approve(spender, amount)
+    ERC20.approve(spender, amount)
     return (TRUE)
 end
 
@@ -121,7 +98,7 @@ end
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, added_value : Uint256
 ) -> (success : felt):
-    ERC20_increaseAllowance(spender, added_value)
+    ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
 
@@ -129,15 +106,6 @@ end
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, subtracted_value : Uint256
 ) -> (success : felt):
-    ERC20_decreaseAllowance(spender, subtracted_value)
+    ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
-end
-
-@external
-func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    to : felt, amount : Uint256
-):
-    Ownable_only_owner()
-    ERC20_mint(to, amount)
-    return ()
 end

--- a/contracts/lib/openzeppelin/token/erc20/ERC20_Pausable.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20_Pausable.cairo
@@ -1,37 +1,17 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20_Pausable.cairo)
+# OpenZeppelin Contracts for Cairo v0.2.0 (token/erc20/ERC20_Pausable.cairo)
 
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint,
-)
+from openzeppelin.token.erc20.library import ERC20
 
-from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
+from openzeppelin.access.ownable import Ownable
 
-from openzeppelin.security.pausable import (
-    Pausable_paused,
-    Pausable_pause,
-    Pausable_unpause,
-    Pausable_when_not_paused,
-)
-
-from openzeppelin.utils.constants import TRUE
+from openzeppelin.security.pausable import Pausable
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
@@ -42,9 +22,9 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     recipient : felt,
     owner : felt,
 ):
-    ERC20_initializer(name, symbol, decimals)
-    ERC20_mint(recipient, initial_supply)
-    Ownable_initializer(owner)
+    ERC20.initializer(name, symbol, decimals)
+    ERC20._mint(recipient, initial_supply)
+    Ownable.initializer(owner)
     return ()
 end
 
@@ -54,13 +34,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC20_name()
+    let (name) = ERC20.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC20_symbol()
+    let (symbol) = ERC20.symbol()
     return (symbol)
 end
 
@@ -68,7 +48,7 @@ end
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     return (totalSupply)
 end
 
@@ -76,7 +56,7 @@ end
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     decimals : felt
 ):
-    let (decimals) = ERC20_decimals()
+    let (decimals) = ERC20.decimals()
     return (decimals)
 end
 
@@ -84,7 +64,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     account : felt
 ) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balanceOf(account)
+    let (balance : Uint256) = ERC20.balance_of(account)
     return (balance)
 end
 
@@ -92,13 +72,19 @@ end
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, spender : felt
 ) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowance(owner, spender)
+    let (remaining : Uint256) = ERC20.allowance(owner, spender)
     return (remaining)
 end
 
 @view
+func owner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (owner : felt):
+    let (owner : felt) = Ownable.owner()
+    return (owner)
+end
+
+@view
 func paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (paused : felt):
-    let (paused) = Pausable_paused.read()
+    let (paused) = Pausable.is_paused()
     return (paused)
 end
 
@@ -110,8 +96,8 @@ end
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ) -> (success : felt):
-    Pausable_when_not_paused()
-    ERC20_transfer(recipient, amount)
+    Pausable.assert_not_paused()
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 
@@ -119,8 +105,8 @@ end
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     sender : felt, recipient : felt, amount : Uint256
 ) -> (success : felt):
-    Pausable_when_not_paused()
-    ERC20_transferFrom(sender, recipient, amount)
+    Pausable.assert_not_paused()
+    ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
 
@@ -128,8 +114,8 @@ end
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, amount : Uint256
 ) -> (success : felt):
-    Pausable_when_not_paused()
-    ERC20_approve(spender, amount)
+    Pausable.assert_not_paused()
+    ERC20.approve(spender, amount)
     return (TRUE)
 end
 
@@ -137,8 +123,8 @@ end
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, added_value : Uint256
 ) -> (success : felt):
-    Pausable_when_not_paused()
-    ERC20_increaseAllowance(spender, added_value)
+    Pausable.assert_not_paused()
+    ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
 
@@ -146,21 +132,35 @@ end
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, subtracted_value : Uint256
 ) -> (success : felt):
-    Pausable_when_not_paused()
-    ERC20_decreaseAllowance(spender, subtracted_value)
+    Pausable.assert_not_paused()
+    ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
 end
 
 @external
+func transferOwnership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    newOwner : felt
+):
+    Ownable.transfer_ownership(newOwner)
+    return ()
+end
+
+@external
+func renounceOwnership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    Ownable.renounce_ownership()
+    return ()
+end
+
+@external
 func pause{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
-    Ownable_only_owner()
-    Pausable_pause()
+    Ownable.assert_only_owner()
+    Pausable._pause()
     return ()
 end
 
 @external
 func unpause{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
-    Ownable_only_owner()
-    Pausable_unpause()
+    Ownable.assert_only_owner()
+    Pausable._unpause()
     return ()
 end

--- a/contracts/lib/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
@@ -1,35 +1,16 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20_Upgradeable.cairo)
+# OpenZeppelin Contracts for Cairo v0.2.0 (token/erc20/ERC20_Upgradeable.cairo)
 
 %lang starknet
 %builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint,
-)
+from openzeppelin.token.erc20.library import ERC20
 
-from openzeppelin.upgrades.library import (
-    Proxy_initializer,
-    Proxy_only_admin,
-    Proxy_set_implementation,
-)
-
-from openzeppelin.utils.constants import TRUE
+from openzeppelin.upgrades.library import Proxy
 
 #
 # Initializer
@@ -44,9 +25,9 @@ func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     recipient : felt,
     proxy_admin : felt,
 ):
-    ERC20_initializer(name, symbol, decimals)
-    ERC20_mint(recipient, initial_supply)
-    Proxy_initializer(proxy_admin)
+    ERC20.initializer(name, symbol, decimals)
+    ERC20._mint(recipient, initial_supply)
+    Proxy.initializer(proxy_admin)
     return ()
 end
 
@@ -54,8 +35,8 @@ end
 func upgrade{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     new_implementation : felt
 ):
-    Proxy_only_admin()
-    Proxy_set_implementation(new_implementation)
+    Proxy.assert_only_admin()
+    Proxy._set_implementation_hash(new_implementation)
     return ()
 end
 
@@ -65,13 +46,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC20_name()
+    let (name) = ERC20.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC20_symbol()
+    let (symbol) = ERC20.symbol()
     return (symbol)
 end
 
@@ -79,7 +60,7 @@ end
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     return (totalSupply)
 end
 
@@ -87,7 +68,7 @@ end
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     decimals : felt
 ):
-    let (decimals) = ERC20_decimals()
+    let (decimals) = ERC20.decimals()
     return (decimals)
 end
 
@@ -95,7 +76,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     account : felt
 ) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balanceOf(account)
+    let (balance : Uint256) = ERC20.balance_of(account)
     return (balance)
 end
 
@@ -103,7 +84,7 @@ end
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, spender : felt
 ) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowance(owner, spender)
+    let (remaining : Uint256) = ERC20.allowance(owner, spender)
     return (remaining)
 end
 
@@ -115,7 +96,7 @@ end
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transfer(recipient, amount)
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 
@@ -123,7 +104,7 @@ end
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     sender : felt, recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transferFrom(sender, recipient, amount)
+    ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
 
@@ -131,7 +112,7 @@ end
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_approve(spender, amount)
+    ERC20.approve(spender, amount)
     return (TRUE)
 end
 
@@ -139,7 +120,7 @@ end
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, added_value : Uint256
 ) -> (success : felt):
-    ERC20_increaseAllowance(spender, added_value)
+    ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
 
@@ -147,6 +128,6 @@ end
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, subtracted_value : Uint256
 ) -> (success : felt):
-    ERC20_decreaseAllowance(spender, subtracted_value)
+    ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
 end

--- a/contracts/lib/openzeppelin/token/erc20/library.cairo
+++ b/contracts/lib/openzeppelin/token/erc20/library.cairo
@@ -1,28 +1,23 @@
 # SPDX-License-Identifier: MIT
-# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/library.cairo)
+# OpenZeppelin Contracts for Cairo v0.2.0 (token/erc20/library.cairo)
 
 %lang starknet
 
-from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.cairo.common.math import assert_not_zero, assert_lt
-from starkware.cairo.common.uint256 import (
-    Uint256,
-    uint256_add,
-    uint256_sub,
-    uint256_le,
-    uint256_lt,
-    uint256_check,
-)
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import Uint256, uint256_check, uint256_eq, uint256_not
 
 from openzeppelin.utils.constants import UINT8_MAX
+from openzeppelin.security.safemath import SafeUint256
 
 #
 # Events
 #
 
 @event
-func Transfer(_from : felt, to : felt, value : Uint256):
+func Transfer(from_ : felt, to : felt, value : Uint256):
 end
 
 @event
@@ -34,15 +29,15 @@ end
 #
 
 @storage_var
-func ERC20_name_() -> (name : felt):
+func ERC20_name() -> (name : felt):
 end
 
 @storage_var
-func ERC20_symbol_() -> (symbol : felt):
+func ERC20_symbol() -> (symbol : felt):
 end
 
 @storage_var
-func ERC20_decimals_() -> (decimals : felt):
+func ERC20_decimals() -> (decimals : felt):
 end
 
 @storage_var
@@ -57,203 +52,263 @@ end
 func ERC20_allowances(owner : felt, spender : felt) -> (allowance : Uint256):
 end
 
-#
-# Constructor
-#
+namespace ERC20:
+    #
+    # Initializer
+    #
 
-func ERC20_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    name : felt, symbol : felt, decimals : felt
-):
-    ERC20_name_.write(name)
-    ERC20_symbol_.write(symbol)
-    assert_lt(decimals, UINT8_MAX)
-    ERC20_decimals_.write(decimals)
-    return ()
-end
+    func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        name : felt, symbol : felt, decimals : felt
+    ):
+        ERC20_name.write(name)
+        ERC20_symbol.write(symbol)
+        with_attr error_message("ERC20: decimals exceed 2^8"):
+            assert_lt(decimals, UINT8_MAX)
+        end
+        ERC20_decimals.write(decimals)
+        return ()
+    end
 
-func ERC20_name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    name : felt
-):
-    let (name) = ERC20_name_.read()
-    return (name)
-end
+    #
+    # Public functions
+    #
 
-func ERC20_symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    symbol : felt
-):
-    let (symbol) = ERC20_symbol_.read()
-    return (symbol)
-end
+    func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
+        let (name) = ERC20_name.read()
+        return (name)
+    end
 
-func ERC20_totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    totalSupply : Uint256
-):
-    let (totalSupply : Uint256) = ERC20_total_supply.read()
-    return (totalSupply)
-end
+    func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        symbol : felt
+    ):
+        let (symbol) = ERC20_symbol.read()
+        return (symbol)
+    end
 
-func ERC20_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-    decimals : felt
-):
-    let (decimals) = ERC20_decimals_.read()
-    return (decimals)
-end
+    func total_supply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        total_supply : Uint256
+    ):
+        let (total_supply : Uint256) = ERC20_total_supply.read()
+        return (total_supply)
+    end
 
-func ERC20_balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    account : felt
-) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balances.read(account)
-    return (balance)
-end
+    func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        decimals : felt
+    ):
+        let (decimals) = ERC20_decimals.read()
+        return (decimals)
+    end
 
-func ERC20_allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    owner : felt, spender : felt
-) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowances.read(owner, spender)
-    return (remaining)
-end
+    func balance_of{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        account : felt
+    ) -> (balance : Uint256):
+        let (balance : Uint256) = ERC20_balances.read(account)
+        return (balance)
+    end
 
-func ERC20_transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    recipient : felt, amount : Uint256
-):
-    let (sender) = get_caller_address()
-    _transfer(sender, recipient, amount)
-    return ()
-end
+    func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt, spender : felt
+    ) -> (remaining : Uint256):
+        let (remaining : Uint256) = ERC20_allowances.read(owner, spender)
+        return (remaining)
+    end
 
-func ERC20_transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    sender : felt, recipient : felt, amount : Uint256
-) -> ():
-    alloc_locals
-    let (caller) = get_caller_address()
-    let (caller_allowance : Uint256) = ERC20_allowances.read(owner=sender, spender=caller)
+    func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        recipient : felt, amount : Uint256
+    ):
+        let (sender) = get_caller_address()
+        _transfer(sender, recipient, amount)
+        return ()
+    end
 
-    # validates amount <= caller_allowance and returns 1 if true
-    let (enough_allowance) = uint256_le(amount, caller_allowance)
-    assert_not_zero(enough_allowance)
+    func transfer_from{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        sender : felt, recipient : felt, amount : Uint256
+    ) -> ():
+        let (caller) = get_caller_address()
+        # subtract allowance
+        _spend_allowance(sender, caller, amount)
+        # execute transfer
+        _transfer(sender, recipient, amount)
+        return ()
+    end
 
-    _transfer(sender, recipient, amount)
+    func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        spender : felt, amount : Uint256
+    ):
+        with_attr error_message("ERC20: amount is not a valid Uint256"):
+            uint256_check(amount)
+        end
 
-    # subtract allowance
-    let (new_allowance : Uint256) = uint256_sub(caller_allowance, amount)
-    ERC20_allowances.write(sender, caller, new_allowance)
-    return ()
-end
+        let (caller) = get_caller_address()
+        _approve(caller, spender, amount)
+        return ()
+    end
 
-func ERC20_approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    spender : felt, amount : Uint256
-):
-    let (caller) = get_caller_address()
-    assert_not_zero(caller)
-    assert_not_zero(spender)
-    uint256_check(amount)
-    ERC20_allowances.write(caller, spender, amount)
-    Approval.emit(caller, spender, amount)
-    return ()
-end
+    func increase_allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        spender : felt, added_value : Uint256
+    ) -> ():
+        with_attr error("ERC20: added_value is not a valid Uint256"):
+            uint256_check(added_value)
+        end
 
-func ERC20_increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    spender : felt, added_value : Uint256
-) -> ():
-    uint256_check(added_value)
-    let (caller) = get_caller_address()
-    let (current_allowance : Uint256) = ERC20_allowances.read(caller, spender)
+        let (caller) = get_caller_address()
+        let (current_allowance : Uint256) = ERC20_allowances.read(caller, spender)
 
-    # add allowance
-    let (new_allowance : Uint256, is_overflow) = uint256_add(current_allowance, added_value)
-    assert (is_overflow) = 0
+        # add allowance
+        with_attr error_message("ERC20: allowance overflow"):
+            let (new_allowance : Uint256) = SafeUint256.add(current_allowance, added_value)
+        end
 
-    ERC20_approve(spender, new_allowance)
-    return ()
-end
+        _approve(caller, spender, new_allowance)
+        return ()
+    end
 
-func ERC20_decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    spender : felt, subtracted_value : Uint256
-) -> ():
-    alloc_locals
-    uint256_check(subtracted_value)
-    let (caller) = get_caller_address()
-    let (current_allowance : Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
-    let (new_allowance : Uint256) = uint256_sub(current_allowance, subtracted_value)
+    func decrease_allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        spender : felt, subtracted_value : Uint256
+    ) -> ():
+        alloc_locals
+        with_attr error_message("ERC20: subtracted_value is not a valid Uint256"):
+            uint256_check(subtracted_value)
+        end
 
-    # validates new_allowance < current_allowance and returns 1 if true
-    let (enough_allowance) = uint256_lt(new_allowance, current_allowance)
-    assert_not_zero(enough_allowance)
+        let (caller) = get_caller_address()
+        let (current_allowance : Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
 
-    ERC20_approve(spender, new_allowance)
-    return ()
-end
+        with_attr error_message("ERC20: allowance below zero"):
+            let (new_allowance : Uint256) = SafeUint256.sub_le(current_allowance, subtracted_value)
+        end
 
-func ERC20_mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    recipient : felt, amount : Uint256
-):
-    assert_not_zero(recipient)
-    uint256_check(amount)
+        _approve(caller, spender, new_allowance)
+        return ()
+    end
 
-    let (balance : Uint256) = ERC20_balances.read(account=recipient)
-    # overflow is not possible because sum is guaranteed to be less than total supply
-    # which we check for overflow below
-    let (new_balance, _ : Uint256) = uint256_add(balance, amount)
-    ERC20_balances.write(recipient, new_balance)
+    #
+    # Internal
+    #
 
-    let (supply : Uint256) = ERC20_total_supply.read()
-    let (new_supply : Uint256, is_overflow) = uint256_add(supply, amount)
-    assert (is_overflow) = 0
+    func _mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        recipient : felt, amount : Uint256
+    ):
+        with_attr error_message("ERC20: amount is not a valid Uint256"):
+            uint256_check(amount)
+        end
 
-    ERC20_total_supply.write(new_supply)
-    Transfer.emit(0, recipient, amount)
-    return ()
-end
+        with_attr error_message("ERC20: cannot mint to the zero address"):
+            assert_not_zero(recipient)
+        end
 
-func ERC20_burn{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    account : felt, amount : Uint256
-):
-    alloc_locals
-    assert_not_zero(account)
-    uint256_check(amount)
+        let (supply : Uint256) = ERC20_total_supply.read()
+        with_attr error_message("ERC20: mint overflow"):
+            let (new_supply : Uint256) = SafeUint256.add(supply, amount)
+        end
+        ERC20_total_supply.write(new_supply)
 
-    let (balance : Uint256) = ERC20_balances.read(account)
-    # validates amount <= balance and returns 1 if true
-    let (enough_balance) = uint256_le(amount, balance)
-    assert_not_zero(enough_balance)
+        let (balance : Uint256) = ERC20_balances.read(account=recipient)
+        # overflow is not possible because sum is guaranteed to be less than total supply
+        # which we check for overflow below
+        let (new_balance : Uint256) = SafeUint256.add(balance, amount)
+        ERC20_balances.write(recipient, new_balance)
 
-    let (new_balance : Uint256) = uint256_sub(balance, amount)
-    ERC20_balances.write(account, new_balance)
+        Transfer.emit(0, recipient, amount)
+        return ()
+    end
 
-    let (supply : Uint256) = ERC20_total_supply.read()
-    let (new_supply : Uint256) = uint256_sub(supply, amount)
-    ERC20_total_supply.write(new_supply)
-    Transfer.emit(account, 0, amount)
-    return ()
-end
+    func _burn{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        account : felt, amount : Uint256
+    ):
+        with_attr error_message("ERC20: amount is not a valid Uint256"):
+            uint256_check(amount)
+        end
 
-#
-# Internal
-#
+        with_attr error_message("ERC20: cannot burn from the zero address"):
+            assert_not_zero(account)
+        end
 
-func _transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    sender : felt, recipient : felt, amount : Uint256
-):
-    alloc_locals
-    assert_not_zero(sender)
-    assert_not_zero(recipient)
-    uint256_check(amount)  # almost surely not needed, might remove after confirmation
+        let (balance : Uint256) = ERC20_balances.read(account)
+        with_attr error_message("ERC20: burn amount exceeds balance"):
+            let (new_balance : Uint256) = SafeUint256.sub_le(balance, amount)
+        end
 
-    let (sender_balance : Uint256) = ERC20_balances.read(account=sender)
+        ERC20_balances.write(account, new_balance)
 
-    # validates amount <= sender_balance and returns 1 if true
-    let (enough_balance) = uint256_le(amount, sender_balance)
-    assert_not_zero(enough_balance)
+        let (supply : Uint256) = ERC20_total_supply.read()
+        let (new_supply : Uint256) = SafeUint256.sub_le(supply, amount)
+        ERC20_total_supply.write(new_supply)
+        Transfer.emit(account, 0, amount)
+        return ()
+    end
 
-    # subtract from sender
-    let (new_sender_balance : Uint256) = uint256_sub(sender_balance, amount)
-    ERC20_balances.write(sender, new_sender_balance)
+    func _transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        sender : felt, recipient : felt, amount : Uint256
+    ):
+        with_attr error_message("ERC20: amount is not a valid Uint256"):
+            uint256_check(amount)  # almost surely not needed, might remove after confirmation
+        end
 
-    # add to recipient
-    let (recipient_balance : Uint256) = ERC20_balances.read(account=recipient)
-    # overflow is not possible because sum is guaranteed by mint to be less than total supply
-    let (new_recipient_balance, _ : Uint256) = uint256_add(recipient_balance, amount)
-    ERC20_balances.write(recipient, new_recipient_balance)
-    Transfer.emit(sender, recipient, amount)
-    return ()
+        with_attr error_message("ERC20: cannot transfer from the zero address"):
+            assert_not_zero(sender)
+        end
+
+        with_attr error_message("ERC20: cannot transfer to the zero address"):
+            assert_not_zero(recipient)
+        end
+
+        let (sender_balance : Uint256) = ERC20_balances.read(account=sender)
+        with_attr error_message("ERC20: transfer amount exceeds balance"):
+            let (new_sender_balance : Uint256) = SafeUint256.sub_le(sender_balance, amount)
+        end
+
+        ERC20_balances.write(sender, new_sender_balance)
+
+        # add to recipient
+        let (recipient_balance : Uint256) = ERC20_balances.read(account=recipient)
+        # overflow is not possible because sum is guaranteed by mint to be less than total supply
+        let (new_recipient_balance : Uint256) = SafeUint256.add(recipient_balance, amount)
+        ERC20_balances.write(recipient, new_recipient_balance)
+        Transfer.emit(sender, recipient, amount)
+        return ()
+    end
+
+    func _approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt, spender : felt, amount : Uint256
+    ):
+        with_attr error_message("ERC20: amount is not a valid Uint256"):
+            uint256_check(amount)
+        end
+
+        with_attr error_message("ERC20: cannot approve from the zero address"):
+            assert_not_zero(owner)
+        end
+
+        with_attr error_message("ERC20: cannot approve to the zero address"):
+            assert_not_zero(spender)
+        end
+
+        ERC20_allowances.write(owner, spender, amount)
+        Approval.emit(owner, spender, amount)
+        return ()
+    end
+
+    func _spend_allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt, spender : felt, amount : Uint256
+    ):
+        alloc_locals
+        with_attr error_message("ERC20: amount is not a valid Uint256"):
+            uint256_check(amount)  # almost surely not needed, might remove after confirmation
+        end
+
+        let (current_allowance : Uint256) = ERC20_allowances.read(owner, spender)
+        let (infinite : Uint256) = uint256_not(Uint256(0, 0))
+        let (is_infinite : felt) = uint256_eq(current_allowance, infinite)
+
+        if is_infinite == FALSE:
+            with_attr error_message("ERC20: insufficient allowance"):
+                let (new_allowance : Uint256) = SafeUint256.sub_le(current_allowance, amount)
+            end
+
+            _approve(owner, spender, new_allowance)
+            return ()
+        end
+        return ()
+    end
 end

--- a/tests/mocks/ERC20.cairo
+++ b/tests/mocks/ERC20.cairo
@@ -7,28 +7,14 @@ from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
-from contracts.lib.openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint
-)
+from contracts.lib.openzeppelin.token.erc20.library import ERC20
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     name : felt, symbol : felt, decimals : felt, initial_supply : Uint256, recipient : felt
 ):
-    ERC20_initializer(name, symbol, decimals)
-    ERC20_mint(recipient, initial_supply)
+    ERC20.initializer(name, symbol, decimals)
+    ERC20._mint(recipient, initial_supply)
     return ()
 end
 
@@ -38,13 +24,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC20_name()
+    let (name) = ERC20.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC20_symbol()
+    let (symbol) = ERC20.symbol()
     return (symbol)
 end
 
@@ -52,7 +38,7 @@ end
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     return (totalSupply)
 end
 
@@ -60,7 +46,7 @@ end
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     decimals : felt
 ):
-    let (decimals) = ERC20_decimals()
+    let (decimals) = ERC20.decimals()
     return (decimals)
 end
 
@@ -68,7 +54,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     account : felt
 ) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balanceOf(account)
+    let (balance : Uint256) = ERC20.balance_of(account)
     return (balance)
 end
 
@@ -76,7 +62,7 @@ end
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, spender : felt
 ) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowance(owner, spender)
+    let (remaining : Uint256) = ERC20.allowance(owner, spender)
     return (remaining)
 end
 
@@ -88,7 +74,7 @@ end
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transfer(recipient, amount)
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 
@@ -96,7 +82,7 @@ end
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     sender : felt, recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transferFrom(sender, recipient, amount)
+    ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
 
@@ -104,7 +90,7 @@ end
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_approve(spender, amount)
+    ERC20.approve(spender, amount)
     return (TRUE)
 end
 
@@ -112,7 +98,7 @@ end
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, added_value : Uint256
 ) -> (success : felt):
-    ERC20_increaseAllowance(spender, added_value)
+    ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
 
@@ -120,7 +106,7 @@ end
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, subtracted_value : Uint256
 ) -> (success : felt):
-    ERC20_decreaseAllowance(spender, subtracted_value)
+    ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
 end
 
@@ -128,6 +114,6 @@ end
 func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ):
-    ERC20_mint(recipient, amount)
+    ERC20._mint(recipient, amount)
     return ()
 end


### PR DESCRIPTION
I am working on Gate module for `Yang`, which relies on the OpenZeppelin's ERC20 library. 

**What I did**
- Copy and paste the latest OpenZeppelin ERC20 library (`0.2.0`).
- Update USDa module
- Update test suite