### PR TITLE
test: update Shrine tests for kill

### DIFF
--- a/src/tests/shrine/test_shrine.cairo
+++ b/src/tests/shrine/test_shrine.cairo
@@ -346,6 +346,7 @@ mod TestShrine {
     fn test_killed_withdraw_fail() {
         let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
+        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
 
         set_contract_address(ShrineUtils::admin());
         shrine.kill();
@@ -376,6 +377,8 @@ mod TestShrine {
     fn test_killed_melt_fail() {
         let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
+        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
 
         set_contract_address(ShrineUtils::admin());
         shrine.kill();


### PR DESCRIPTION
Following #272, the existing test for `Shrine.kill` will fail. This PR fixes the failing test, and adds additional tests for `Shrine.withdraw`, `Shrine.melt` and `Shrine.inject` which are all blocked.