### PR TITLE
chore: removing use of PRIME in favor of CAIRO_PRIME

### DIFF
--- a/contracts/shared/wad_ray.cairo
+++ b/contracts/shared/wad_ray.cairo
@@ -92,7 +92,7 @@ namespace WadRay:
 
     func wsigned_div{range_check_ptr}(a, b) -> (wad):
         alloc_locals
-        # `signed_div_rem` assumes 0 < div <= PRIME / rc_bound
+        # `signed_div_rem` assumes 0 < div <= CAIRO_PRIME / rc_bound
         let (div) = abs_value(b)
         # `sign` assumes -rc_bound < value < rc_bound
         let (div_sign) = sign(b)

--- a/tests/shared/test_wad_ray.py
+++ b/tests/shared/test_wad_ray.py
@@ -8,7 +8,7 @@ from starkware.starknet.testing.starknet import Starknet, StarknetContract
 from starkware.starkware_utils.error_handling import StarkException
 
 from tests.utils import (
-    PRIME,
+    CAIRO_PRIME,
     RANGE_CHECK_BOUND,
     RAY_SCALE,
     WAD_RAY_DIFF,
@@ -216,8 +216,8 @@ async def test_mul_div_signed(wad_ray, left, right, fn, op, scale, ret):
         sign = -1 if right < 0 else 1
         # Convert right to absolute value before converting it to felt
         right = abs(right)
-        # `signed_div_rem` assumes 0 < right <= PRIME / RANGE_CHECK_BOUND
-        assume(right <= PRIME // RANGE_CHECK_BOUND)
+        # `signed_div_rem` assumes 0 < right <= CAIRO_PRIME / RANGE_CHECK_BOUND
+        assume(right <= CAIRO_PRIME // RANGE_CHECK_BOUND)
         # Scale left by wad after converting it to felt for computation of python value
         left *= scale
 
@@ -261,11 +261,11 @@ async def test_mul_div_signed(wad_ray, left, right, fn, op, scale, ret):
 )
 @pytest.mark.asyncio
 async def test_div_unsigned(wad_ray, left, right, fn, op, scale, ret):
-    # `unsigned_div_rem` assumes 0 < right <= PRIME / RANGE_CHECK_BOUND
-    assume(right <= PRIME // RANGE_CHECK_BOUND)
+    # `unsigned_div_rem` assumes 0 < right <= CAIRO_PRIME / RANGE_CHECK_BOUND
+    assume(right <= CAIRO_PRIME // RANGE_CHECK_BOUND)
     scaled_left = left * scale
     # Exclude values greater than felt after scaling
-    assume(scaled_left <= PRIME)
+    assume(scaled_left <= CAIRO_PRIME)
     expected_py = op(scaled_left, right)
     expected_cairo = signed_int_to_felt(expected_py)
     method = wad_ray.get_contract_function(fn)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,9 +15,7 @@ from starkware.starknet.services.api.feeder_gateway.response_objects import Func
 from starkware.starknet.testing.objects import StarknetTransactionExecutionInfo
 from starkware.starknet.testing.starknet import Starknet, StarknetContract
 
-PRIME = 2**251 + 17 * 2**192 + 1
 RANGE_CHECK_BOUND = 2**128
-
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)
 ZERO_ADDRESS = 0
 TRUE = 1
@@ -78,10 +76,10 @@ def as_address(value: Addressable) -> int:
 
 
 def signed_int_to_felt(a: int) -> int:
-    """Takes in integer value, returns input if positive, otherwise return PRIME + input"""
+    """Takes in integer value, returns input if positive, otherwise return CAIRO_PRIME + input"""
     if a >= 0:
         return a
-    return PRIME + a
+    return CAIRO_PRIME + a
 
 
 def felt_to_str(felt: int) -> str:

--- a/tests/yin/test_yin.py
+++ b/tests/yin/test_yin.py
@@ -3,9 +3,8 @@ from starkware.starknet.testing.starknet import StarknetContract
 from starkware.starkware_utils.error_handling import StarkException
 
 from tests.shrine.constants import FORGE_AMT_WAD, TROVE_1
-from tests.utils import SHRINE_OWNER, TROVE1_OWNER, assert_event_emitted, compile_contract, str_to_felt
+from tests.utils import CAIRO_PRIME, SHRINE_OWNER, TROVE1_OWNER, assert_event_emitted, compile_contract, str_to_felt
 
-CAIRO_PRIME = 2**251 + 17 * 2**192 + 1
 INFINITE_ALLOWANCE = CAIRO_PRIME - 1
 
 TRUE = 1


### PR DESCRIPTION
Minor cleanup. I've noticed we have PRIME and CAIRO_PRIME declared multiple times.