### PR TITLE
fix: failing LTV assertion for partial absorb

### DIFF
--- a/tests/purger/test_purger.py
+++ b/tests/purger/test_purger.py
@@ -15,7 +15,6 @@ from tests.utils import (
     EMPIRIC_DECIMALS,
     EMPIRIC_OWNER,
     FALSE,
-    RAY_DECIMALS,
     RAY_SCALE,
     SENTINEL_OWNER,
     SHRINE_OWNER,
@@ -773,10 +772,6 @@ async def test_partial_absorb_with_redistribution_pass(
             "before_trove_debt": before_trove_debt,
         }
 
-    is_undercollateralized = False
-    if before_troves_info[liquidated_trove]["before_trove_ltv"] > Decimal("1"):
-        is_undercollateralized = True
-
     # Check purge penalty
     has_penalty = before_troves_info[liquidated_trove]["before_trove_ltv"] < Decimal("1")
     penalty = from_ray((await purger.get_penalty(liquidated_trove).execute()).result.penalty)
@@ -1014,31 +1009,8 @@ async def test_partial_absorb_with_redistribution_pass(
         expected_debt = after_troves_info[trove]["expected_trove_debt"]
         assert_equalish(after_trove_debt, expected_debt)
 
-        before_trove_ltv = before_troves_info[trove]["before_trove_ltv"]
-        after_trove_ltv = after_troves_info[trove]["after_trove_ltv"]
-
-        # If liquidated trove is undercollateralized, LTV of other troves must be worse off after redistribution
-        # because the debt increment > trove value increment.
-        # Otherwise, given 88.88% < LTV of liquidated trove <= 100%, the LTV of other troves
-        # should remain approximately the same because trove value increment >= debt increment.
-        debt_increment = after_trove_debt - before_troves_info[trove]["before_trove_debt"]
-        yang_value_increment = (
-            after_troves_info[trove]["after_trove_value"] - before_troves_info[trove]["before_trove_value"]
-        )
-        print("before trove value: ", before_troves_info[trove]["before_trove_value"])
-        print("before trove debt: ", before_troves_info[trove]["before_trove_debt"])
-        print("before trove ltv: ", before_troves_info[trove]["before_trove_ltv"])
-        print("after trove value: ", after_troves_info[trove]["after_trove_value"])
-        print("after trove debt: ", after_troves_info[trove]["after_trove_debt"])
-        print("after trove ltv: ", after_troves_info[trove]["after_trove_ltv"])
-
-        if is_undercollateralized:
-            assert yang_value_increment < debt_increment
-            assert after_trove_ltv > before_trove_ltv
-        else:
-            ltv_error_margin = RAY_DECIMALS // 2
-            assert_equalish(after_trove_ltv, before_trove_ltv, ltv_error_margin)
-            assert yang_value_increment >= debt_increment
+        # LTV may worsen or improve regardless of the troves' LTV.
+        # Therefore, we do not make any assertions.
 
     assert (await shrine.get_trove_redistribution_id(TROVE_2).execute()).result.redistribution_id == 0
     await shrine.melt(TROVE2_OWNER, TROVE_2, 0).execute(caller_address=SHRINE_OWNER)


### PR DESCRIPTION
I realized it is not possible to make any assertion about the LTV of a trove that receives distribution based on whether the liquidated trove is undercollateralized or not. Even if the liquidated trove is undercollateralized, the LTV of a trove receiving the redistribution can still improve.
```
**Example**
Trove value: 1000 USD
Trove debt: 1100 USD
LTV: 1.1

Debt increment from redistribution: 100 USD
Trove value increment from redistribution: 95 USD
Liquidated trove LTV: 1.0526

New trove value: 1095 USD
New trove debt: 1200 USD
LTV: 1.095
```


It is also not possible to derive a relationship by comparing the LTVs of the liquidated trove and the receiving trove, because it depends on the relative amount redistributed in relation to the receiving trove's debt and value.

Therefore, my earlier assumption that LTV must worsen if the liquidated trove is undercollateralized is wrong, and this assertion should be removed. Hopefully this resolves the flakiness.