### PR TITLE
refactor(caretaker): get_live from Shrine

### DIFF
--- a/src/interfaces/ICaretaker.cairo
+++ b/src/interfaces/ICaretaker.cairo
@@ -7,7 +7,6 @@ use aura::utils::wadray::Wad;
 #[abi]
 trait ICaretaker {
     // getter
-    fn get_live() -> bool;
     fn preview_release(trove_id: u64) -> (Span<ContractAddress>, Span<u128>);
     fn preview_reclaim(yin: Wad) -> (Span<ContractAddress>, Span<u128>);
     // external


### PR DESCRIPTION
Suggesting a change in Caretaker - this PR removes the `is_live` storage var from the Caretaker. Instead, its value is taken from Shrine since in there it serves the same purpose and Caretaker is tightly coupled to Shrine. I kept the public `get_live` function in Caretaker, but that could also be made internal.