### PR TITLE
fix: test for partial absorption with redistribution

### DIFF
--- a/tests/purger/test_purger.py
+++ b/tests/purger/test_purger.py
@@ -852,6 +852,7 @@ async def test_partial_absorb_with_redistribution_pass(
 
     actual_freed_assets = partial_absorb.result.freed_assets_amt
     for actual, yang in zip(actual_freed_assets, yangs):
+        # Relax error margin by half due to loss of precision from fixed point arithmetic
         error_margin = custom_error_margin(yang.decimals // 2)
         expected = yangs_info[yang.contract_address]["expected_freed_asset"]
         assert_equalish(from_fixed_point(actual, yang.decimals), expected, error_margin)


### PR DESCRIPTION
Fixes a failing Purger test on `main` - the LTV of troves receiving a redistribution will be same or worse off only if the liquidated trove is undercollateralized; if the liquidated trove is overcollateralized, the LTV of troves receiving the redistribution will remain approximately the same (could be very slightly higher or lower).

I also removed the `@flaky` decorator for now as the tests are passing and it may have made it harder for us to catch this incorrect assertion, but we may need to add it back if it does turn out to be flaky again in the CI.