### PR TITLE
fix: tests for unsigned div in `WadRay`

### DIFF
--- a/tests/shared/test_wad_ray.py
+++ b/tests/shared/test_wad_ray.py
@@ -32,7 +32,7 @@ st_uint = st.integers(min_value=0, max_value=2 * 200)
 
 
 @pytest.fixture(scope="session")
-async def wad_ray(starknet, users) -> StarknetContract:
+async def wad_ray(starknet) -> StarknetContract:
     contract = compile_contract("tests/shared/test_wad_ray.cairo")
     wad_ray = await starknet.deploy(contract_class=contract, constructor_calldata=[])
     return wad_ray


### PR DESCRIPTION
Fixed a bug in the tests for unsigned div in `WadRay` as seen in https://github.com/lindy-labs/aura_contracts/commit/a5777652e60d3f966e6cfe9886b27111f84acaa8 