### PR TITLE
refactor: max close amount

### DIFF
--- a/src/core/purger.cairo
+++ b/src/core/purger.cairo
@@ -479,7 +479,7 @@ mod Purger {
 
                     // LTV and value after compensation are used to calculate the max purge amount
                     let max_absorption_amt: Wad = get_max_close_amount_internal(
-                        threshold, ltv_after_compensation, value_after_compensation, debt, penalty
+                        threshold, value_after_compensation, debt, penalty
                     );
                     (
                         penalty,
@@ -510,14 +510,10 @@ mod Purger {
     // Note: this function reverts if the trove's LTV is below its threshold multiplied by `THRESHOLD_SAFETY_MARGIN`
     // because `debt - wadray::rmul_wr(value, target_ltv)` would underflow
     #[inline(always)]
-    fn get_max_close_amount_internal(
-        threshold: Ray, ltv: Ray, value: Wad, debt: Wad, penalty: Ray
-    ) -> Wad {
+    fn get_max_close_amount_internal(threshold: Ray, value: Wad, debt: Wad, penalty: Ray) -> Wad {
         let penalty_multiplier = RAY_ONE.into() + penalty;
         let target_ltv = THRESHOLD_SAFETY_MARGIN.into() * threshold;
 
-        // If the LTV is greater than 1 / penalty_multiplier, then the max close amount
-        // based on the equation below will be greater than `debt`, so we cap it at `debt`. 
         min(
             wadray::rdiv_wr(
                 debt - wadray::rmul_wr(value, target_ltv),
@@ -552,7 +548,7 @@ mod Purger {
     fn preview_liquidate_internal(threshold: Ray, ltv: Ray, value: Wad, debt: Wad) -> (Ray, Wad) {
         match get_liquidation_penalty_internal(threshold, ltv) {
             Option::Some(penalty) => {
-                (penalty, get_max_close_amount_internal(threshold, ltv, value, debt, penalty))
+                (penalty, get_max_close_amount_internal(threshold, value, debt, penalty))
             },
             Option::None => (RayZeroable::zero(), WadZeroable::zero()),
         }


### PR DESCRIPTION
Resolves #356.

It turns out that there is also a saving of 34,740 Sierra gas in all cases.