### PR TITLE
chore: compile contracts as standalone JSON files

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,6 +2,9 @@
 name = "aura"
 version = "0.1.0"
 
+# Build each contract as a standalone JSON file
+[[target.starknet-contract]]
+
 [scripts]
 test = "cairo-test --starknet ."
 


### PR DESCRIPTION
Currently, `scarb build` gives a consolidated output for all contracts in `src`. Instead, we want each contract to be a standalone file for deployment.

This can be done by adding one line to `Scarb.toml` - see Scarb [docs](https://docs.swmansion.com/scarb/docs/starknet/contract-target).

To check this, switch to a branch with multiple files in `src/core` and run `scarb build`. You should then see multiple JSON files in `taget/dev` as opposed to a single `aura.json` file at the moment.