### PR TITLE
chore: scarb config update

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 # Build each contract as a standalone JSON file
 [[target.starknet-contract]]
+sierra = true
 
 [scripts]
 fmt = "cairo-format --recursive src/"
@@ -12,3 +13,4 @@ check_fmt = "cairo-format --recursive --check --print-parsing-errors src/"
 test = "cairo-test --starknet ."
 
 [dependencies]
+starknet = ">=1.1.0"


### PR DESCRIPTION
Declaring "starknet" as Aura [dependency](https://docs.swmansion.com/scarb/docs/starknet/starknet-package), otherwise Scarb complains:

```sh
warn: package `aura` declares `starknet-contract` target, but does not depend on `starknet` package
note: this may cause contract compilation to fail with cryptic errors
help: add dependency on `starknet` to package manifest
 --> Scarb.toml
    [dependencies]
    starknet = ">=1.1.0"
```

Also adding `sierra = true` which is [the default](https://docs.swmansion.com/scarb/docs/starknet/contract-target#sierra-contract-class-generation), just wanted to have it explicit.