### PR TITLE
fix: emit event using Span before modifying loop

### DIFF
--- a/src/core/allocator.cairo
+++ b/src/core/allocator.cairo
@@ -134,7 +134,6 @@ mod Allocator {
         assert(total_percentage == RAY_ONE.into(), 'sum(percentages) != RAY_ONE');
 
         recipients_count::write(recipients_len);
-    // Note that `AllocationUpdated` event has been emitted earlier
     }
 
     //


### PR DESCRIPTION
As `pop_front` changes the mutable `Span` in-place, we cannot rely on the same `Span` variable (e.g. as return value, or as an event data) after a loop because the Span would now be empty. The fix is to create a copy of the `Span` that can be used after the loop. 

However, is this expensive?

Before we changed to `pop_front`, we were indexing into the array/span. In that approach, we would not need to create an additional copy. In these cases where we need the same array after a loop, we therefore have a choice between: 
(1) using `pop_front` in loops and incurring the cost of an additional copy of the Span; or 
(2) using index in loops and incur the costs of checking the index is within bounds of the Span's length but saving on a copy.

How do the gas costs compare using dummy code for a Span of three `u128` elements? 
- (1) costs 27,400 gas whereas (2) costs 35,080 gas.
- If I add one more element to the array, (1) has a marginal increase of 3,270 gas while (2) has a marginal increase of 5,340 gas.
- If I create one more copy of a Span of 3 elements, (1) has a marginal increase of 600 gas.

Therefore, (1) is still clearly the way to go.


```
use array::{ArrayTrait, SpanTrait};
use box::BoxTrait;
use clone::Clone;
use option::OptionTrait;
use debug::PrintTrait;

fn create_span() -> Span<u128> {
    let mut x: Array<u128> = ArrayTrait::new();
    x.append(1);
    x.append(2);
    x.append(3);
    //x.append(4);
    x.span()
}

fn foo(x: Span<u128>) -> Span<u128> {
    let mut x_copy: Span<u128> = x.clone();
    //let mut x_copy2: Span<u128> = x.clone();
    loop {
        match x_copy.pop_front() {
            Option::Some(i) => {},
            Option::None(_) => {
                break ();
            },
        };
    };

    x
}

fn bar(x: Span<u128>) -> Span<u128> {
    let x_len: u32 = x.len(); 
    let mut idx: u32 = 0;
    loop {
        if idx == x_len {
            break ();
        }
        
        idx += 1;
    };
    x
}

#[cfg(test)]
mod TestFoo {
    use array::{ArrayTrait, SpanTrait};
    use box::BoxTrait;
    use option::OptionTrait;
    use debug::PrintTrait;

    use super::{foo, bar, create_span};

    #[test]
    #[available_gas(20000000)]
    fn test_foo() {
        
         let actual: Span<u128> = foo(create_span());
         'foo'.print();
         (20000000 - testing::get_available_gas()).print();

         let actual_len: u32 = actual.len();         
         assert(actual_len == 3, 'wrong_len'); 
        
         let idx0: u128 = *actual.at(0);
         assert(idx0 == 1, 'wrong!');
    }

    
    #[test]
    #[available_gas(20000000)]
    fn test_bar() {
        
         let actual: Span<u128> = bar(create_span());
         'bar'.print();
         (20000000 - testing::get_available_gas()).print();

         let actual_len: u32 = actual.len();         
         assert(actual_len == 3, 'wrong len');
         
         let idx0: u128 = *actual.at(0);
         assert(idx0 == 1, 'wrong!');
    }
}
```