### PR TITLE
ci: update pip-audit

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -19,18 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Python setup
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.9'
-          cache: pip
-          cache-dependency-path: '**/requirements-dev.txt'
-
-      - name: Env setup
-        run: pip install -r requirements-dev.txt
-
-      - name: Install pip-audit
-        run: pip install git+https://github.com/pypa/pip-audit.git@5775f9e4416465b43e5667874444fe4728d149dd
-
       - name: Run pip-audit
-        run: pip-audit -r requirements-dev.txt --ignore-vuln PYSEC-2021-427
+        uses: pypa/gh-action-pip-audit@v1.0.5
+        with:
+          inputs: requirements-dev.txt
+          ignore-vulns: PYSEC-2021-427


### PR DESCRIPTION
Trying to fix a new vulnerability with setuptools, which is in the environment.

Using the latest `pip-audit` Github Actions should resolve the vulnerability for `setuptools` since the issue was fixed in `v2.4.12` of `pip-audit`. For unknown reasons, that did not work, so an additional command is added to upgrade `setuptools` before running `pip-audit`. 