### PR TITLE
fix: liquidation penalty underflow issues

### DIFF
--- a/src/core/purger.cairo
+++ b/src/core/purger.cairo
@@ -456,7 +456,7 @@ mod Purger {
         }
 
         // It's possible for `ltv_after_compensation` to be greater than one, so we handle this case 
-        // to avoid underflow
+        // to avoid underflow. Note that this also guarantees `ltv` is lesser than one.
         if ltv_after_compensation > RAY_ONE.into() {
             return Option::Some(RayZeroable::zero());
         }


### PR DESCRIPTION
This PR fixes an issue in `get_liquidation_penalty_internal` and `get_absorption_penalty_internal` where if `ltv` or `ltv_after_compensation` exceeds 100% respectively, an underflow occurs which causes the function to fail. 

Comments were also added to `get_liquidation_penalty` and `get_absorption_penalty` to clarify that the penalty can be zero even when a trove is liquidatable/absorbable if the LTV/LTV after compensation exceeds 100%. 