### PR TITLE
fix: trove ID validation and storage_var naming in Abbot

### DIFF
--- a/contracts/abbot/abbot.cairo
+++ b/contracts/abbot/abbot.cairo
@@ -2,7 +2,7 @@
 
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
-from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.math import assert_le_felt, assert_not_zero
 from starkware.starknet.common.syscalls import get_caller_address
 
 from contracts.sentinel.interface import ISentinel
@@ -180,6 +180,15 @@ func deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 
     with_attr error_message("Abbot: Yang address cannot be zero") {
         assert_not_zero(yang);
+    }
+
+    with_attr error_message("Abbot: Trove ID cannot be zero") {
+        assert_not_zero(trove_id);
+    }
+
+    with_attr error_message("Abbot: Cannot deposit to a non-existing trove") {
+        let (troves_count: ufelt) = abbot_troves_count.read();
+        assert_le_felt(trove_id, troves_count);
     }
 
     let (shrine: address) = abbot_shrine.read();

--- a/tests/abbot/test_abbot.py
+++ b/tests/abbot/test_abbot.py
@@ -180,16 +180,31 @@ async def test_deposit(abbot, shrine, yangs, depositor):
         assert (await shrine.get_deposit(yang.contract_address, TROVE_1).execute()).result.balance == expected_yang
 
 
-@pytest.mark.usefixtures("sentinel_with_yangs")
+@pytest.mark.usefixtures("sentinel_with_yangs", "funded_trove1_owner", "shrine")
 @pytest.mark.asyncio
 async def test_deposit_failures(abbot, steth_yang: YangConfig, shitcoin_yang: YangConfig):
     with pytest.raises(StarkException, match="Abbot: Yang address cannot be zero"):
         await abbot.deposit(0, TROVE_1, 0).execute(caller_address=TROVE1_OWNER)
 
+    with pytest.raises(StarkException, match="Abbot: Trove ID cannot be zero"):
+        await abbot.deposit(shitcoin_yang.contract_address, 0, 0).execute(caller_address=TROVE1_OWNER)
+
+    # need to open a trove for the next two asserts to test functionality correctly
+    tx = await abbot.open_trove(
+        INITIAL_FORGED_AMOUNT,
+        [steth_yang.contract_address],
+        [INITIAL_STETH_DEPOSIT],
+    ).execute(caller_address=TROVE1_OWNER)
+    # sanity check that a trove was opened
+    assert_event_emitted(tx, abbot.contract_address, "TroveOpened", [TROVE1_OWNER, TROVE_1])
+
     with pytest.raises(StarkException, match=rf"Sentinel: Yang {STARKNET_ADDR} is not approved"):
         await abbot.deposit(shitcoin_yang.contract_address, TROVE_1, to_wad(100_000)).execute(
             caller_address=TROVE1_OWNER
         )
+
+    with pytest.raises(StarkException, match="Abbot: Cannot deposit to a non-existing trove"):
+        await abbot.deposit(steth_yang.contract_address, 999, to_wad(1)).execute(caller_address=TROVE1_OWNER)
 
 
 @pytest.mark.usefixtures("sentinel_with_yangs", "funded_trove1_owner", "forged_trove_1")


### PR DESCRIPTION
Fixes #216. Also updates the `@storage_var` names in Abbot to follow the conventions.