### PR TITLE
doc: naming conventions

### DIFF
--- a/docs/CairoConventions.md
+++ b/docs/CairoConventions.md
@@ -28,10 +28,10 @@ We follow these conventions when naming things
 
 | thing                     | convention                 | example                                                          |
 |---------------------------|----------------------------|------------------------------------------------------------------|
-| directories and files     | snake_case                 | `module_name/module.cairo`                                      |
-| functions                 | snake_case                 | `func open_account{...}():`                                            |
-| contract interfaces       | CamelCase prepended with I | <pre>@contract_interface<br />namespace IAccount:<br />end</pre> |
+| directories and files     | snake_case                 | `module_name/module.cairo`                                       |
+| functions                 | snake_case                 | `func open_account{...}():`                                      |
 | namespaces                | CamelCase                  | `namespace Engine`                                               |
+| contract interfaces       | CamelCase prepended with I | <pre>@contract_interface<br />namespace IAccount:<br />end</pre> |
 | structs                   | CamelCase                  | `struct Loan`                                                    |
 | variables, struct members | snake_case                 | `let user_balance = 100`                                         |
 | events                    | CamelCase                  | <pre>@event<br />func ThingHappened():<br />end</pre>            |


### PR DESCRIPTION
Adds a section on general naming conventions to the docs. I realize we're already following these but 1) it will be clearer for others that will join the team in the future and 2) I'm writing a post about this on Cairopractice and figured people are interested in this, so why not have it here as well 😇 