### PR TITLE
ci: switch to 64 core GH hosted runner

### DIFF
--- a/.github/workflows/cairo_tests.yml
+++ b/.github/workflows/cairo_tests.yml
@@ -17,17 +17,21 @@ jobs:
       !github.event.pull_request.draft &&
       !(contains(toJSON(github.event.commits.*.message), '[skip ci]') ||
         contains(toJSON(github.event.commits.*.message), '[ci skip]'))
-    runs-on: self-hosted
+    runs-on: cairo-test-eater-64
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Update PATH
-        run: echo "/home/ec2-user/.local/bin:/usr/local/bin" >> $GITHUB_PATH
+      - name: Python setup
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: '**/requirements-dev.txt'
 
       - name: Install deps
-        run: pip3.9 install -r requirements-dev.txt
+        run: pip install -r requirements-dev.txt
 
       - name: Run tests
         run: pytest -sv -r A tests


### PR DESCRIPTION
We got access to the beta version of GitHub large runners. Testing a switch to a 64 core machine.