### PR TITLE
feat: auth lib

### DIFF
--- a/contracts/lib/auth.cairo
+++ b/contracts/lib/auth.cairo
@@ -20,7 +20,7 @@ end
 
 namespace Auth:
     # asserts whether the caller is authorized, fails if they are not
-    func assert_caller{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    func assert_caller_authed{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
         let (c) = get_caller_address()
         let (is_authed) = auth_authorization_storage.read(c)
         with_attr error_message("Auth: caller not authorized"):
@@ -30,7 +30,9 @@ namespace Auth:
     end
 
     # asserts whether an address is authorized, fails if they are not
-    func assert_address{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(address):
+    func assert_address_authed{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        address
+    ):
         let (is_authed) = auth_authorization_storage.read(address)
         with_attr error_message("Auth: address {address} not authorized"):
             assert is_authed = TRUE
@@ -53,7 +55,7 @@ namespace Auth:
     end
 
     # returns the authorization status of an address
-    func get_authorization{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    func is_authorized{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         address
     ) -> (bool):
         return auth_authorization_storage.read(address)

--- a/contracts/shrine/shrine.cairo
+++ b/contracts/shrine/shrine.cairo
@@ -159,7 +159,7 @@ end
 
 @view
 func get_auth{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(address) -> (bool):
-    return Auth.get_authorization(address)
+    return Auth.is_authorized(address)
 end
 
 @view
@@ -243,7 +243,7 @@ func add_yang{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
 ):
     alloc_locals
 
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     # Assert that yang is not already added
     let (yang_id) = shrine_yang_id_storage.read(yang_address)
@@ -276,7 +276,7 @@ end
 func update_yang_max{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     yang_address, new_max
 ):
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     let (yang_id) = get_valid_yang_id(yang_address)
     let (old_yang_info : Yang) = shrine_yangs_storage.read(yang_id)
@@ -290,7 +290,7 @@ end
 
 @external
 func set_ceiling{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(new_ceiling):
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     shrine_ceiling_storage.write(new_ceiling)
 
@@ -307,7 +307,7 @@ end
 func set_threshold{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     yang_address, new_threshold
 ):
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     # Check that threshold value is not greater than max threshold
     with_attr error_message("Shrine: Threshold exceeds 100%"):
@@ -324,7 +324,7 @@ end
 
 @external
 func kill{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     shrine_live_storage.write(FALSE)
 
@@ -358,14 +358,14 @@ end
 
 @external
 func authorize{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(address):
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
     Auth.authorize(address)
     return ()
 end
 
 @external
 func revoke{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(address):
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
     Auth.revoke(address)
     return ()
 end
@@ -377,7 +377,7 @@ func advance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 ):
     alloc_locals
 
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     let (interval) = now()
     let (yang_id) = get_valid_yang_id(yang_address)
@@ -393,7 +393,7 @@ end
 func update_multiplier{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     new_multiplier
 ):
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     let (interval) = now()
     shrine_multiplier_storage.write(interval, new_multiplier)
@@ -411,7 +411,7 @@ func move_yang{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 ):
     alloc_locals
 
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     let (yang_id) = get_valid_yang_id(yang_address)
 
@@ -457,7 +457,7 @@ func deposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 ):
     alloc_locals
 
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     # Check system is live
     assert_live()
@@ -497,7 +497,7 @@ func withdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
 ):
     alloc_locals
 
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     # Retrieve yang info
     let (yang_id) = get_valid_yang_id(yang_address)
@@ -537,7 +537,7 @@ end
 func forge{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(amount, trove_id):
     alloc_locals
 
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     # Check system is live
     assert_live()
@@ -598,7 +598,7 @@ end
 func melt{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(amount, trove_id):
     alloc_locals
 
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     # Charge interest
     charge(trove_id)
@@ -634,7 +634,7 @@ end
 # Checks should be performed beforehand by the module calling this function
 @external
 func seize{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(trove_id):
-    Auth.assert_caller()
+    Auth.assert_caller_authed()
 
     # Update Trove information
     let (old_trove_info : Trove) = get_trove(trove_id)

--- a/tests/lib/auth_contract.cairo
+++ b/tests/lib/auth_contract.cairo
@@ -18,22 +18,24 @@ func revoke{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(a
 end
 
 @view
-func get_authorization{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    address
-) -> (bool):
-    return Auth.get_authorization(address)
+func is_authorized{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(address) -> (
+    bool
+):
+    return Auth.is_authorized(address)
 end
 
 @view
-func assert_caller{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (bool):
-    Auth.assert_caller()
+func assert_caller_authed{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    bool
+):
+    Auth.assert_caller_authed()
     return (TRUE)
 end
 
 @view
-func assert_address{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(address) -> (
-    bool
-):
-    Auth.assert_address(address)
+func assert_address_authed{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    address
+) -> (bool):
+    Auth.assert_address_authed(address)
     return (TRUE)
 end

--- a/tests/lib/test_auth.py
+++ b/tests/lib/test_auth.py
@@ -13,33 +13,33 @@ async def auth_contract(starknet):
 @pytest.mark.asyncio
 async def test_authorize_and_revoke(auth_contract):
     addr = 123
-    assert (await auth_contract.get_authorization(addr).invoke()).result.bool == FALSE
+    assert (await auth_contract.is_authorized(addr).invoke()).result.bool == FALSE
     tx = await auth_contract.authorize(addr).invoke()
     assert_event_emitted(tx, auth_contract.contract_address, "Authorized", [addr])
-    assert (await auth_contract.get_authorization(addr).invoke()).result.bool == TRUE
+    assert (await auth_contract.is_authorized(addr).invoke()).result.bool == TRUE
     tx = await auth_contract.revoke(addr).invoke()
     assert_event_emitted(tx, auth_contract.contract_address, "Revoked", [addr])
-    assert (await auth_contract.get_authorization(addr).invoke()).result.bool == FALSE
+    assert (await auth_contract.is_authorized(addr).invoke()).result.bool == FALSE
 
 
 @pytest.mark.asyncio
-async def test_assert_caller(auth_contract):
+async def test_assert_caller_authed(auth_contract):
     caller = 999
 
     with pytest.raises(StarkException):
-        await auth_contract.assert_caller().invoke()
+        await auth_contract.assert_caller_authed().invoke()
 
     await auth_contract.authorize(caller).invoke()
-    assert (await auth_contract.get_authorization(caller).invoke()).result.bool == TRUE
-    assert (await auth_contract.assert_caller().invoke(caller_address=caller)).result.bool == TRUE
+    assert (await auth_contract.is_authorized(caller).invoke()).result.bool == TRUE
+    assert (await auth_contract.assert_caller_authed().invoke(caller_address=caller)).result.bool == TRUE
 
 
 @pytest.mark.asyncio
-async def test_assert_address(auth_contract):
+async def test_assert_address_authed(auth_contract):
     addr = 321
 
     with pytest.raises(StarkException):
-        await auth_contract.assert_address(addr).invoke()
+        await auth_contract.assert_address_authed(addr).invoke()
 
     await auth_contract.authorize(addr).invoke()
-    assert (await auth_contract.assert_address(addr).invoke()).result.bool == TRUE
+    assert (await auth_contract.assert_address_authed(addr).invoke()).result.bool == TRUE


### PR DESCRIPTION
Resolves #44 - moves auth from Shrine to it's own lib so it can be used in other modules as well. `assert_auth` has been renamed to `assert_caller` to communicate the task more clearly. I've also added a `assert_address` to the lib although it's currently not being used anywhere.
