### PR TITLE
feat: new close factor formula

### DIFF
--- a/src/core/purger.cairo
+++ b/src/core/purger.cairo
@@ -305,14 +305,15 @@ mod Purger {
 
 
     // Returns the maximum amount of debt that can be paid off in a given liquidation
-    // Note: this function reverts if the trove's LTV is below its threshold multiplied by `THRESHOLD_SAFETY_MARGIN`. 
+    // Note: this function reverts if the trove's LTV is below its threshold multiplied by `THRESHOLD_SAFETY_MARGIN`
+    // because `debt - wadray::rmul_wr(value, target_ltv)` would underflow
     #[inline(always)]
     fn get_max_close_amount_internal(
         threshold: Ray, ltv: Ray, value: Wad, debt: Wad, penalty: Ray
     ) -> Wad {
         let penalty_multiplier = RAY_ONE.into() + penalty;
         // If the LTV is greater than 1 / penalty_multiplier, then the max close amount
-        // the function will calculate will be greater than `debt`, so we cap it at `debt`. 
+        // based on the equation below will be greater than `debt`, so we cap it at `debt`. 
         if ltv >= RAY_ONE.into() / penalty_multiplier {
             return debt;
         }


### PR DESCRIPTION
This PR implements a new way of calculating the `max_close_amount` in Purger, whereby the maximum close amount is the amount needed in order to bring the trove's LTV down to 10% below its threshold. 

This solves the problem of having only a single close factor curve for all thresholds. 

The maximum close amount is calculated as follows:
```
repayment_amount = (original_debt - target_ltv * original_trove_value) / (1 - target_ltv * penalty)
```

where `penalty` is the percent penalty plus one (e.g., `1.03` for 3% penalty). 

If the trove's LTV exceeds `1 / penalty`, then `repayment_amount` is capped to `original_debt`, since it is at this point that the formula's output exceeds the trove's value. 

