### PR TITLE
fix: remove `pow10`

### DIFF
--- a/src/tests/external/utils.cairo
+++ b/src/tests/external/utils.cairo
@@ -187,7 +187,7 @@ mod PragmaUtils {
     //
 
     fn convert_price_to_pragma_scale(price: u128) -> u128 {
-        let pragma_price_scale: u128 = pow10(PRAGMA_DECIMALS);
+        let pragma_price_scale: u128 = pow(10_u128, PRAGMA_DECIMALS);
         price * pragma_price_scale
     }
 

--- a/src/tests/purger/utils.cairo
+++ b/src/tests/purger/utils.cairo
@@ -21,7 +21,7 @@ mod PurgerUtils {
     use aura::interfaces::IPurger::{IPurgerDispatcher, IPurgerDispatcherTrait};
     use aura::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use aura::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use aura::utils::pow::pow10;
+    use aura::utils::math::pow;
     use aura::utils::wadray;
     use aura::utils::wadray::{
         Ray, RayZeroable, RAY_ONE, RAY_PERCENT, Wad, WadZeroable, WAD_DECIMALS, WAD_ONE
@@ -503,7 +503,7 @@ mod PurgerUtils {
         pct_decrease: Ray,
     ) {
         let current_ts = get_block_timestamp();
-        let scale: u128 = pow10(WAD_DECIMALS - PragmaUtils::PRAGMA_DECIMALS);
+        let scale: u128 = pow(10_u128, WAD_DECIMALS - PragmaUtils::PRAGMA_DECIMALS);
         set_contract_address(ShrineUtils::admin());
         loop {
             match yangs.pop_front() {


### PR DESCRIPTION
This PR gets rid of remaining `pow10` calls and replaces them with the new `pow` function. 