### PR TITLE
chore: remove `typeguard` dependency pin

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,3 @@ pytest-asyncio==0.15.1
 pytest-xdist==3.0.2
 sympy==1.8
 toml==0.10.2
-typeguard==2.13.3


### PR DESCRIPTION
Fix #252.