### PR TITLE
chore: YangSuspensionUpdated event

### DIFF
--- a/src/core/sentinel.cairo
+++ b/src/core/sentinel.cairo
@@ -288,7 +288,7 @@ mod Sentinel {
                 .shrine
                 .read()
                 .get_yang_suspension_status(yang);
-            assert(suspension_status == YangSuspensionStatus::None(()), 'SE: Yang suspended');
+            assert(suspension_status == YangSuspensionStatus::None, 'SE: Yang suspended');
             let current_total: u128 = gate.get_total_assets();
             let max_amt: u128 = self.yang_asset_max.read(yang);
             assert(current_total + enter_amt <= max_amt, 'SE: Exceeds max amount allowed');

--- a/src/tests/sentinel/test_sentinel.cairo
+++ b/src/tests/sentinel/test_sentinel.cairo
@@ -484,18 +484,18 @@ mod TestSentinel {
         set_block_timestamp(ShrineUtils::DEPLOYMENT_TIMESTAMP);
 
         let status = shrine.get_yang_suspension_status(eth);
-        assert(status == YangSuspensionStatus::None(()), 'status 1');
+        assert(status == YangSuspensionStatus::None, 'status 1');
 
         sentinel.suspend_yang(eth);
         let status = shrine.get_yang_suspension_status(eth);
-        assert(status == YangSuspensionStatus::Temporary(()), 'status 2');
+        assert(status == YangSuspensionStatus::Temporary, 'status 2');
 
         // move time forward by 1 day
         set_block_timestamp(ShrineUtils::DEPLOYMENT_TIMESTAMP + 86400);
 
         sentinel.unsuspend_yang(eth);
         let status = shrine.get_yang_suspension_status(eth);
-        assert(status == YangSuspensionStatus::None(()), 'status 3');
+        assert(status == YangSuspensionStatus::None, 'status 3');
     }
 
     #[test]

--- a/src/tests/shrine/test_shrine.cairo
+++ b/src/tests/shrine/test_shrine.cairo
@@ -1781,11 +1781,11 @@ mod TestShrine {
         let shrine = ShrineUtils::shrine(shrine_addr);
 
         let status_yang1 = shrine.get_yang_suspension_status(ShrineUtils::yang1_addr());
-        assert(status_yang1 == YangSuspensionStatus::None(()), 'yang1');
+        assert(status_yang1 == YangSuspensionStatus::None, 'yang1');
         let status_yang2 = shrine.get_yang_suspension_status(ShrineUtils::yang2_addr());
-        assert(status_yang2 == YangSuspensionStatus::None(()), 'yang2');
+        assert(status_yang2 == YangSuspensionStatus::None, 'yang2');
         let status_yang3 = shrine.get_yang_suspension_status(ShrineUtils::yang3_addr());
-        assert(status_yang3 == YangSuspensionStatus::None(()), 'yang3');
+        assert(status_yang3 == YangSuspensionStatus::None, 'yang3');
     }
 
     #[test]
@@ -1824,7 +1824,18 @@ mod TestShrine {
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::Temporary(()), 'status 1');
+        assert(status == YangSuspensionStatus::Temporary, 'status 1');
+
+        // check event emission
+        common::assert_events_emitted(
+            shrine_addr,
+            array![
+                Shrine::Event::YangSuspensionUpdated(
+                    Shrine::YangSuspensionUpdated { yang, suspension_ts: start_ts }
+                ),
+            ]
+                .span()
+        );
 
         // setting block time to a second before the suspension would be permanent
         set_block_timestamp(start_ts + Shrine::SUSPENSION_GRACE_PERIOD - 1);
@@ -1834,7 +1845,18 @@ mod TestShrine {
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::None(()), 'status 2');
+        assert(status == YangSuspensionStatus::None, 'status 2');
+
+        // check event emission
+        common::assert_events_emitted(
+            shrine_addr,
+            array![
+                Shrine::Event::YangSuspensionUpdated(
+                    Shrine::YangSuspensionUpdated { yang, suspension_ts: 0 }
+                ),
+            ]
+                .span()
+        );
     }
 
     #[test]
@@ -1868,7 +1890,18 @@ mod TestShrine {
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::Temporary(()), 'status 1');
+        assert(status == YangSuspensionStatus::Temporary, 'status 1');
+
+        // check event emission
+        common::assert_events_emitted(
+            shrine_addr,
+            array![
+                Shrine::Event::YangSuspensionUpdated(
+                    Shrine::YangSuspensionUpdated { yang, suspension_ts: start_ts }
+                ),
+            ]
+                .span()
+        );
 
         // check threshold (should be the same at the beginning)
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
@@ -1882,7 +1915,7 @@ mod TestShrine {
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::Temporary(()), 'status 2');
+        assert(status == YangSuspensionStatus::Temporary, 'status 2');
 
         // check threshold
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
@@ -1893,7 +1926,7 @@ mod TestShrine {
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::Temporary(()), 'status 3');
+        assert(status == YangSuspensionStatus::Temporary, 'status 3');
 
         // check threshold
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
@@ -1904,7 +1937,7 @@ mod TestShrine {
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::Temporary(()), 'status 4');
+        assert(status == YangSuspensionStatus::Temporary, 'status 4');
 
         // check threshold
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
@@ -1922,7 +1955,7 @@ mod TestShrine {
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::Permanent(()), 'status 5');
+        assert(status == YangSuspensionStatus::Permanent, 'status 5');
 
         // check threshold
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
@@ -1946,7 +1979,7 @@ mod TestShrine {
         shrine.update_yang_suspension(yang, start_ts - Shrine::SUSPENSION_GRACE_PERIOD);
         // sanity check
         let status = shrine.get_yang_suspension_status(yang);
-        assert(status == YangSuspensionStatus::Permanent(()), 'delisted');
+        assert(status == YangSuspensionStatus::Permanent, 'delisted');
 
         // trying to reset yang suspension status, should fail
         shrine.update_yang_suspension(yang, 0);
@@ -1968,9 +2001,9 @@ mod TestShrine {
         shrine.update_yang_suspension(yang, ts + 1);
     }
 
-    // In this test, we have two troves. Both are initially healthy. And then suddenly the 
-    // LTV of the larger trove drops enough such that the global LTV is above the 
-    // recovery mode threshold, and high enough above the threshold such that 
+    // In this test, we have two troves. Both are initially healthy. And then suddenly the
+    // LTV of the larger trove drops enough such that the global LTV is above the
+    // recovery mode threshold, and high enough above the threshold such that
     // the second (smaller) trove is now underwater.
     #[test]
     #[available_gas(20000000000)]
@@ -2017,7 +2050,7 @@ mod TestShrine {
         // so that trove 1 is underwater
         //
         // z = x + y, where x is from the last equation and y is the additional collateral
-        // value that must be withdrawn to reach the desired threshold reduction. 
+        // value that must be withdrawn to reach the desired threshold reduction.
         //
         // trove1_ltv - 10^(-24) = (trove1_threshold * THRESHOLD_DECREASE_FACTOR * rm_threshold) / (whale_trove_forge_amt / (whale_trove_deposit_value - z))
         // trove1_ltv - 10^(-24) = (whale_trove_deposit_value - z) * (trove1_threshold * THRESHOLD_DECREASE_FACTOR * rm_threshold) / whale_trove_forge_amt
@@ -2049,14 +2082,14 @@ mod TestShrine {
                 remaining_collateral_value_to_withdraw / ShrineUtils::YANG1_START_PRICE.into()
             );
 
-        // Now trove1 should be underwater, while the whale trove should still be healthy. 
+        // Now trove1 should be underwater, while the whale trove should still be healthy.
         assert(!shrine.is_healthy(common::TROVE_1), 'should be unhealthy');
         assert(shrine.is_healthy(common::WHALE_TROVE), 'should be healthy #3');
     }
 
-    // Invariant test: scaling the "raw" trove threshold for recovery mode is 
+    // Invariant test: scaling the "raw" trove threshold for recovery mode is
     // the same as scaling each yang threshold individually and only then
-    // calculating the trove threshold 
+    // calculating the trove threshold
     #[test]
     #[available_gas(20000000000)]
     fn test_recovery_mode_invariant() {


### PR DESCRIPTION
Resolves #428 

I've also updated the syntax of `YangSuspensionStatus` enum variants to the shorter syntax.