### PR TITLE
fix: sentinel interface declaration

### DIFF
--- a/src/interfaces/ISentinel.cairo
+++ b/src/interfaces/ISentinel.cairo
@@ -19,9 +19,10 @@ trait ISentinel {
     // External
     fn add_yang(
         yang: ContractAddress,
-        yang_max: Wad,
+        yang_asset_max: u128,
         yang_threshold: Ray,
         yang_price: Wad,
+        yang_rate: Ray,
         gate: ContractAddress
     );
     fn set_yang_asset_max(yang: ContractAddress, new_asset_max: u128);


### PR DESCRIPTION
Small fix of `ISentinel.add_yang` - it did not match the actual `add_yang` fn.