### PR TITLE
fix: relax error margin in tests for Purger

### DIFF
--- a/tests/purger/test_purger.py
+++ b/tests/purger/test_purger.py
@@ -809,8 +809,6 @@ async def test_partial_absorb_with_redistribution_pass(
         from_wad(absorber_forge_amt_wad),
     )
 
-    print("liquidated trove ltv: ", before_troves_info[liquidated_trove]["before_trove_ltv"])
-
     yangs_info = {}
 
     for token, yang, gate in zip(yang_tokens, yangs, yang_gates):
@@ -1021,8 +1019,8 @@ async def test_partial_absorb_with_redistribution_pass(
 
         # If liquidated trove is undercollateralized, LTV of other troves must be worse off after redistribution
         # because the debt increment > trove value increment.
-        # Otherwise, LTV should remain approximately the same because the debt and trove value increment would be
-        # approximately the same.
+        # Otherwise, given 88.88% < LTV of liquidated trove <= 100%, the LTV of other troves
+        # should remain approximately the same because trove value increment >= debt increment.
         debt_increment = after_trove_debt - before_troves_info[trove]["before_trove_debt"]
         yang_value_increment = (
             after_troves_info[trove]["after_trove_value"] - before_troves_info[trove]["before_trove_value"]


### PR DESCRIPTION
Due to the fix for initial deposit in Gate via the Sentinel, there is a loss of precision in the test suite as we went from working with round numbers to round numbers + 1000 wei. This PR relaxes the error margin for failing tests.

There was a failing test in the earlier CI [runs](https://github.com/lindy-labs/aura_contracts/actions/runs/4164739420/jobs/7206782906) where the LTV of a trove receiving redistribution improved even when the amount of debt redistributed to it was greater than the collateral value it received. This should not be possible. While trying to debug this failed CI run, I added an additional test assertion for comparing the debt increment and the trove value increment. However, I could not reproduce the failure locally, nor in the CI afterwards.

I have also removed the `@flaky` decorator entirely so that we can catch this error if it re-occurs.