### PR TITLE
test: AWS runner for cairo tests

### DIFF
--- a/.github/workflows/cairo_tests.yml
+++ b/.github/workflows/cairo_tests.yml
@@ -13,21 +13,17 @@ jobs:
       !github.event.pull_request.draft &&
       !(contains(toJSON(github.event.commits.*.message), '[skip ci]') ||
         contains(toJSON(github.event.commits.*.message), '[ci skip]'))
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Python setup
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.9'
-          cache: pip
-          cache-dependency-path: '**/requirements-dev.txt'
+      - name: Update PATH
+        run: echo "/home/ec2-user/.local/bin:/usr/local/bin" >> $GITHUB_PATH
 
-      - name: Env setup
-        run: pip install -r requirements-dev.txt
+      - name: Install deps
+        run: pip3.9 install -r requirements-dev.txt
 
       - name: Run tests
         run: pytest -sv -r A --cache-clear tests


### PR DESCRIPTION
This PR makes the Cairo test action run on AWS. The other CI actions are still using GitHub runners.

The AWS infra was set up using [this repo](https://github.com/philips-labs/terraform-aws-github-runner), particularly the ephemeral runners module. I have it set up only locally. I won't create a repo and document it because 1) I'm lazy 2) it contains various private keys, which, to make it correct would mean a lot of effort (see point 1) and 3) we'll probably switch to GitHub's [Larger runners](https://github.blog/changelog/2022-09-01-github-actions-larger-runners-are-now-in-public-beta/) eventually, even though they will only offer 64 cores.

Currently, the machine executing the tests is a `m6i.8xlarge` Spot [instance](https://aws.amazon.com/ec2/instance-types/). We're limited to 32 vCPUs (the default limit), but I've submitted a request to bump it to 256. It should be approved within 5 business days.

The good thing is that the test suite execution time scales inversely with the number of cores. It took about 10 minutes on a 16 vCPU machine and roughly 5 minutes on the current 32 vCPU. There's also about a 40s lag until the job is picked up and machine boots up. There's also no dependency caching, as that's cumbersome to set up (at least with my current knowledge).

The whole thing is pretty cheap, it should cost under $10/m I reckon. 