### PR TITLE
fix(wadray): check from_uint input

### DIFF
--- a/contracts/lib/wad_ray.cairo
+++ b/contracts/lib/wad_ray.cairo
@@ -190,14 +190,15 @@ namespace WadRay {
     // Conversions
     //
 
-    func to_uint(n) -> (uint: Uint256) {
+    func to_uint{range_check_ptr}(n) -> (uint: Uint256) {
+        assert_valid_unsigned(n);
         let uint = Uint256(low=n, high=0);
         return (uint,);
     }
 
     func from_uint{range_check_ptr}(n: Uint256) -> wad {
         assert n.high = 0;
-        assert_valid(n.low);
+        assert_valid_unsigned(n.low);
         return n.low;
     }
 

--- a/tests/lib/test_wad_ray.cairo
+++ b/tests/lib/test_wad_ray.cairo
@@ -89,7 +89,7 @@ func test_runsigned_div_unchecked{range_check_ptr}(a, b) -> (res: ray) {
 }
 
 @view
-func test_to_uint(n) -> (uint: Uint256) {
+func test_to_uint{range_check_ptr}(n) -> (uint: Uint256) {
     return WadRay.to_uint(n);
 }
 

--- a/tests/lib/test_wad_ray.py
+++ b/tests/lib/test_wad_ray.py
@@ -14,6 +14,7 @@ from tests.utils import (
     RAY_SCALE,
     WAD_RAY_DIFF,
     WAD_SCALE,
+    Uint256,
     compile_contract,
     signed_int_to_felt,
     to_ray,
@@ -30,6 +31,7 @@ st_int125 = st.integers(min_value=-(2**125), max_value=2**125)
 st_uint125 = st.integers(min_value=1, max_value=2**125)
 st_uint128 = st.integers(min_value=1, max_value=2**128)
 st_uint = st.integers(min_value=0, max_value=2 * 200)
+rogue_uint = st.integers(min_value=2**128, max_value=CAIRO_PRIME - 1)
 
 
 @pytest.fixture(scope="session")
@@ -347,6 +349,16 @@ async def test_from_uint_fail(wad_ray, val):
     val = to_uint(val)
     with pytest.raises(StarkException, match="WadRay: Out of bounds"):
         await wad_ray.test_from_uint(val).execute()
+
+
+@settings(max_examples=50, deadline=None)
+@given(low=rogue_uint)
+@example(low=-1)
+@pytest.mark.asyncio
+async def test_from_uint_fail_on_rogue_input(wad_ray, low):
+    with pytest.raises(StarkException, match="WadRay: Out of bounds"):
+        uint = Uint256(low=low, high=0)
+        await wad_ray.test_from_uint(uint).execute()
 
 
 @pytest.mark.parametrize("func", ["add_unsigned", "sub_unsigned", "wunsigned_div", "runsigned_div"])


### PR DESCRIPTION
A maliciously crafted `Uint256` struct could pass the `from_uint` conversion in our lib. An example of this is `Uint256(low=-1, high=0)`, which is not a valid Uint256 value (wouldn't pass `uint256_check`), but is a valid Uint256 struct. This PR fixes the bug.