### PR TITLE
ci: freeze cairo

### DIFF
--- a/.github/workflows/cairo-1.0.yml
+++ b/.github/workflows/cairo-1.0.yml
@@ -1,4 +1,4 @@
-name: Cairo 1.0
+name: Cairo 1
 
 on:
   push:
@@ -14,16 +14,13 @@ on:
 env:
   CAIRO_FOLDER: ./cairo
   BUILD_FOLDER: ./target
+  CAIRO_HASH: fecc9dc5
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get latest commit hash
-        run: |
-          echo "CAIRO_HASH=fecc9dc5" >> $GITHUB_ENV
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -32,53 +29,48 @@ jobs:
         with:
           toolchain: nightly-2022-11-03
 
-      # - name: Get cache
-      #   id: cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       **/target
-      #       **/cairo
-      #     key: ${{ runner.os }}-cairo-${{ env.CAIRO_HASH }}
-      #     restore-keys: Linux-cairo-
+      - name: Get cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            **/target
+            **/cairo
+          key: cairo-${{ env.CAIRO_HASH }}
+          restore-keys: cairo-
 
-        # Always pull dependencies to access `corelib`
+      # Always pull dependencies to access `corelib`
       - name: Pull dependencies
         shell: bash
         run: |
           if [ -d $CAIRO_FOLDER ]; then
             echo "Cairo directory exists"
-            git -C $CAIRO_FOLDER pull
+            git -C $CAIRO_FOLDER log -n 1
           else
             echo "Cairo directory does not exist"
             git clone https://github.com/starkware-libs/cairo.git $CAIRO_FOLDER
           fi
 
-      # - name: View
-      #   run: |
-      #     ls -la
-      #     ls -la $CAIRO_FOLDER
-
       - name: Install dependencies
         run: |
-          cd $CAIRO_FOLDER && git checkout $CAIRO_HASH && cd -
+          git -C $CAIRO_FOLDER checkout ${{ env.CAIRO_HASH }}
           cargo build --manifest-path=./cairo/Cargo.toml --target-dir $BUILD_FOLDER/cairo --release --all
 
-      # - name: Save cache
-      #   uses: actions/cache/save@v3
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       **/target
-      #       **/cairo
-      #     key: ${{ runner.os }}-cairo-${{ env.CAIRO_HASH }}
+      - name: Save cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            **/target
+            **/cairo
+          key: cairo-${{ env.CAIRO_HASH }}
 
       - name: Add Cairo to PATH
         run: echo "$BUILD_FOLDER/cairo/release" >> $GITHUB_PATH


### PR DESCRIPTION
Updates the Cairo 1 workflow to use the `fecc9dc5` commit from the Cairo repo.

I've also dropped Scarb installation for now, since we don't really use it. The two `scarb run` commands are run directly in the workflow steps.

Had to modify the caching keys a little bit because the previous cache was still active and then the whole job couldn't be set up properly. The main logic remains tho.

I've also added logic that will run both the lint and test steps [even if lint fails](https://github.com/lindy-labs/aura_contracts/actions/runs/5179542600/jobs/9332561139).