### PR TITLE
fix: bug in exp

### DIFF
--- a/src/tests/utils/test_exp.cairo
+++ b/src/tests/utils/test_exp.cairo
@@ -2,7 +2,7 @@
 mod tests {
     use aura::utils::exp::exp;
     use aura::utils::wadray::Wad;
-    use aura::utils::wadray::WAD_ONE;
+    use aura::utils::wadray::{WAD_ONE, WAD_PERCENT};
 
     // Acceptable error for e^x where x <= 20. Corresponds to 0.000000000001 (10^-12) precision
     const ACCEPTABLE_ERROR: u128 = 1000000;
@@ -24,6 +24,9 @@ mod tests {
         assert(
             exp(Wad { val: WAD_ONE }) == Wad { val: 2718281828459045235 }, 'Incorrect e^1 result'
         );
+
+        let res = exp(Wad { val: WAD_PERCENT * 2 });
+        assert_equalish(res, Wad { val: 1020201340026755810 });
 
         let res = exp(Wad { val: WAD_ONE * 10 });
         assert_equalish(res, Wad { val: 22026465794806716516957 });

--- a/src/utils/exp.cairo
+++ b/src/utils/exp.cairo
@@ -141,12 +141,10 @@ fn exp(x: Wad) -> Wad {
     let mut series_sum: u256 = ONE_20; // The initial one in the sum, with 20 decimal places.
     let x: u256 = x.into();
     let mut term: u256 = x; // Each term in the sum, where the nth term is (x^n / n!).
+    series_sum += term;
 
     // Each term (x^n / n!) equals the previous one times x, divided by n. Since x is a fixed point number,
     // multiplying by it requires dividing by ONE_20, but dividing by the non-fixed point n values does not.
-
-    term = term * x / 100000000000000000000_u256;
-    series_sum += term;
 
     term = term * x / 200000000000000000000_u256;
     series_sum += term;


### PR DESCRIPTION
I noticed a bug with exp while working on Equalizer tests. exp(0.02) should return ~1.0202, but it was returning ~1.0004. Found the bug and fixed it.