### PR TITLE
ci: strict libfunc check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,5 @@ jobs:
         with:
           scarb-version: "nightly"
       - run: scarb fmt --check
+      - run: scarb build
       - run: scarb test

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 # Build each contract as a standalone JSON file
 [[target.starknet-contract]]
 sierra = true
+# strict libfuncs check - throw a compilation error
+# when the code uses a libfunc that is not allowed
+allowed-libfuncs-deny = true
 
 [dependencies]
 starknet = ">=2.2.0"


### PR DESCRIPTION
Resolves #324 

Relevant [Scarb docs here](https://docs.swmansion.com/scarb/docs/extensions/starknet/contract-target.html#allowed-libfuncs-validation).

Had to add a `build` step to the CI, because only running `test` does not surface the use of an unallowed libfunc.

When there's one, this is how the error output looks like:

```sh
Compiling aura v0.1.0 (/Users/m/projects/aura/contracts/Scarb.toml)
error: libfunc `bytes31_const` is not allowed in the libfuncs list `Default libfunc list`
 --> contract: Absorber
help: try compiling with the `experimental` list
 --> Scarb.toml
    [[target.starknet-contract]]
    allowed-libfuncs-list.name = "experimental"

error: libfunc `bytes31_const` is not allowed in the libfuncs list `Default libfunc list`
 --> contract: Sentinel
help: try compiling with the `experimental` list
 --> Scarb.toml
    [[target.starknet-contract]]
    allowed-libfuncs-list.name = "experimental"

error: libfunc `bytes31_const` is not allowed in the libfuncs list `Default libfunc list`
 --> contract: Shrine
help: try compiling with the `experimental` list
 --> Scarb.toml
    [[target.starknet-contract]]
    allowed-libfuncs-list.name = "experimental"

error: libfunc `bytes31_const` is not allowed in the libfuncs list `Default libfunc list`
 --> contract: Pragma
help: try compiling with the `experimental` list
 --> Scarb.toml
    [[target.starknet-contract]]
    allowed-libfuncs-list.name = "experimental"

error: aborting compilation, because contracts use disallowed Sierra libfuncs
error: could not compile `aura` due to previous error
```