### PR TITLE
fix: use unsigned check in wadray min

### DIFF
--- a/contracts/lib/wad_ray.cairo
+++ b/contracts/lib/wad_ray.cairo
@@ -45,8 +45,8 @@ namespace WadRay {
     }
 
     func unsigned_min{range_check_ptr}(a, b) -> felt {
-        assert_valid(a);
-        assert_valid(b);
+        assert_valid_unsigned(a);
+        assert_valid_unsigned(b);
 
         let le = is_le(a, b);
         if (le == TRUE) {


### PR DESCRIPTION
Follow-up on #196, making the `WadRay.unsigned_min` use `assert_valid_unsigned`.

