### PR TITLE
chore: use snake_case for modules

### DIFF
--- a/src/core/abbot.cairo
+++ b/src/core/abbot.cairo
@@ -1,12 +1,12 @@
 #[starknet::contract]
-mod Abbot {
+mod abbot {
     use starknet::{ContractAddress, get_caller_address};
 
     use opus::interfaces::IAbbot::IAbbot;
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::AssetBalance;
-    use opus::utils::reentrancy_guard::ReentrancyGuard;
+    use opus::utils::reentrancy_guard::reentrancy_guard;
     use opus::utils::wadray::{BoundedWad, Wad};
 
     #[storage]
@@ -228,7 +228,7 @@ mod Abbot {
             ref self: ContractState, trove_id: u64, user: ContractAddress, yang_asset: AssetBalance
         ) {
             // reentrancy guard is used as a precaution
-            ReentrancyGuard::start();
+            reentrancy_guard::start();
 
             let yang_amt: Wad = self
                 .sentinel
@@ -236,7 +236,7 @@ mod Abbot {
                 .enter(yang_asset.address, user, trove_id, yang_asset.amount);
             self.shrine.read().deposit(yang_asset.address, trove_id, yang_amt);
 
-            ReentrancyGuard::end();
+            reentrancy_guard::end();
         }
 
         #[inline(always)]
@@ -248,12 +248,12 @@ mod Abbot {
             yang_amt: Wad
         ) {
             // reentrancy guard is used as a precaution
-            ReentrancyGuard::start();
+            reentrancy_guard::start();
 
             self.sentinel.read().exit(yang, user, trove_id, yang_amt);
             self.shrine.read().withdraw(yang, trove_id, yang_amt);
 
-            ReentrancyGuard::end();
+            reentrancy_guard::end();
         }
     }
 }

--- a/src/core/absorber.cairo
+++ b/src/core/absorber.cairo
@@ -5,12 +5,12 @@
 // wadray-fixed-point arithmetic functions in their calculations. Consequently,
 // wadray's internal functions are used to perform these calculations.
 #[starknet::contract]
-mod Absorber {
+mod absorber {
     use cmp::min;
     use integer::u256_safe_divmod;
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
 
-    use opus::core::roles::AbsorberRoles;
+    use opus::core::roles::absorber_roles;
 
     use opus::interfaces::IAbsorber::{IAbsorber, IBlesserDispatcher, IBlesserDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -231,7 +231,7 @@ mod Absorber {
         shrine: ContractAddress,
         sentinel: ContractAddress,
     ) {
-        self.access_control.initializer(admin, Option::Some(AbsorberRoles::default_admin_role()));
+        self.access_control.initializer(admin, Option::Some(absorber_roles::default_admin_role()));
 
         self.shrine.write(IShrineDispatcher { contract_address: shrine });
         self.sentinel.write(ISentinelDispatcher { contract_address: sentinel });
@@ -378,7 +378,7 @@ mod Absorber {
             blesser: ContractAddress,
             is_active: bool
         ) {
-            self.access_control.assert_has_role(AbsorberRoles::SET_REWARD);
+            self.access_control.assert_has_role(absorber_roles::SET_REWARD);
 
             assert(asset.is_non_zero() && blesser.is_non_zero(), 'ABS: Address cannot be 0');
 
@@ -593,7 +593,7 @@ mod Absorber {
 
         // Update assets received after an absorption
         fn update(ref self: ContractState, asset_balances: Span<AssetBalance>) {
-            self.access_control.assert_has_role(AbsorberRoles::UPDATE);
+            self.access_control.assert_has_role(absorber_roles::UPDATE);
 
             let current_epoch: u32 = self.current_epoch.read();
 
@@ -680,7 +680,7 @@ mod Absorber {
         }
 
         fn kill(ref self: ContractState) {
-            self.access_control.assert_has_role(AbsorberRoles::KILL);
+            self.access_control.assert_has_role(absorber_roles::KILL);
             self.is_live.write(false);
             self.emit(Killed {});
         }

--- a/src/core/allocator.cairo
+++ b/src/core/allocator.cairo
@@ -1,8 +1,8 @@
 #[starknet::contract]
-mod Allocator {
+mod allocator {
     use starknet::ContractAddress;
 
-    use opus::core::roles::AllocatorRoles;
+    use opus::core::roles::allocator_roles;
 
     use opus::interfaces::IAllocator::IAllocator;
     use opus::utils::access_control::access_control_component;
@@ -78,7 +78,7 @@ mod Allocator {
         recipients: Span<ContractAddress>,
         percentages: Span<Ray>
     ) {
-        self.access_control.initializer(admin, Option::Some(AllocatorRoles::default_admin_role()));
+        self.access_control.initializer(admin, Option::Some(allocator_roles::default_admin_role()));
 
         self.set_allocation_helper(recipients, percentages);
     }
@@ -124,7 +124,7 @@ mod Allocator {
         fn set_allocation(
             ref self: ContractState, recipients: Span<ContractAddress>, percentages: Span<Ray>
         ) {
-            self.access_control.assert_has_role(AllocatorRoles::SET_ALLOCATION);
+            self.access_control.assert_has_role(allocator_roles::SET_ALLOCATION);
 
             self.set_allocation_helper(recipients, percentages);
         }

--- a/src/core/caretaker.cairo
+++ b/src/core/caretaker.cairo
@@ -1,9 +1,9 @@
 #[starknet::contract]
-mod Caretaker {
+mod caretaker {
     use cmp::min;
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
 
-    use opus::core::roles::CaretakerRoles;
+    use opus::core::roles::caretaker_roles;
 
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::ICaretaker::ICaretaker;
@@ -13,7 +13,7 @@ mod Caretaker {
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::AssetBalance;
     use opus::utils::access_control::access_control_component;
-    use opus::utils::reentrancy_guard::ReentrancyGuard;
+    use opus::utils::reentrancy_guard::reentrancy_guard;
     use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RAY_ONE, Wad};
 
@@ -100,7 +100,7 @@ mod Caretaker {
         sentinel: ContractAddress,
         equalizer: ContractAddress
     ) {
-        self.access_control.initializer(admin, Option::Some(CaretakerRoles::default_admin_role()));
+        self.access_control.initializer(admin, Option::Some(caretaker_roles::default_admin_role()));
 
         self.abbot.write(IAbbotDispatcher { contract_address: abbot });
         self.shrine.write(IShrineDispatcher { contract_address: shrine });
@@ -188,7 +188,7 @@ mod Caretaker {
 
         // Admin will initially have access to `shut`.
         fn shut(ref self: ContractState) {
-            self.access_control.assert_has_role(CaretakerRoles::SHUT);
+            self.access_control.assert_has_role(caretaker_roles::SHUT);
 
             let shrine: IShrineDispatcher = self.shrine.read();
 
@@ -260,7 +260,7 @@ mod Caretaker {
             assert(shrine.get_live() == false, 'CA: System is live');
 
             // reentrancy guard is used as a precaution
-            ReentrancyGuard::start();
+            reentrancy_guard::start();
 
             // Assert caller is trove owner
             let trove_owner: ContractAddress = self.abbot.read().get_trove_owner(trove_id);
@@ -296,7 +296,7 @@ mod Caretaker {
 
             self.emit(Release { user: trove_owner, trove_id, assets: released_assets.span() });
 
-            ReentrancyGuard::end();
+            reentrancy_guard::end();
             released_assets.span()
         }
 
@@ -322,7 +322,7 @@ mod Caretaker {
             assert(shrine.get_live() == false, 'CA: System is live');
 
             // reentrancy guard is used as a precaution
-            ReentrancyGuard::start();
+            reentrancy_guard::start();
 
             let caller = get_caller_address();
 
@@ -356,7 +356,7 @@ mod Caretaker {
 
             self.emit(Reclaim { user: caller, yin_amt: yin, assets: reclaimable_assets });
 
-            ReentrancyGuard::end();
+            reentrancy_guard::end();
             reclaimable_assets
         }
     }

--- a/src/core/controller.cairo
+++ b/src/core/controller.cairo
@@ -1,8 +1,8 @@
 #[starknet::contract]
-mod Controller {
+mod controller {
     use starknet::{ContractAddress, contract_address, get_block_timestamp};
 
-    use opus::core::roles::ControllerRoles;
+    use opus::core::roles::controller_roles;
 
     use opus::interfaces::IController::IController;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
@@ -95,7 +95,9 @@ mod Controller {
         alpha_i: u8,
         beta_i: u8,
     ) {
-        self.access_control.initializer(admin, Option::Some(ControllerRoles::default_admin_role()));
+        self
+            .access_control
+            .initializer(admin, Option::Some(controller_roles::default_admin_role()));
 
         // Setting `i_term_last_updated` to the current timestamp to
         // ensure that the integral term is correctly updated
@@ -184,14 +186,14 @@ mod Controller {
 
 
         fn set_p_gain(ref self: ContractState, p_gain: Ray) {
-            self.access_control.assert_has_role(ControllerRoles::TUNE_CONTROLLER);
+            self.access_control.assert_has_role(controller_roles::TUNE_CONTROLLER);
             self.p_gain.write(p_gain.into());
             self.emit(GainUpdated { name: 'p_gain', value: p_gain });
         }
 
 
         fn set_i_gain(ref self: ContractState, i_gain: Ray) {
-            self.access_control.assert_has_role(ControllerRoles::TUNE_CONTROLLER);
+            self.access_control.assert_has_role(controller_roles::TUNE_CONTROLLER);
 
             // Since `i_term_last_updated` isn't updated in `update_multiplier`
             // while `i_gain` is zero, we must update it here whenever the
@@ -212,7 +214,7 @@ mod Controller {
 
 
         fn set_alpha_p(ref self: ContractState, alpha_p: u8) {
-            self.access_control.assert_has_role(ControllerRoles::TUNE_CONTROLLER);
+            self.access_control.assert_has_role(controller_roles::TUNE_CONTROLLER);
             assert(alpha_p % 2 == 1, 'CTR: alpha_p must be odd');
             self.alpha_p.write(alpha_p);
             self.emit(ParameterUpdated { name: 'alpha_p', value: alpha_p });
@@ -220,7 +222,7 @@ mod Controller {
 
 
         fn set_beta_p(ref self: ContractState, beta_p: u8) {
-            self.access_control.assert_has_role(ControllerRoles::TUNE_CONTROLLER);
+            self.access_control.assert_has_role(controller_roles::TUNE_CONTROLLER);
             assert(beta_p % 2 == 0, 'CTR: beta_p must be even');
             self.beta_p.write(beta_p);
             self.emit(ParameterUpdated { name: 'beta_p', value: beta_p });
@@ -228,7 +230,7 @@ mod Controller {
 
 
         fn set_alpha_i(ref self: ContractState, alpha_i: u8) {
-            self.access_control.assert_has_role(ControllerRoles::TUNE_CONTROLLER);
+            self.access_control.assert_has_role(controller_roles::TUNE_CONTROLLER);
             assert(alpha_i % 2 == 1, 'CTR: alpha_i must be odd');
             self.alpha_i.write(alpha_i);
             self.emit(ParameterUpdated { name: 'alpha_i', value: alpha_i });
@@ -236,7 +238,7 @@ mod Controller {
 
 
         fn set_beta_i(ref self: ContractState, beta_i: u8) {
-            self.access_control.assert_has_role(ControllerRoles::TUNE_CONTROLLER);
+            self.access_control.assert_has_role(controller_roles::TUNE_CONTROLLER);
             assert(beta_i % 2 == 0, 'CTR: beta_i must be even');
             self.beta_i.write(beta_i);
             self.emit(ParameterUpdated { name: 'beta_i', value: beta_i });

--- a/src/core/equalizer.cairo
+++ b/src/core/equalizer.cairo
@@ -1,8 +1,8 @@
 #[starknet::contract]
-mod Equalizer {
+mod equalizer {
     use starknet::ContractAddress;
 
-    use opus::core::roles::EqualizerRoles;
+    use opus::core::roles::equalizer_roles;
 
     use opus::interfaces::IAllocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
     use opus::interfaces::IEqualizer::IEqualizer;
@@ -74,7 +74,7 @@ mod Equalizer {
         shrine: ContractAddress,
         allocator: ContractAddress
     ) {
-        self.access_control.initializer(admin, Option::Some(EqualizerRoles::default_admin_role()));
+        self.access_control.initializer(admin, Option::Some(equalizer_roles::default_admin_role()));
 
         self.shrine.write(IShrineDispatcher { contract_address: shrine });
         self.allocator.write(IAllocatorDispatcher { contract_address: allocator });
@@ -106,7 +106,7 @@ mod Equalizer {
 
         // Update the Allocator's address
         fn set_allocator(ref self: ContractState, allocator: ContractAddress) {
-            self.access_control.assert_has_role(EqualizerRoles::SET_ALLOCATOR);
+            self.access_control.assert_has_role(equalizer_roles::SET_ALLOCATOR);
 
             let old_address: ContractAddress = self.allocator.read().contract_address;
             self.allocator.write(IAllocatorDispatcher { contract_address: allocator });

--- a/src/core/flash_mint.cairo
+++ b/src/core/flash_mint.cairo
@@ -15,13 +15,13 @@
 //
 
 #[starknet::contract]
-mod FlashMint {
+mod flash_mint {
     use starknet::{ContractAddress, get_caller_address};
 
     use opus::interfaces::IFlashBorrower::{IFlashBorrowerDispatcher, IFlashBorrowerDispatcherTrait};
     use opus::interfaces::IFlashMint::IFlashMint;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::reentrancy_guard::ReentrancyGuard;
+    use opus::utils::reentrancy_guard::reentrancy_guard;
     use opus::utils::wadray::Wad;
 
     // The value of keccak256("ERC3156FlashBorrower.onFlashLoan") as per EIP3156
@@ -100,7 +100,7 @@ mod FlashMint {
             // prevents looping which would lead to excessive minting
             // we only allow a FLASH_MINT_AMOUNT_PCT percentage of total
             // yin to be minted, as per spec
-            ReentrancyGuard::start();
+            reentrancy_guard::start();
 
             assert(amount <= self.max_flash_loan(token), 'FM: amount exceeds maximum');
 
@@ -122,7 +122,7 @@ mod FlashMint {
 
             self.emit(FlashMint { initiator, receiver, token, amount });
 
-            ReentrancyGuard::end();
+            reentrancy_guard::end();
 
             true
         }

--- a/src/core/gate.cairo
+++ b/src/core/gate.cairo
@@ -1,5 +1,5 @@
 #[starknet::contract]
-mod Gate {
+mod gate {
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
 
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};

--- a/src/core/purger.cairo
+++ b/src/core/purger.cairo
@@ -1,9 +1,9 @@
 #[starknet::contract]
-mod Purger {
+mod purger {
     use cmp::min;
     use starknet::{ContractAddress, get_caller_address};
 
-    use opus::core::roles::PurgerRoles;
+    use opus::core::roles::purger_roles;
 
     use opus::interfaces::IAbsorber::{IAbsorberDispatcher, IAbsorberDispatcherTrait};
     use opus::interfaces::IOracle::{IOracleDispatcher, IOracleDispatcherTrait};
@@ -12,7 +12,7 @@ mod Purger {
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
 
     use opus::utils::access_control::access_control_component;
-    use opus::utils::reentrancy_guard::ReentrancyGuard;
+    use opus::utils::reentrancy_guard::reentrancy_guard;
     use opus::types::AssetBalance;
     use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RayZeroable, RAY_ONE, Wad, WadZeroable};
@@ -130,7 +130,7 @@ mod Purger {
         absorber: ContractAddress,
         oracle: ContractAddress,
     ) {
-        self.access_control.initializer(admin, Option::Some(PurgerRoles::default_admin_role()));
+        self.access_control.initializer(admin, Option::Some(purger_roles::default_admin_role()));
 
         self.shrine.write(IShrineDispatcher { contract_address: shrine });
         self.sentinel.write(ISentinelDispatcher { contract_address: sentinel });
@@ -188,7 +188,7 @@ mod Purger {
         // External
         //
         fn set_penalty_scalar(ref self: ContractState, new_scalar: Ray) {
-            self.access_control.assert_has_role(PurgerRoles::SET_PENALTY_SCALAR);
+            self.access_control.assert_has_role(purger_roles::SET_PENALTY_SCALAR);
             assert(
                 MIN_PENALTY_SCALAR.into() <= new_scalar && new_scalar <= MAX_PENALTY_SCALAR.into(),
                 'PU: Invalid scalar'
@@ -389,7 +389,7 @@ mod Purger {
             recipient: ContractAddress,
         ) -> Span<AssetBalance> {
             // reentrancy guard is used as a precaution
-            ReentrancyGuard::start();
+            reentrancy_guard::start();
 
             let sentinel: ISentinelDispatcher = self.sentinel.read();
             let yangs: Span<ContractAddress> = sentinel.get_yang_addresses();
@@ -422,7 +422,7 @@ mod Purger {
                 };
             };
 
-            ReentrancyGuard::end();
+            reentrancy_guard::end();
 
             freed_assets.span()
         }

--- a/src/core/roles.cairo
+++ b/src/core/roles.cairo
@@ -1,4 +1,4 @@
-mod AbsorberRoles {
+mod absorber_roles {
     const KILL: u128 = 1;
     const SET_REWARD: u128 = 2;
     const UPDATE: u128 = 4;
@@ -14,7 +14,7 @@ mod AbsorberRoles {
     }
 }
 
-mod AllocatorRoles {
+mod allocator_roles {
     const SET_ALLOCATION: u128 = 1;
 
     #[inline(always)]
@@ -23,7 +23,7 @@ mod AllocatorRoles {
     }
 }
 
-mod BlesserRoles {
+mod blesser_roles {
     const BLESS: u128 = 1;
 
     #[inline(always)]
@@ -32,7 +32,7 @@ mod BlesserRoles {
     }
 }
 
-mod CaretakerRoles {
+mod caretaker_roles {
     const SHUT: u128 = 1;
 
     #[inline(always)]
@@ -41,7 +41,7 @@ mod CaretakerRoles {
     }
 }
 
-mod ControllerRoles {
+mod controller_roles {
     const TUNE_CONTROLLER: u128 = 1;
 
     #[inline(always)]
@@ -50,7 +50,7 @@ mod ControllerRoles {
     }
 }
 
-mod EqualizerRoles {
+mod equalizer_roles {
     const SET_ALLOCATOR: u128 = 1;
 
     #[inline(always)]
@@ -59,7 +59,7 @@ mod EqualizerRoles {
     }
 }
 
-mod PragmaRoles {
+mod pragma_roles {
     const ADD_YANG: u128 = 1;
     const SET_ORACLE_ADDRESS: u128 = 2;
     const SET_PRICE_VALIDITY_THRESHOLDS: u128 = 4;
@@ -77,7 +77,7 @@ mod PragmaRoles {
     }
 }
 
-mod PurgerRoles {
+mod purger_roles {
     const SET_PENALTY_SCALAR: u128 = 1;
 
     #[inline(always)]
@@ -86,7 +86,7 @@ mod PurgerRoles {
     }
 }
 
-mod SentinelRoles {
+mod sentinel_roles {
     const ADD_YANG: u128 = 1;
     const ENTER: u128 = 2;
     const EXIT: u128 = 4;
@@ -115,7 +115,7 @@ mod SentinelRoles {
     }
 }
 
-mod ShrineRoles {
+mod shrine_roles {
     const ADD_YANG: u128 = 1;
     const ADVANCE: u128 = 2;
     const DEPOSIT: u128 = 4;

--- a/src/core/sentinel.cairo
+++ b/src/core/sentinel.cairo
@@ -1,9 +1,9 @@
 #[starknet::contract]
-mod Sentinel {
+mod sentinel {
     use starknet::{get_block_timestamp, get_caller_address};
     use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
 
-    use opus::core::roles::SentinelRoles;
+    use opus::core::roles::sentinel_roles;
 
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
@@ -100,7 +100,7 @@ mod Sentinel {
 
     #[constructor]
     fn constructor(ref self: ContractState, admin: ContractAddress, shrine: ContractAddress) {
-        self.access_control.initializer(admin, Option::Some(SentinelRoles::default_admin_role()));
+        self.access_control.initializer(admin, Option::Some(sentinel_roles::default_admin_role()));
         self.shrine.write(IShrineDispatcher { contract_address: shrine });
     }
 
@@ -190,7 +190,7 @@ mod Sentinel {
             yang_rate: Ray,
             gate: ContractAddress
         ) {
-            self.access_control.assert_has_role(SentinelRoles::ADD_YANG);
+            self.access_control.assert_has_role(sentinel_roles::ADD_YANG);
             assert(yang.is_non_zero(), 'SE: Yang cannot be zero address');
             assert(gate.is_non_zero(), 'SE: Gate cannot be zero address');
             assert(
@@ -229,7 +229,7 @@ mod Sentinel {
         }
 
         fn set_yang_asset_max(ref self: ContractState, yang: ContractAddress, new_asset_max: u128) {
-            self.access_control.assert_has_role(SentinelRoles::SET_YANG_ASSET_MAX);
+            self.access_control.assert_has_role(sentinel_roles::SET_YANG_ASSET_MAX);
 
             let gate: IGateDispatcher = self.yang_to_gate.read(yang);
             assert(gate.contract_address.is_non_zero(), 'SE: Yang not added');
@@ -241,7 +241,7 @@ mod Sentinel {
         }
 
         fn kill_gate(ref self: ContractState, yang: ContractAddress) {
-            self.access_control.assert_has_role(SentinelRoles::KILL_GATE);
+            self.access_control.assert_has_role(sentinel_roles::KILL_GATE);
 
             self.yang_is_live.write(yang, false);
 
@@ -249,12 +249,12 @@ mod Sentinel {
         }
 
         fn suspend_yang(ref self: ContractState, yang: ContractAddress) {
-            self.access_control.assert_has_role(SentinelRoles::UPDATE_YANG_SUSPENSION);
+            self.access_control.assert_has_role(sentinel_roles::UPDATE_YANG_SUSPENSION);
             self.shrine.read().suspend_yang(yang);
         }
 
         fn unsuspend_yang(ref self: ContractState, yang: ContractAddress) {
-            self.access_control.assert_has_role(SentinelRoles::UPDATE_YANG_SUSPENSION);
+            self.access_control.assert_has_role(sentinel_roles::UPDATE_YANG_SUSPENSION);
             self.shrine.read().unsuspend_yang(yang);
         }
 
@@ -269,7 +269,7 @@ mod Sentinel {
             trove_id: u64,
             asset_amt: u128
         ) -> Wad {
-            self.access_control.assert_has_role(SentinelRoles::ENTER);
+            self.access_control.assert_has_role(sentinel_roles::ENTER);
 
             let gate: IGateDispatcher = self.yang_to_gate.read(yang);
 
@@ -284,7 +284,7 @@ mod Sentinel {
             trove_id: u64,
             yang_amt: Wad
         ) -> u128 {
-            self.access_control.assert_has_role(SentinelRoles::EXIT);
+            self.access_control.assert_has_role(sentinel_roles::EXIT);
             let gate: IGateDispatcher = self.yang_to_gate.read(yang);
             assert(gate.contract_address.is_non_zero(), 'SE: Yang not added');
 

--- a/src/external/pragma.cairo
+++ b/src/external/pragma.cairo
@@ -6,17 +6,17 @@
 //       order to get ASSET/SYN
 
 #[starknet::contract]
-mod Pragma {
+mod pragma {
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
 
-    use opus::core::roles::PragmaRoles;
+    use opus::core::roles::pragma_roles;
 
     use opus::interfaces::external::{IPragmaOracleDispatcher, IPragmaOracleDispatcherTrait};
     use opus::interfaces::IOracle::IOracle;
     use opus::interfaces::IPragma::IPragma;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
-    use opus::types::Pragma::{DataType, PricesResponse, PriceValidityThresholds, YangSettings};
+    use opus::types::pragma::{DataType, PricesResponse, PriceValidityThresholds, YangSettings};
     use opus::utils::access_control::access_control_component;
     use opus::utils::wadray;
     use opus::utils::wadray::Wad;
@@ -158,7 +158,7 @@ mod Pragma {
         freshness_threshold: u64,
         sources_threshold: u64
     ) {
-        self.access_control.initializer(admin, Option::Some(PragmaRoles::default_admin_role()));
+        self.access_control.initializer(admin, Option::Some(pragma_roles::default_admin_role()));
 
         // init storage
         self.oracle.write(IPragmaOracleDispatcher { contract_address: oracle });
@@ -193,7 +193,7 @@ mod Pragma {
         //
 
         fn set_oracle(ref self: ContractState, new_oracle: ContractAddress) {
-            self.access_control.assert_has_role(PragmaRoles::SET_ORACLE_ADDRESS);
+            self.access_control.assert_has_role(pragma_roles::SET_ORACLE_ADDRESS);
             assert(new_oracle.is_non_zero(), 'PGM: Address cannot be zero');
 
             let old_oracle: IPragmaOracleDispatcher = self.oracle.read();
@@ -208,7 +208,7 @@ mod Pragma {
         }
 
         fn set_price_validity_thresholds(ref self: ContractState, freshness: u64, sources: u64) {
-            self.access_control.assert_has_role(PragmaRoles::SET_PRICE_VALIDITY_THRESHOLDS);
+            self.access_control.assert_has_role(pragma_roles::SET_PRICE_VALIDITY_THRESHOLDS);
             assert(
                 LOWER_FRESHNESS_BOUND <= freshness && freshness <= UPPER_FRESHNESS_BOUND,
                 'PGM: Freshness out of bounds'
@@ -226,7 +226,7 @@ mod Pragma {
         }
 
         fn set_update_frequency(ref self: ContractState, new_frequency: u64) {
-            self.access_control.assert_has_role(PragmaRoles::SET_UPDATE_FREQUENCY);
+            self.access_control.assert_has_role(pragma_roles::SET_UPDATE_FREQUENCY);
             assert(
                 LOWER_UPDATE_FREQUENCY_BOUND <= new_frequency
                     && new_frequency <= UPPER_UPDATE_FREQUENCY_BOUND,
@@ -239,7 +239,7 @@ mod Pragma {
         }
 
         fn add_yang(ref self: ContractState, pair_id: u256, yang: ContractAddress) {
-            self.access_control.assert_has_role(PragmaRoles::ADD_YANG);
+            self.access_control.assert_has_role(pragma_roles::ADD_YANG);
             assert(pair_id != 0, 'PGM: Invalid pair ID');
             assert(yang.is_non_zero(), 'PGM: Invalid yang address');
             self.assert_new_yang(pair_id, yang);
@@ -292,7 +292,7 @@ mod Pragma {
             // force an update to happen immediatelly
             let mut can_update: bool = self.probe_task();
             if !can_update {
-                can_update = self.has_role(PragmaRoles::UPDATE_PRICES, get_caller_address());
+                can_update = self.has_role(pragma_roles::UPDATE_PRICES, get_caller_address());
             }
             assert(can_update, 'PGM: Too soon to update prices');
 

--- a/src/interfaces/external.cairo
+++ b/src/interfaces/external.cairo
@@ -1,9 +1,9 @@
-use opus::types::Pragma;
+use opus::types::pragma;
 
 #[starknet::interface]
 trait IPragmaOracle<TContractState> {
     // getters
     fn get_data_median(
-        self: @TContractState, data_type: Pragma::DataType
-    ) -> Pragma::PricesResponse;
+        self: @TContractState, data_type: pragma::DataType
+    ) -> pragma::PricesResponse;
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -5,7 +5,7 @@ mod core {
     mod caretaker;
     mod controller;
     mod equalizer;
-    mod flashmint;
+    mod flash_mint;
     mod gate;
     mod purger;
     mod roles;
@@ -78,9 +78,9 @@ mod tests {
         mod test_pragma;
         mod utils;
     }
-    mod flashmint {
+    mod flash_mint {
         mod flash_borrower;
-        mod test_flashmint;
+        mod test_flash_mint;
         mod utils;
     }
     mod gate {

--- a/src/tests/absorber/mock_blesser.cairo
+++ b/src/tests/absorber/mock_blesser.cairo
@@ -1,8 +1,8 @@
 #[starknet::contract]
-mod MockBlesser {
+mod mock_blesser {
     use starknet::{ContractAddress, get_contract_address};
 
-    use opus::core::roles::BlesserRoles;
+    use opus::core::roles::blesser_roles;
 
     use opus::interfaces::IAbsorber::IBlesser;
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -39,7 +39,7 @@ mod MockBlesser {
         bless_amt: u128
     ) {
         self.access_control.initializer(admin, Option::None);
-        self.access_control.grant_role_helper(BlesserRoles::default_admin_role(), absorber);
+        self.access_control.grant_role_helper(blesser_roles::default_admin_role(), absorber);
 
         self.asset.write(IERC20Dispatcher { contract_address: asset });
         self.absorber.write(absorber);
@@ -53,7 +53,7 @@ mod MockBlesser {
         }
 
         fn bless(ref self: ContractState) -> u128 {
-            self.access_control.assert_has_role(BlesserRoles::BLESS);
+            self.access_control.assert_has_role(blesser_roles::BLESS);
 
             let asset: IERC20Dispatcher = self.asset.read();
             let bless_amt: u256 = self.preview_bless_internal(asset).into();

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -1,4 +1,3 @@
-use array::ArrayTrait;
 use debug::PrintTrait;
 use starknet::{
     deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
@@ -8,7 +7,7 @@ use starknet::{
 use starknet::contract_address::ContractAddressZeroable;
 use starknet::testing::{pop_log_raw, set_block_timestamp, set_contract_address};
 
-use opus::core::shrine::Shrine;
+use opus::core::shrine::shrine;
 
 use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
 use opus::interfaces::IERC20::{
@@ -21,8 +20,8 @@ use opus::types::{AssetBalance, Reward, YangBalance};
 use opus::utils::wadray;
 use opus::utils::wadray::{Ray, Wad, WadZeroable};
 
-use opus::tests::sentinel::utils::SentinelUtils;
-use opus::tests::shrine::utils::ShrineUtils;
+use opus::tests::sentinel::utils::sentinel_utils;
+use opus::tests::shrine::utils::shrine_utils;
 
 //
 // Constants
@@ -110,7 +109,7 @@ impl RewardPartialEq of PartialEq<Reward> {
 // Helper function to advance timestamp by the given intervals
 #[inline(always)]
 fn advance_intervals(intervals: u64) {
-    set_block_timestamp(get_block_timestamp() + (intervals * Shrine::TIME_INTERVAL));
+    set_block_timestamp(get_block_timestamp() + (intervals * shrine::TIME_INTERVAL));
 }
 
 // Helper function to deploy a token
@@ -165,7 +164,7 @@ fn open_trove_helper(
             Option::Some(yang) => {
                 // Approve Gate to transfer from user
                 let gate: IGateDispatcher = *gates.pop_front().unwrap();
-                SentinelUtils::approve_max(gate, *yang, user);
+                sentinel_utils::approve_max(gate, *yang, user);
             },
             Option::None => { break; }
         };

--- a/src/tests/controller/test_controller.cairo
+++ b/src/tests/controller/test_controller.cairo
@@ -1,8 +1,8 @@
-mod TestController {
+mod test_controller {
     use debug::PrintTrait;
     use starknet::testing::set_contract_address;
 
-    use opus::core::controller::Controller;
+    use opus::core::controller::controller as controller_contract;
 
     use opus::interfaces::IController::{IControllerDispatcher, IControllerDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
@@ -13,8 +13,8 @@ mod TestController {
 
     use opus::tests::common;
     use opus::tests::common::{assert_equalish, badguy};
-    use opus::tests::controller::utils::ControllerUtils;
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::controller::utils::controller_utils;
+    use opus::tests::shrine::utils::shrine_utils;
 
     const YIN_PRICE1: u128 = 999942800000000000; // wad
     const YIN_PRICE2: u128 = 999879000000000000; // wad
@@ -24,34 +24,46 @@ mod TestController {
     #[test]
     #[available_gas(20000000000)]
     fn test_deploy_controller() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
 
         let ((p_gain, i_gain), (alpha_p, beta_p, alpha_i, beta_i)) = controller.get_parameters();
-        assert(p_gain == ControllerUtils::P_GAIN.into(), 'wrong p gain');
-        assert(i_gain == ControllerUtils::I_GAIN.into(), 'wrong i gain');
-        assert(alpha_p == ControllerUtils::ALPHA_P, 'wrong alpha_p');
-        assert(alpha_i == ControllerUtils::ALPHA_I, 'wrong alpha_i');
-        assert(beta_p == ControllerUtils::BETA_P, 'wrong beta_p');
-        assert(beta_i == ControllerUtils::BETA_I, 'wrong beta_i');
+        assert(p_gain == controller_utils::P_GAIN.into(), 'wrong p gain');
+        assert(i_gain == controller_utils::I_GAIN.into(), 'wrong i gain');
+        assert(alpha_p == controller_utils::ALPHA_P, 'wrong alpha_p');
+        assert(alpha_i == controller_utils::ALPHA_I, 'wrong alpha_i');
+        assert(beta_p == controller_utils::BETA_P, 'wrong beta_p');
+        assert(beta_i == controller_utils::BETA_I, 'wrong beta_i');
 
-        let mut expected_events: Span<Controller::Event> = array![
-            Controller::Event::GainUpdated(
-                Controller::GainUpdated { name: 'p_gain', value: ControllerUtils::P_GAIN.into() }
+        let mut expected_events: Span<controller_contract::Event> = array![
+            controller_contract::Event::GainUpdated(
+                controller_contract::GainUpdated {
+                    name: 'p_gain', value: controller_utils::P_GAIN.into()
+                }
             ),
-            Controller::Event::GainUpdated(
-                Controller::GainUpdated { name: 'i_gain', value: ControllerUtils::I_GAIN.into() }
+            controller_contract::Event::GainUpdated(
+                controller_contract::GainUpdated {
+                    name: 'i_gain', value: controller_utils::I_GAIN.into()
+                }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'alpha_p', value: ControllerUtils::ALPHA_P }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated {
+                    name: 'alpha_p', value: controller_utils::ALPHA_P
+                }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'alpha_i', value: ControllerUtils::ALPHA_I }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated {
+                    name: 'alpha_i', value: controller_utils::ALPHA_I
+                }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'beta_p', value: ControllerUtils::BETA_P }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated {
+                    name: 'beta_p', value: controller_utils::BETA_P
+                }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'beta_i', value: ControllerUtils::BETA_I }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated {
+                    name: 'beta_i', value: controller_utils::BETA_I
+                }
             ),
         ]
             .span();
@@ -61,9 +73,9 @@ mod TestController {
     #[test]
     #[available_gas(20000000000)]
     fn test_setters() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
 
-        set_contract_address(ControllerUtils::admin());
+        set_contract_address(controller_utils::admin());
 
         let new_p_gain: Ray = 1_u128.into();
         let new_i_gain: Ray = 2_u128.into();
@@ -87,24 +99,24 @@ mod TestController {
         assert(beta_p == new_beta_p, 'wrong beta_p');
         assert(beta_i == new_beta_i, 'wrong beta_i');
 
-        let mut expected_events: Span<Controller::Event> = array![
-            Controller::Event::GainUpdated(
-                Controller::GainUpdated { name: 'p_gain', value: new_p_gain.into() }
+        let mut expected_events: Span<controller_contract::Event> = array![
+            controller_contract::Event::GainUpdated(
+                controller_contract::GainUpdated { name: 'p_gain', value: new_p_gain.into() }
             ),
-            Controller::Event::GainUpdated(
-                Controller::GainUpdated { name: 'i_gain', value: new_i_gain.into() }
+            controller_contract::Event::GainUpdated(
+                controller_contract::GainUpdated { name: 'i_gain', value: new_i_gain.into() }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'alpha_p', value: new_alpha_p }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated { name: 'alpha_p', value: new_alpha_p }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'alpha_i', value: new_alpha_i }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated { name: 'alpha_i', value: new_alpha_i }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'beta_p', value: new_beta_p }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated { name: 'beta_p', value: new_beta_p }
             ),
-            Controller::Event::ParameterUpdated(
-                Controller::ParameterUpdated { name: 'beta_i', value: new_beta_i }
+            controller_contract::Event::ParameterUpdated(
+                controller_contract::ParameterUpdated { name: 'beta_i', value: new_beta_i }
             ),
         ]
             .span();
@@ -117,7 +129,7 @@ mod TestController {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_p_gain_unauthorized() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
         set_contract_address(badguy());
         controller.set_p_gain(1_u128.into());
     }
@@ -126,7 +138,7 @@ mod TestController {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_i_gain_unauthorized() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
         set_contract_address(badguy());
         controller.set_i_gain(1_u128.into());
     }
@@ -135,7 +147,7 @@ mod TestController {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_alpha_p_unauthorized() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
         set_contract_address(badguy());
         controller.set_alpha_p(1);
     }
@@ -144,7 +156,7 @@ mod TestController {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_alpha_i_unauthorized() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
         set_contract_address(badguy());
         controller.set_alpha_i(1);
     }
@@ -153,7 +165,7 @@ mod TestController {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_beta_p_unauthorized() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
         set_contract_address(badguy());
         controller.set_beta_p(1);
     }
@@ -162,7 +174,7 @@ mod TestController {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_beta_i_unauthorized() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
         set_contract_address(badguy());
         controller.set_beta_i(1);
     }
@@ -170,9 +182,9 @@ mod TestController {
     #[test]
     #[available_gas(20000000000)]
     fn test_against_ground_truth() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
 
-        set_contract_address(ControllerUtils::admin());
+        set_contract_address(controller_utils::admin());
 
         // Updating `i_gain` to match the ground truth simulation
         controller.set_i_gain(100000000000000000000000_u128.into());
@@ -180,8 +192,8 @@ mod TestController {
         assert(controller.get_p_term() == SignedRayZeroable::zero(), 'Wrong p term #1');
         assert(controller.get_i_term() == SignedRayZeroable::zero(), 'Wrong i term #1');
 
-        ControllerUtils::fast_forward_1_hour();
-        ControllerUtils::set_yin_spot_price(shrine, YIN_PRICE1.into());
+        controller_utils::fast_forward_1_hour();
+        controller_utils::set_yin_spot_price(shrine, YIN_PRICE1.into());
         controller.update_multiplier();
 
         assert_equalish(
@@ -198,8 +210,8 @@ mod TestController {
             'Wrong i term #2'
         );
 
-        ControllerUtils::fast_forward_1_hour();
-        ControllerUtils::set_yin_spot_price(shrine, YIN_PRICE2.into());
+        controller_utils::fast_forward_1_hour();
+        controller_utils::set_yin_spot_price(shrine, YIN_PRICE2.into());
         controller.update_multiplier();
 
         assert_equalish(
@@ -219,9 +231,9 @@ mod TestController {
     #[test]
     #[available_gas(20000000000)]
     fn test_against_ground_truth2() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
 
-        set_contract_address(ControllerUtils::admin());
+        set_contract_address(controller_utils::admin());
 
         // Updating `i_gain` to match the ground truth simulation
         controller.set_i_gain(100000000000000000000000000_u128.into()); // 0.1 (ray)
@@ -447,7 +459,7 @@ mod TestController {
         loop {
             match prices.pop_front() {
                 Option::Some(price) => {
-                    ControllerUtils::set_yin_spot_price(shrine, price);
+                    controller_utils::set_yin_spot_price(shrine, price);
                     controller.update_multiplier();
 
                     assert_equalish(
@@ -471,7 +483,7 @@ mod TestController {
                         'Wrong multiplier'
                     );
 
-                    ControllerUtils::fast_forward_1_hour();
+                    controller_utils::fast_forward_1_hour();
                 },
                 Option::None => { break; }
             };
@@ -484,9 +496,9 @@ mod TestController {
     #[test]
     #[available_gas(20000000000)]
     fn test_against_ground_truth3() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
 
-        set_contract_address(ControllerUtils::admin());
+        set_contract_address(controller_utils::admin());
 
         // Updating `i_gain` to match the ground truth simulation
         controller.set_i_gain(100000000000000000000000000_u128.into()); // 0.1 (ray)
@@ -550,7 +562,7 @@ mod TestController {
                 if current_interval == *gt_update_intervals.at(0) {
                     gt_update_intervals.pop_front();
                     let price: Wad = prices.pop_front().unwrap();
-                    ControllerUtils::set_yin_spot_price(shrine, price);
+                    controller_utils::set_yin_spot_price(shrine, price);
                     controller.update_multiplier();
                 }
             }
@@ -576,7 +588,7 @@ mod TestController {
                 'Wrong multiplier'
             );
 
-            ControllerUtils::fast_forward_1_hour();
+            controller_utils::fast_forward_1_hour();
             current_interval += 1;
         }
     }
@@ -584,9 +596,9 @@ mod TestController {
     #[test]
     #[available_gas(200000000000)]
     fn test_against_ground_truth4() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
+        let (controller, shrine) = controller_utils::deploy_controller();
 
-        set_contract_address(ControllerUtils::admin());
+        set_contract_address(controller_utils::admin());
 
         // Updating `i_gain` to match the ground truth simulation
         controller.set_i_gain(100000000000000000000000000_u128.into()); // 0.1 (ray)
@@ -694,7 +706,7 @@ mod TestController {
         loop {
             match prices.pop_front() {
                 Option::Some(price) => {
-                    ControllerUtils::set_yin_spot_price(shrine, price);
+                    controller_utils::set_yin_spot_price(shrine, price);
                     controller.update_multiplier();
 
                     assert_equalish(
@@ -716,7 +728,7 @@ mod TestController {
                         'Wrong multiplier'
                     );
 
-                    ControllerUtils::fast_forward_1_hour();
+                    controller_utils::fast_forward_1_hour();
                 },
                 Option::None => { break; }
             };
@@ -726,19 +738,19 @@ mod TestController {
     #[test]
     #[available_gas(20000000000)]
     fn test_frequent_updates() {
-        let (controller, shrine) = ControllerUtils::deploy_controller();
-        set_contract_address(ControllerUtils::admin());
+        let (controller, shrine) = controller_utils::deploy_controller();
+        set_contract_address(controller_utils::admin());
         controller
             .set_i_gain(
                 100000000000000000000000_u128.into()
             ); // Ensuring the integral gain is non-zero
 
-        ControllerUtils::set_yin_spot_price(shrine, YIN_PRICE1.into());
+        controller_utils::set_yin_spot_price(shrine, YIN_PRICE1.into());
         controller.update_multiplier();
 
         // Standard flow, updating the multiplier every hour
         let prev_multiplier: Ray = controller.get_current_multiplier();
-        ControllerUtils::fast_forward_1_hour();
+        controller_utils::fast_forward_1_hour();
         controller.update_multiplier();
         let current_multiplier: Ray = controller.get_current_multiplier();
         assert(current_multiplier > prev_multiplier, 'Multiplier should increase');

--- a/src/tests/controller/utils.cairo
+++ b/src/tests/controller/utils.cairo
@@ -1,4 +1,4 @@
-mod ControllerUtils {
+mod controller_utils {
     use debug::PrintTrait;
     use starknet::{
         ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
@@ -7,8 +7,8 @@ mod ControllerUtils {
     use starknet::contract_address::ContractAddressZeroable;
     use starknet::testing::{set_block_timestamp, set_contract_address};
 
-    use opus::core::controller::Controller;
-    use opus::core::roles::ShrineRoles;
+    use opus::core::controller::controller as controller_contract;
+    use opus::core::roles::shrine_roles;
 
     use opus::interfaces::IController::{IControllerDispatcher, IControllerDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
@@ -18,7 +18,7 @@ mod ControllerUtils {
     use opus::utils::wadray;
     use opus::utils::wadray::{Ray, Wad};
 
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::shrine::utils::shrine_utils;
 
     // Controller update interval
     const ONE_HOUR: u64 = consteval_int!(60 * 60); // 1 hour
@@ -39,8 +39,8 @@ mod ControllerUtils {
     }
 
     fn deploy_controller() -> (IControllerDispatcher, IShrineDispatcher) {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::make_root(shrine_addr, ShrineUtils::admin());
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::make_root(shrine_addr, shrine_utils::admin());
 
         let mut calldata: Array<felt252> = array![
             contract_address_to_felt252(admin()),
@@ -54,15 +54,15 @@ mod ControllerUtils {
         ];
 
         let controller_class_hash: ClassHash = class_hash_try_from_felt252(
-            Controller::TEST_CLASS_HASH
+            controller_contract::TEST_CLASS_HASH
         )
             .unwrap();
         let (controller_addr, _) = deploy_syscall(controller_class_hash, 0, calldata.span(), false)
             .unwrap_syscall();
 
         let shrine_ac = IAccessControlDispatcher { contract_address: shrine_addr };
-        set_contract_address(ShrineUtils::admin());
-        shrine_ac.grant_role(ShrineRoles::controller(), controller_addr);
+        set_contract_address(shrine_utils::admin());
+        shrine_ac.grant_role(shrine_roles::controller(), controller_addr);
 
         set_contract_address(ContractAddressZeroable::zero());
 
@@ -74,7 +74,7 @@ mod ControllerUtils {
 
     #[inline(always)]
     fn set_yin_spot_price(shrine: IShrineDispatcher, spot_price: Wad) {
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.update_yin_spot_price(spot_price);
         set_contract_address(ContractAddressZeroable::zero());
     }

--- a/src/tests/equalizer/utils.cairo
+++ b/src/tests/equalizer/utils.cairo
@@ -1,4 +1,4 @@
-mod EqualizerUtils {
+mod equalizer_utils {
     use starknet::{
         deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
         contract_address_to_felt252, contract_address_try_from_felt252, SyscallResultTrait
@@ -6,9 +6,9 @@ mod EqualizerUtils {
     use starknet::contract_address::ContractAddressZeroable;
     use starknet::testing::set_contract_address;
 
-    use opus::core::allocator::Allocator;
-    use opus::core::equalizer::Equalizer;
-    use opus::core::roles::ShrineRoles;
+    use opus::core::allocator::allocator as allocator_contract;
+    use opus::core::equalizer::equalizer as equalizer_contract;
+    use opus::core::roles::shrine_roles;
 
     use opus::interfaces::IAllocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
     use opus::interfaces::IEqualizer::{IEqualizerDispatcher, IEqualizerDispatcherTrait};
@@ -16,7 +16,7 @@ mod EqualizerUtils {
     use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
     use opus::utils::wadray::Ray;
 
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::shrine::utils::shrine_utils;
 
     //
     // Convenience helpers
@@ -78,7 +78,7 @@ mod EqualizerUtils {
         mut recipients: Span<ContractAddress>, mut percentages: Span<Ray>
     ) -> IAllocatorDispatcher {
         let mut calldata: Array<felt252> = array![
-            contract_address_to_felt252(ShrineUtils::admin()), recipients.len().into(),
+            contract_address_to_felt252(shrine_utils::admin()), recipients.len().into(),
         ];
 
         loop {
@@ -102,7 +102,7 @@ mod EqualizerUtils {
         };
 
         let allocator_class_hash: ClassHash = class_hash_try_from_felt252(
-            Allocator::TEST_CLASS_HASH
+            allocator_contract::TEST_CLASS_HASH
         )
             .unwrap();
         let (allocator_addr, _) = deploy_syscall(allocator_class_hash, 0, calldata.span(), false)
@@ -112,7 +112,7 @@ mod EqualizerUtils {
     }
 
     fn equalizer_deploy() -> (IShrineDispatcher, IEqualizerDispatcher, IAllocatorDispatcher) {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         equalizer_deploy_with_shrine(shrine.contract_address)
     }
 
@@ -122,7 +122,7 @@ mod EqualizerUtils {
         let allocator: IAllocatorDispatcher = allocator_deploy(
             initial_recipients(), initial_percentages()
         );
-        let admin = ShrineUtils::admin();
+        let admin = shrine_utils::admin();
 
         let mut calldata: Array<felt252> = array![
             contract_address_to_felt252(admin),
@@ -131,7 +131,7 @@ mod EqualizerUtils {
         ];
 
         let equalizer_class_hash: ClassHash = class_hash_try_from_felt252(
-            Equalizer::TEST_CLASS_HASH
+            equalizer_contract::TEST_CLASS_HASH
         )
             .unwrap();
         let (equalizer_addr, _) = deploy_syscall(equalizer_class_hash, 0, calldata.span(), false)
@@ -141,7 +141,7 @@ mod EqualizerUtils {
         let shrine_ac: IAccessControlDispatcher = IAccessControlDispatcher {
             contract_address: shrine
         };
-        shrine_ac.grant_role(ShrineRoles::equalizer(), equalizer_addr);
+        shrine_ac.grant_role(shrine_roles::equalizer(), equalizer_addr);
 
         set_contract_address(ContractAddressZeroable::zero());
 

--- a/src/tests/external/mock_pragma.cairo
+++ b/src/tests/external/mock_pragma.cairo
@@ -1,4 +1,4 @@
-use opus::types::Pragma::PricesResponse;
+use opus::types::pragma::PricesResponse;
 
 #[starknet::interface]
 trait IMockPragma<TContractState> {
@@ -9,9 +9,9 @@ trait IMockPragma<TContractState> {
 }
 
 #[starknet::contract]
-mod MockPragma {
+mod mock_pragma {
     use opus::interfaces::external::IPragmaOracle;
-    use opus::types::Pragma::{DataType, PricesResponse};
+    use opus::types::pragma::{DataType, PricesResponse};
 
     use super::IMockPragma;
 

--- a/src/tests/flash_mint/flash_borrower.cairo
+++ b/src/tests/flash_mint/flash_borrower.cairo
@@ -1,8 +1,8 @@
 #[starknet::contract]
-mod FlashBorrower {
+mod flash_borrower {
     use starknet::{contract_address_const, get_contract_address, ContractAddress};
 
-    use opus::core::flashmint::FlashMint::ON_FLASH_MINT_SUCCESS;
+    use opus::core::flash_mint::flash_mint::ON_FLASH_MINT_SUCCESS;
 
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IFlashMint::{IFlashMintDispatcher, IFlashMintDispatcherTrait};

--- a/src/tests/flash_mint/test_flash_mint.cairo
+++ b/src/tests/flash_mint/test_flash_mint.cairo
@@ -1,8 +1,8 @@
-mod TestFlashmint {
+mod test_flash_mint {
     use starknet::ContractAddress;
     use starknet::testing::set_contract_address;
 
-    use opus::core::flashmint::FlashMint;
+    use opus::core::flash_mint::flash_mint as flash_mint_contract;
 
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IFlashBorrower::{IFlashBorrowerDispatcher, IFlashBorrowerDispatcherTrait};
@@ -12,9 +12,9 @@ mod TestFlashmint {
     use opus::utils::wadray::{Wad, WAD_ONE};
 
     use opus::tests::common;
-    use opus::tests::flashmint::flash_borrower::FlashBorrower;
-    use opus::tests::flashmint::utils::FlashmintUtils;
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::flash_mint::flash_borrower::flash_borrower as flash_borrower_contract;
+    use opus::tests::flash_mint::utils::flash_mint_utils;
+    use opus::tests::shrine::utils::shrine_utils;
 
     //
     // Tests
@@ -23,12 +23,12 @@ mod TestFlashmint {
     #[test]
     #[available_gas(20000000000)]
     fn test_flashmint_max_loan() {
-        let (shrine, flashmint) = FlashmintUtils::flashmint_setup();
+        let (shrine, flashmint) = flash_mint_utils::flashmint_setup();
 
         // Check that max loan is correct
         let max_loan: u256 = flashmint.max_flash_loan(shrine);
-        let expected_max_loan: u256 = (Wad { val: FlashmintUtils::YIN_TOTAL_SUPPLY }
-            * Wad { val: FlashMint::FLASH_MINT_AMOUNT_PCT })
+        let expected_max_loan: u256 = (Wad { val: flash_mint_utils::YIN_TOTAL_SUPPLY }
+            * Wad { val: flash_mint_contract::FLASH_MINT_AMOUNT_PCT })
             .into();
         assert(max_loan == expected_max_loan, 'Incorrect max flash loan');
     }
@@ -36,8 +36,8 @@ mod TestFlashmint {
     #[test]
     #[available_gas(20000000000)]
     fn test_flash_fee() {
-        let shrine: ContractAddress = ShrineUtils::shrine_deploy();
-        let flashmint: IFlashMintDispatcher = FlashmintUtils::flashmint_deploy(shrine);
+        let shrine: ContractAddress = shrine_utils::shrine_deploy();
+        let flashmint: IFlashMintDispatcher = flash_mint_utils::flashmint_deploy(shrine);
 
         // Check that flash fee is correct
         assert(flashmint.flash_fee(shrine, 0xdeadbeefdead_u256).is_zero(), 'Incorrect flash fee');
@@ -46,11 +46,11 @@ mod TestFlashmint {
     #[test]
     #[available_gas(20000000000)]
     fn test_flashmint_pass() {
-        let (shrine, flashmint, borrower) = FlashmintUtils::flash_borrower_setup();
-        let yin = ShrineUtils::yin(shrine);
+        let (shrine, flashmint, borrower) = flash_mint_utils::flash_borrower_setup();
+        let yin = shrine_utils::yin(shrine);
 
-        let mut calldata: Span<felt252> = FlashmintUtils::build_calldata(
-            true, FlashBorrower::VALID_USAGE
+        let mut calldata: Span<felt252> = flash_mint_utils::build_calldata(
+            true, flash_borrower_contract::VALID_USAGE
         );
 
         // `borrower` contains a check that ensures that `flashmint` actually transferred
@@ -62,17 +62,17 @@ mod TestFlashmint {
         flashmint.flash_loan(borrower, shrine, first_loan_amt, calldata);
         assert(yin.balance_of(borrower).is_zero(), 'Wrong yin bal after flashmint 1');
 
-        ShrineUtils::assert_total_debt_invariant(
-            ShrineUtils::shrine(shrine), ShrineUtils::three_yang_addrs(), 1
+        shrine_utils::assert_total_debt_invariant(
+            shrine_utils::shrine(shrine), shrine_utils::three_yang_addrs(), 1
         );
 
         set_contract_address(flash_mint_caller);
-        let second_loan_amt: u256 = FlashmintUtils::DEFAULT_MINT_AMOUNT;
+        let second_loan_amt: u256 = flash_mint_utils::DEFAULT_MINT_AMOUNT;
         flashmint.flash_loan(borrower, shrine, second_loan_amt, calldata);
         assert(yin.balance_of(borrower).is_zero(), 'Wrong yin bal after flashmint 2');
 
-        ShrineUtils::assert_total_debt_invariant(
-            ShrineUtils::shrine(shrine), ShrineUtils::three_yang_addrs(), 1
+        shrine_utils::assert_total_debt_invariant(
+            shrine_utils::shrine(shrine), shrine_utils::three_yang_addrs(), 1
         );
 
         set_contract_address(flash_mint_caller);
@@ -80,29 +80,29 @@ mod TestFlashmint {
         flashmint.flash_loan(borrower, shrine, third_loan_amt, calldata);
         assert(yin.balance_of(borrower).is_zero(), 'Wrong yin bal after flashmint 3');
 
-        ShrineUtils::assert_total_debt_invariant(
-            ShrineUtils::shrine(shrine), ShrineUtils::three_yang_addrs(), 1
+        shrine_utils::assert_total_debt_invariant(
+            shrine_utils::shrine(shrine), shrine_utils::three_yang_addrs(), 1
         );
 
-        let mut expected_events: Span<FlashMint::Event> = array![
-            FlashMint::Event::FlashMint(
-                FlashMint::FlashMint {
+        let mut expected_events: Span<flash_mint_contract::Event> = array![
+            flash_mint_contract::Event::FlashMint(
+                flash_mint_contract::FlashMint {
                     initiator: flash_mint_caller,
                     receiver: borrower,
                     token: shrine,
                     amount: first_loan_amt
                 }
             ),
-            FlashMint::Event::FlashMint(
-                FlashMint::FlashMint {
+            flash_mint_contract::Event::FlashMint(
+                flash_mint_contract::FlashMint {
                     initiator: flash_mint_caller,
                     receiver: borrower,
                     token: shrine,
                     amount: second_loan_amt
                 }
             ),
-            FlashMint::Event::FlashMint(
-                FlashMint::FlashMint {
+            flash_mint_contract::Event::FlashMint(
+                flash_mint_contract::FlashMint {
                     initiator: flash_mint_caller,
                     receiver: borrower,
                     token: shrine,
@@ -113,9 +113,9 @@ mod TestFlashmint {
             .span();
         common::assert_events_emitted(flashmint.contract_address, expected_events, Option::None);
 
-        let mut expected_events: Span<FlashBorrower::Event> = array![
-            FlashBorrower::Event::FlashLoancall_dataReceived(
-                FlashBorrower::FlashLoancall_dataReceived {
+        let mut expected_events: Span<flash_borrower_contract::Event> = array![
+            flash_borrower_contract::Event::FlashLoancall_dataReceived(
+                flash_borrower_contract::FlashLoancall_dataReceived {
                     initiator: flash_mint_caller,
                     token: shrine,
                     amount: first_loan_amt,
@@ -123,8 +123,8 @@ mod TestFlashmint {
                     call_data: calldata,
                 }
             ),
-            FlashBorrower::Event::FlashLoancall_dataReceived(
-                FlashBorrower::FlashLoancall_dataReceived {
+            flash_borrower_contract::Event::FlashLoancall_dataReceived(
+                flash_borrower_contract::FlashLoancall_dataReceived {
                     initiator: flash_mint_caller,
                     token: shrine,
                     amount: second_loan_amt,
@@ -132,8 +132,8 @@ mod TestFlashmint {
                     call_data: calldata,
                 }
             ),
-            FlashBorrower::Event::FlashLoancall_dataReceived(
-                FlashBorrower::FlashLoancall_dataReceived {
+            flash_borrower_contract::Event::FlashLoancall_dataReceived(
+                flash_borrower_contract::FlashLoancall_dataReceived {
                     initiator: flash_mint_caller,
                     token: shrine,
                     amount: third_loan_amt,
@@ -150,13 +150,13 @@ mod TestFlashmint {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('FM: amount exceeds maximum', 'ENTRYPOINT_FAILED'))]
     fn test_flashmint_excess_minting() {
-        let (shrine, flashmint, borrower) = FlashmintUtils::flash_borrower_setup();
+        let (shrine, flashmint, borrower) = flash_mint_utils::flash_borrower_setup();
         flashmint
             .flash_loan(
                 borrower,
                 shrine,
                 1000000000000000000001_u256,
-                FlashmintUtils::build_calldata(true, FlashBorrower::VALID_USAGE)
+                flash_mint_utils::build_calldata(true, flash_borrower_contract::VALID_USAGE)
             );
     }
 
@@ -164,13 +164,13 @@ mod TestFlashmint {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('FM: on_flash_loan failed', 'ENTRYPOINT_FAILED'))]
     fn test_flashmint_incorrect_return() {
-        let (shrine, flashmint, borrower) = FlashmintUtils::flash_borrower_setup();
+        let (shrine, flashmint, borrower) = flash_mint_utils::flash_borrower_setup();
         flashmint
             .flash_loan(
                 borrower,
                 shrine,
-                FlashmintUtils::DEFAULT_MINT_AMOUNT,
-                FlashmintUtils::build_calldata(false, FlashBorrower::VALID_USAGE)
+                flash_mint_utils::DEFAULT_MINT_AMOUNT,
+                flash_mint_utils::build_calldata(false, flash_borrower_contract::VALID_USAGE)
             );
     }
 
@@ -180,13 +180,13 @@ mod TestFlashmint {
         expected: ('SH: Insufficient yin balance', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED')
     )]
     fn test_flashmint_steal() {
-        let (shrine, flashmint, borrower) = FlashmintUtils::flash_borrower_setup();
+        let (shrine, flashmint, borrower) = flash_mint_utils::flash_borrower_setup();
         flashmint
             .flash_loan(
                 borrower,
                 shrine,
-                FlashmintUtils::DEFAULT_MINT_AMOUNT,
-                FlashmintUtils::build_calldata(true, FlashBorrower::ATTEMPT_TO_STEAL)
+                flash_mint_utils::DEFAULT_MINT_AMOUNT,
+                flash_mint_utils::build_calldata(true, flash_borrower_contract::ATTEMPT_TO_STEAL)
             );
     }
 
@@ -198,13 +198,13 @@ mod TestFlashmint {
         )
     )]
     fn test_flashmint_reenter() {
-        let (shrine, flashmint, borrower) = FlashmintUtils::flash_borrower_setup();
+        let (shrine, flashmint, borrower) = flash_mint_utils::flash_borrower_setup();
         flashmint
             .flash_loan(
                 borrower,
                 shrine,
-                FlashmintUtils::DEFAULT_MINT_AMOUNT,
-                FlashmintUtils::build_calldata(true, FlashBorrower::ATTEMPT_TO_REENTER)
+                flash_mint_utils::DEFAULT_MINT_AMOUNT,
+                flash_mint_utils::build_calldata(true, flash_borrower_contract::ATTEMPT_TO_REENTER)
             );
     }
 }

--- a/src/tests/gate/utils.cairo
+++ b/src/tests/gate/utils.cairo
@@ -1,4 +1,4 @@
-mod GateUtils {
+mod gate_utils {
     use debug::PrintTrait;
     use integer::BoundedInt;
     use starknet::{
@@ -8,7 +8,7 @@ mod GateUtils {
     use starknet::contract_address::ContractAddressZeroable;
     use starknet::testing::{set_block_timestamp, set_contract_address};
 
-    use opus::core::gate::Gate;
+    use opus::core::gate::gate as gate_contract;
     use opus::interfaces::IERC20::{
         IERC20Dispatcher, IERC20DispatcherTrait, IMintableDispatcher, IMintableDispatcherTrait
     };
@@ -18,7 +18,7 @@ mod GateUtils {
 
     use opus::tests::common;
     use opus::tests::erc20::ERC20;
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::shrine::utils::shrine_utils;
 
     //
     // Constants
@@ -63,7 +63,7 @@ mod GateUtils {
     fn gate_deploy(
         token: ContractAddress, shrine: ContractAddress, sentinel: ContractAddress
     ) -> ContractAddress {
-        set_block_timestamp(ShrineUtils::DEPLOYMENT_TIMESTAMP);
+        set_block_timestamp(shrine_utils::DEPLOYMENT_TIMESTAMP);
 
         let mut calldata: Array<felt252> = array![
             contract_address_to_felt252(shrine),
@@ -71,7 +71,7 @@ mod GateUtils {
             contract_address_to_felt252(sentinel),
         ];
 
-        let gate_class_hash: ClassHash = class_hash_try_from_felt252(Gate::TEST_CLASS_HASH)
+        let gate_class_hash: ClassHash = class_hash_try_from_felt252(gate_contract::TEST_CLASS_HASH)
             .unwrap();
         let (gate, _) = deploy_syscall(gate_class_hash, 0, calldata.span(), false).unwrap_syscall();
 
@@ -79,46 +79,46 @@ mod GateUtils {
     }
 
     fn eth_gate_deploy() -> (ContractAddress, ContractAddress, ContractAddress) {
-        let shrine = ShrineUtils::shrine_deploy();
+        let shrine = shrine_utils::shrine_deploy();
         let eth: ContractAddress = eth_token_deploy();
         let gate: ContractAddress = gate_deploy(eth, shrine, mock_sentinel());
         (shrine, eth, gate)
     }
 
     fn wbtc_gate_deploy() -> (ContractAddress, ContractAddress, ContractAddress) {
-        let shrine = ShrineUtils::shrine_deploy();
+        let shrine = shrine_utils::shrine_deploy();
         let wbtc: ContractAddress = wbtc_token_deploy();
         let gate: ContractAddress = gate_deploy(wbtc, shrine, mock_sentinel());
         (shrine, wbtc, gate)
     }
 
     fn add_eth_as_yang(shrine: ContractAddress, eth: ContractAddress) {
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         let shrine = IShrineDispatcher { contract_address: shrine };
         shrine
             .add_yang(
                 eth,
-                ShrineUtils::YANG1_THRESHOLD.into(),
-                ShrineUtils::YANG1_START_PRICE.into(),
-                ShrineUtils::YANG1_BASE_RATE.into(),
+                shrine_utils::YANG1_THRESHOLD.into(),
+                shrine_utils::YANG1_START_PRICE.into(),
+                shrine_utils::YANG1_BASE_RATE.into(),
                 WadZeroable::zero() // initial amount
             );
-        shrine.set_debt_ceiling(ShrineUtils::DEBT_CEILING.into());
+        shrine.set_debt_ceiling(shrine_utils::DEBT_CEILING.into());
         set_contract_address(ContractAddressZeroable::zero());
     }
 
     fn add_wbtc_as_yang(shrine: ContractAddress, wbtc: ContractAddress) {
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         let shrine = IShrineDispatcher { contract_address: shrine };
         shrine
             .add_yang(
                 wbtc,
-                ShrineUtils::YANG2_THRESHOLD.into(),
-                ShrineUtils::YANG2_START_PRICE.into(),
-                ShrineUtils::YANG2_BASE_RATE.into(),
+                shrine_utils::YANG2_THRESHOLD.into(),
+                shrine_utils::YANG2_START_PRICE.into(),
+                shrine_utils::YANG2_BASE_RATE.into(),
                 WadZeroable::zero() // initial amount
             );
-        shrine.set_debt_ceiling(ShrineUtils::DEBT_CEILING.into());
+        shrine.set_debt_ceiling(shrine_utils::DEBT_CEILING.into());
         set_contract_address(ContractAddressZeroable::zero());
     }
 

--- a/src/tests/purger/flash_liquidator.cairo
+++ b/src/tests/purger/flash_liquidator.cairo
@@ -13,11 +13,11 @@ trait IFlashLiquidator<TContractState> {
 }
 
 #[starknet::contract]
-mod FlashLiquidator {
+mod flash_liquidator {
     use integer::BoundedInt;
     use starknet::{get_contract_address, ContractAddress};
 
-    use opus::core::flashmint::FlashMint::ON_FLASH_MINT_SUCCESS;
+    use opus::core::flash_mint::flash_mint::ON_FLASH_MINT_SUCCESS;
 
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -30,7 +30,7 @@ mod FlashLiquidator {
     use opus::utils::wadray;
     use opus::utils::wadray::{Wad, WadZeroable};
 
-    use opus::tests::absorber::utils::AbsorberUtils;
+    use opus::tests::absorber::utils::absorber_utils;
     use opus::tests::common;
 
     #[storage]
@@ -115,7 +115,7 @@ mod FlashLiquidator {
                 .read()
                 .liquidate(trove_id, amount.try_into().unwrap(), flash_liquidator);
 
-            let mut provider_assets: Span<u128> = AbsorberUtils::provider_asset_amts();
+            let mut provider_assets: Span<u128> = absorber_utils::provider_asset_amts();
             let mut updated_assets: Array<AssetBalance> = ArrayTrait::new();
             let mut freed_assets_copy = freed_assets;
             loop {

--- a/src/tests/purger/utils.cairo
+++ b/src/tests/purger/utils.cairo
@@ -1,4 +1,4 @@
-mod PurgerUtils {
+mod purger_utils {
     use cmp::min;
     use starknet::{
         deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
@@ -8,9 +8,9 @@ mod PurgerUtils {
     use starknet::contract_address::ContractAddressZeroable;
     use starknet::testing::set_contract_address;
 
-    use opus::core::absorber::Absorber;
-    use opus::core::purger::Purger;
-    use opus::core::roles::{AbsorberRoles, PragmaRoles, SentinelRoles, ShrineRoles};
+    use opus::core::absorber::absorber as absorber_contract;
+    use opus::core::purger::purger as purger_contract;
+    use opus::core::roles::{absorber_roles, pragma_roles, sentinel_roles, shrine_roles};
 
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IAbsorber::{IAbsorberDispatcher, IAbsorberDispatcherTrait};
@@ -24,17 +24,15 @@ mod PurgerUtils {
     use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RAY_ONE, RAY_PERCENT, Wad, WadZeroable, WAD_DECIMALS, WAD_ONE};
 
-    use opus::tests::absorber::utils::AbsorberUtils;
+    use opus::tests::absorber::utils::absorber_utils;
     use opus::tests::common;
-    use opus::tests::external::mock_pragma::{
-        IMockPragmaDispatcher, IMockPragmaDispatcherTrait, MockPragma
-    };
-    use opus::tests::external::utils::PragmaUtils;
+    use opus::tests::external::mock_pragma::{IMockPragmaDispatcher, IMockPragmaDispatcherTrait};
+    use opus::tests::external::utils::pragma_utils;
     use opus::tests::purger::flash_liquidator::{
-        FlashLiquidator, IFlashLiquidatorDispatcher, IFlashLiquidatorDispatcherTrait
+        flash_liquidator, IFlashLiquidatorDispatcher, IFlashLiquidatorDispatcherTrait
     };
-    use opus::tests::sentinel::utils::SentinelUtils;
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::sentinel::utils::sentinel_utils;
+    use opus::tests::shrine::utils::shrine_utils;
 
     use debug::PrintTrait;
 
@@ -266,9 +264,9 @@ mod PurgerUtils {
 
     fn inoperational_absorber_yin_cases() -> Span<Wad> {
         array![ // minimum amount that must be provided based on initial shares
-            Absorber::INITIAL_SHARES
+            absorber_contract::INITIAL_SHARES
                 .into(), // largest possible amount of yin in Absorber based on initial shares
-            (Absorber::MINIMUM_SHARES - 1).into()
+            (absorber_contract::MINIMUM_SHARES - 1).into()
         ]
             .span()
     }
@@ -278,7 +276,7 @@ mod PurgerUtils {
     fn generate_operational_absorber_yin_cases(trove_debt: Wad) -> Span<Wad> {
         array![
             // smallest possible amount of yin in Absorber based on initial shares
-            Absorber::MINIMUM_SHARES.into(),
+            absorber_contract::MINIMUM_SHARES.into(),
             (trove_debt.val / 3).into(),
             (trove_debt.val - 1000).into(),
             // trove's debt minus the smallest unit of Wad
@@ -300,31 +298,31 @@ mod PurgerUtils {
         Span<ContractAddress>,
         Span<IGateDispatcher>,
     ) {
-        let (shrine, sentinel, abbot, absorber, yangs, gates) = AbsorberUtils::absorber_deploy();
+        let (shrine, sentinel, abbot, absorber, yangs, gates) = absorber_utils::absorber_deploy();
 
-        let reward_tokens: Span<ContractAddress> = AbsorberUtils::reward_tokens_deploy();
-        let reward_amts_per_blessing: Span<u128> = AbsorberUtils::reward_amts_per_blessing();
-        AbsorberUtils::deploy_blesser_for_rewards(
+        let reward_tokens: Span<ContractAddress> = absorber_utils::reward_tokens_deploy();
+        let reward_amts_per_blessing: Span<u128> = absorber_utils::reward_amts_per_blessing();
+        absorber_utils::deploy_blesser_for_rewards(
             absorber, reward_tokens, reward_amts_per_blessing
         );
 
-        let (_, oracle, _, mock_pragma) = PragmaUtils::pragma_deploy_with_shrine(
+        let (_, oracle, _, mock_pragma) = pragma_utils::pragma_deploy_with_shrine(
             sentinel, shrine.contract_address
         );
-        PragmaUtils::add_yangs_to_pragma(oracle, yangs);
+        pragma_utils::add_yangs_to_pragma(oracle, yangs);
 
         // Seed initial prices for ETH and WBTC in Pragma
         let current_ts = get_block_timestamp();
-        PragmaUtils::mock_valid_price_update(
+        pragma_utils::mock_valid_price_update(
             mock_pragma,
-            PragmaUtils::ETH_USD_PAIR_ID,
-            PragmaUtils::convert_price_to_pragma_scale(PragmaUtils::ETH_INIT_PRICE),
+            pragma_utils::ETH_USD_PAIR_ID,
+            pragma_utils::convert_price_to_pragma_scale(pragma_utils::ETH_INIT_PRICE),
             current_ts
         );
-        PragmaUtils::mock_valid_price_update(
+        pragma_utils::mock_valid_price_update(
             mock_pragma,
-            PragmaUtils::WBTC_USD_PAIR_ID,
-            PragmaUtils::convert_price_to_pragma_scale(PragmaUtils::WBTC_INIT_PRICE),
+            pragma_utils::WBTC_USD_PAIR_ID,
+            pragma_utils::convert_price_to_pragma_scale(pragma_utils::WBTC_INIT_PRICE),
             current_ts
         );
         IOracleDispatcher { contract_address: oracle.contract_address }.update_prices();
@@ -339,7 +337,9 @@ mod PurgerUtils {
             contract_address_to_felt252(oracle.contract_address)
         ];
 
-        let purger_class_hash: ClassHash = class_hash_try_from_felt252(Purger::TEST_CLASS_HASH)
+        let purger_class_hash: ClassHash = class_hash_try_from_felt252(
+            purger_contract::TEST_CLASS_HASH
+        )
             .unwrap();
         let (purger_addr, _) = deploy_syscall(purger_class_hash, 0, calldata.span(), false)
             .unwrap_syscall();
@@ -348,26 +348,26 @@ mod PurgerUtils {
 
         // Approve Purger in Shrine
         let shrine_ac = IAccessControlDispatcher { contract_address: shrine.contract_address };
-        set_contract_address(ShrineUtils::admin());
-        shrine_ac.grant_role(ShrineRoles::purger(), purger_addr);
+        set_contract_address(shrine_utils::admin());
+        shrine_ac.grant_role(shrine_roles::purger(), purger_addr);
 
         // Approve Purger in Sentinel
         let sentinel_ac = IAccessControlDispatcher { contract_address: sentinel.contract_address };
-        set_contract_address(SentinelUtils::admin());
-        sentinel_ac.grant_role(SentinelRoles::purger(), purger_addr);
+        set_contract_address(sentinel_utils::admin());
+        sentinel_ac.grant_role(sentinel_roles::purger(), purger_addr);
 
         // Approve Purger in Oracle
         let oracle_ac = IAccessControlDispatcher { contract_address: oracle.contract_address };
-        set_contract_address(PragmaUtils::admin());
-        oracle_ac.grant_role(PragmaRoles::purger(), purger_addr);
+        set_contract_address(pragma_utils::admin());
+        oracle_ac.grant_role(pragma_roles::purger(), purger_addr);
 
         // Approve Purger in Absorber
         let absorber_ac = IAccessControlDispatcher { contract_address: absorber.contract_address };
-        set_contract_address(AbsorberUtils::admin());
-        absorber_ac.grant_role(AbsorberRoles::purger(), purger_addr);
+        set_contract_address(absorber_utils::admin());
+        absorber_ac.grant_role(absorber_roles::purger(), purger_addr);
 
         // Increase debt ceiling
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         let debt_ceiling: Wad = (100000 * WAD_ONE).into();
         shrine.set_debt_ceiling(debt_ceiling);
 
@@ -407,7 +407,7 @@ mod PurgerUtils {
         ];
 
         let flash_liquidator_class_hash: ClassHash = class_hash_try_from_felt252(
-            FlashLiquidator::TEST_CLASS_HASH
+            flash_liquidator::TEST_CLASS_HASH
         )
             .unwrap();
         let (flash_liquidator_addr, _) = deploy_syscall(
@@ -439,11 +439,11 @@ mod PurgerUtils {
         gates: Span<IGateDispatcher>,
         amt: Wad,
     ) {
-        AbsorberUtils::provide_to_absorber(
+        absorber_utils::provide_to_absorber(
             shrine,
             abbot,
             absorber,
-            AbsorberUtils::provider_1(),
+            absorber_utils::provider_1(),
             yangs,
             recipient_trove_yang_asset_amts(),
             gates,
@@ -478,7 +478,7 @@ mod PurgerUtils {
 
     // Update thresholds for all yangs to the given value
     fn set_thresholds(shrine: IShrineDispatcher, mut yangs: Span<ContractAddress>, threshold: Ray) {
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         loop {
             match yangs.pop_front() {
                 Option::Some(yang) => { shrine.set_threshold(*yang, threshold); },
@@ -497,8 +497,8 @@ mod PurgerUtils {
         pct_decrease: Ray,
     ) {
         let current_ts = get_block_timestamp();
-        let scale: u128 = pow(10_u128, WAD_DECIMALS - PragmaUtils::PRAGMA_DECIMALS);
-        set_contract_address(ShrineUtils::admin());
+        let scale: u128 = pow(10_u128, WAD_DECIMALS - pragma_utils::PRAGMA_DECIMALS);
+        set_contract_address(shrine_utils::admin());
         loop {
             match yangs.pop_front() {
                 Option::Some(yang) => {
@@ -513,7 +513,7 @@ mod PurgerUtils {
                     // the target LTV.
                     shrine.advance(*yang, new_price);
 
-                    PragmaUtils::mock_valid_price_update(
+                    pragma_utils::mock_valid_price_update(
                         mock_pragma,
                         *yang_pair_ids.pop_front().unwrap(),
                         new_pragma_price,
@@ -622,7 +622,7 @@ mod PurgerUtils {
 
         let (penalty, max_absorption_amt, _) = purger.preview_absorb(trove_id);
         assert(max_absorption_amt.is_non_zero(), 'close amount should not be 0');
-        if ltv < (RAY_ONE - Purger::COMPENSATION_PCT).into() {
+        if ltv < (RAY_ONE - purger_contract::COMPENSATION_PCT).into() {
             assert(penalty.is_non_zero(), 'penalty should not be 0');
         } else {
             assert(penalty.is_zero(), 'penalty should be 0');
@@ -636,7 +636,7 @@ mod PurgerUtils {
     }
 
     fn assert_ltv_at_safety_margin(threshold: Ray, ltv: Ray) {
-        let expected_ltv: Ray = Purger::THRESHOLD_SAFETY_MARGIN.into() * threshold;
+        let expected_ltv: Ray = purger_contract::THRESHOLD_SAFETY_MARGIN.into() * threshold;
         let error_margin: Ray = (RAY_PERCENT / 10).into(); // 0.1%
         common::assert_equalish(ltv, expected_ltv, error_margin, 'LTV not within safety margin');
     }

--- a/src/tests/shrine/test_shrine.cairo
+++ b/src/tests/shrine/test_shrine.cairo
@@ -1,4 +1,4 @@
-mod TestShrine {
+mod test_shrine {
     use debug::PrintTrait;
     use integer::BoundedU256;
     use starknet::get_block_timestamp;
@@ -7,8 +7,8 @@ mod TestShrine {
     };
     use starknet::testing::{set_block_timestamp, set_contract_address};
 
-    use opus::core::shrine::Shrine;
-    use opus::core::roles::ShrineRoles;
+    use opus::core::shrine::shrine as shrine_contract;
+    use opus::core::roles::shrine_roles;
 
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
@@ -20,7 +20,7 @@ mod TestShrine {
         WAD_DECIMALS, WAD_PERCENT, WAD_ONE, WAD_SCALE
     };
 
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::shrine::utils::shrine_utils;
     use opus::tests::common;
 
     //
@@ -31,16 +31,16 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_shrine_deploy() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
 
         // Check ERC-20 getters
         let yin: IERC20Dispatcher = IERC20Dispatcher { contract_address: shrine_addr };
-        assert(yin.name() == ShrineUtils::YIN_NAME, 'wrong name');
-        assert(yin.symbol() == ShrineUtils::YIN_SYMBOL, 'wrong symbol');
+        assert(yin.name() == shrine_utils::YIN_NAME, 'wrong name');
+        assert(yin.symbol() == shrine_utils::YIN_SYMBOL, 'wrong symbol');
         assert(yin.decimals() == WAD_DECIMALS, 'wrong decimals');
 
         // Check Shrine getters
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
         assert(shrine.get_live(), 'not live');
         let (multiplier, _, _) = shrine.get_current_multiplier();
         assert(multiplier == RAY_ONE.into(), 'wrong multiplier');
@@ -48,14 +48,14 @@ mod TestShrine {
         let shrine_accesscontrol: IAccessControlDispatcher = IAccessControlDispatcher {
             contract_address: shrine_addr
         };
-        assert(shrine_accesscontrol.get_admin() == ShrineUtils::admin(), 'wrong admin');
+        assert(shrine_accesscontrol.get_admin() == shrine_utils::admin(), 'wrong admin');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::MultiplierUpdated(
-                Shrine::MultiplierUpdated {
-                    multiplier: Shrine::INITIAL_MULTIPLIER.into(),
-                    cumulative_multiplier: Shrine::INITIAL_MULTIPLIER.into(),
-                    interval: ShrineUtils::get_interval(ShrineUtils::DEPLOYMENT_TIMESTAMP) - 1,
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::MultiplierUpdated(
+                shrine_contract::MultiplierUpdated {
+                    multiplier: shrine_contract::INITIAL_MULTIPLIER.into(),
+                    cumulative_multiplier: shrine_contract::INITIAL_MULTIPLIER.into(),
+                    interval: shrine_utils::get_interval(shrine_utils::DEPLOYMENT_TIMESTAMP) - 1,
                 }
             )
         ]
@@ -64,51 +64,53 @@ mod TestShrine {
     }
 
     // Checks the following functions
-    // - `set_ShrineUtils::DEBT_CEILING`
+    // - `set_shrine_utils::DEBT_CEILING`
     // - `add_yang`
     // - initial threshold and value of Shrine
     #[test]
     #[available_gas(20000000000)]
     fn test_shrine_setup() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::MultiplierUpdated(
-                Shrine::MultiplierUpdated {
-                    multiplier: Shrine::INITIAL_MULTIPLIER.into(),
-                    cumulative_multiplier: Shrine::INITIAL_MULTIPLIER.into(),
-                    interval: ShrineUtils::get_interval(ShrineUtils::DEPLOYMENT_TIMESTAMP) - 1,
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::MultiplierUpdated(
+                shrine_contract::MultiplierUpdated {
+                    multiplier: shrine_contract::INITIAL_MULTIPLIER.into(),
+                    cumulative_multiplier: shrine_contract::INITIAL_MULTIPLIER.into(),
+                    interval: shrine_utils::get_interval(shrine_utils::DEPLOYMENT_TIMESTAMP) - 1,
                 }
             ),
-            Shrine::Event::DebtCeilingUpdated(
-                Shrine::DebtCeilingUpdated { ceiling: ShrineUtils::DEBT_CEILING.into() }
+            shrine_contract::Event::DebtCeilingUpdated(
+                shrine_contract::DebtCeilingUpdated { ceiling: shrine_utils::DEBT_CEILING.into() }
             )
         ]
             .span();
         common::assert_events_emitted(shrine_addr, expected_events, Option::None);
 
         // Check debt ceiling
-        let shrine = ShrineUtils::shrine(shrine_addr);
-        assert(shrine.get_debt_ceiling() == ShrineUtils::DEBT_CEILING.into(), 'wrong debt ceiling');
+        let shrine = shrine_utils::shrine(shrine_addr);
+        assert(
+            shrine.get_debt_ceiling() == shrine_utils::DEBT_CEILING.into(), 'wrong debt ceiling'
+        );
 
         // Check yangs
         assert(shrine.get_yangs_count() == 3, 'wrong yangs count');
 
         let expected_era: u64 = 1;
 
-        let mut yang_addrs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
-        let mut start_prices: Span<Wad> = ShrineUtils::three_yang_start_prices();
+        let mut yang_addrs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
+        let mut start_prices: Span<Wad> = shrine_utils::three_yang_start_prices();
         let mut thresholds: Span<Ray> = array![
-            ShrineUtils::YANG1_THRESHOLD.into(),
-            ShrineUtils::YANG2_THRESHOLD.into(),
-            ShrineUtils::YANG3_THRESHOLD.into(),
+            shrine_utils::YANG1_THRESHOLD.into(),
+            shrine_utils::YANG2_THRESHOLD.into(),
+            shrine_utils::YANG3_THRESHOLD.into(),
         ]
             .span();
         let mut base_rates: Span<Ray> = array![
-            ShrineUtils::YANG1_BASE_RATE.into(),
-            ShrineUtils::YANG2_BASE_RATE.into(),
-            ShrineUtils::YANG3_BASE_RATE.into(),
+            shrine_utils::YANG1_BASE_RATE.into(),
+            shrine_utils::YANG2_BASE_RATE.into(),
+            shrine_utils::YANG3_BASE_RATE.into(),
         ]
             .span();
 
@@ -152,25 +154,25 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_shrine_setup_with_feed() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
         let shrine: IShrineDispatcher = IShrineDispatcher { contract_address: shrine_addr };
 
-        let yang_addrs = ShrineUtils::three_yang_addrs();
-        let yang_start_prices = ShrineUtils::three_yang_start_prices();
-        let yang_feeds = ShrineUtils::advance_prices_and_set_multiplier(
-            shrine, ShrineUtils::FEED_LEN, yang_addrs, yang_start_prices,
+        let yang_addrs = shrine_utils::three_yang_addrs();
+        let yang_start_prices = shrine_utils::three_yang_start_prices();
+        let yang_feeds = shrine_utils::advance_prices_and_set_multiplier(
+            shrine, shrine_utils::FEED_LEN, yang_addrs, yang_start_prices,
         );
 
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
 
         let mut exp_start_cumulative_prices: Array<Wad> = array![
             *yang_start_prices.at(0), *yang_start_prices.at(1), *yang_start_prices.at(2),
         ];
 
-        let mut expected_events: Array<Shrine::Event> = ArrayTrait::new();
+        let mut expected_events: Array<shrine_contract::Event> = ArrayTrait::new();
 
-        let start_interval: u64 = ShrineUtils::get_interval(ShrineUtils::DEPLOYMENT_TIMESTAMP);
+        let start_interval: u64 = shrine_utils::get_interval(shrine_utils::DEPLOYMENT_TIMESTAMP);
         let mut yang_addrs_copy = yang_addrs;
         let mut exp_start_cumulative_prices_copy = exp_start_cumulative_prices.span();
         loop {
@@ -231,8 +233,8 @@ mod TestShrine {
 
                         expected_events
                             .append(
-                                Shrine::Event::YangPriceUpdated(
-                                    Shrine::YangPriceUpdated {
+                                shrine_contract::Event::YangPriceUpdated(
+                                    shrine_contract::YangPriceUpdated {
                                         yang: *yang_addr,
                                         price: expected_price,
                                         cumulative_price: expected_cumulative_price,
@@ -257,8 +259,8 @@ mod TestShrine {
 
             expected_events
                 .append(
-                    Shrine::Event::MultiplierUpdated(
-                        Shrine::MultiplierUpdated {
+                    shrine_contract::Event::MultiplierUpdated(
+                        shrine_contract::MultiplierUpdated {
                             multiplier: RAY_ONE.into(),
                             cumulative_multiplier: expected_cumulative_multiplier,
                             interval
@@ -278,7 +280,7 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_add_yang() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         let current_rate_era: u64 = shrine.get_current_rate_era();
         let yangs_count: u32 = shrine.get_yangs_count();
         assert(yangs_count == 3, 'incorrect yangs count');
@@ -289,7 +291,7 @@ mod TestShrine {
         let new_yang_start_price: Wad = 5000000000000000000_u128.into(); // 5 (Wad)
         let new_yang_rate: Ray = 60000000000000000000000000_u128.into(); // 6% (Ray)
 
-        let admin = ShrineUtils::admin();
+        let admin = shrine_utils::admin();
         set_contract_address(admin);
         shrine
             .add_yang(
@@ -314,20 +316,24 @@ mod TestShrine {
             'incorrect yang rate'
         );
 
-        let expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::ThresholdUpdated(
-                Shrine::ThresholdUpdated { yang: new_yang_address, threshold: new_yang_threshold }
+        let expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::ThresholdUpdated(
+                shrine_contract::ThresholdUpdated {
+                    yang: new_yang_address, threshold: new_yang_threshold
+                }
             ),
-            Shrine::Event::YangAdded(
-                Shrine::YangAdded {
+            shrine_contract::Event::YangAdded(
+                shrine_contract::YangAdded {
                     yang: new_yang_address,
                     yang_id: expected_yangs_count,
                     start_price: new_yang_start_price,
                     initial_rate: new_yang_rate
                 }
             ),
-            Shrine::Event::YangTotalUpdated(
-                Shrine::YangTotalUpdated { yang: new_yang_address, total: WadZeroable::zero() }
+            shrine_contract::Event::YangTotalUpdated(
+                shrine_contract::YangTotalUpdated {
+                    yang: new_yang_address, total: WadZeroable::zero()
+                }
             ),
         ]
             .span();
@@ -338,14 +344,14 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang already exists', 'ENTRYPOINT_FAILED'))]
     fn test_add_yang_duplicate_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
         shrine
             .add_yang(
-                ShrineUtils::yang1_addr(),
-                ShrineUtils::YANG1_THRESHOLD.into(),
-                ShrineUtils::YANG1_START_PRICE.into(),
-                ShrineUtils::YANG1_BASE_RATE.into(),
+                shrine_utils::yang1_addr(),
+                shrine_utils::YANG1_THRESHOLD.into(),
+                shrine_utils::YANG1_START_PRICE.into(),
+                shrine_utils::YANG1_BASE_RATE.into(),
                 WadZeroable::zero()
             );
     }
@@ -354,14 +360,14 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_add_yang_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         set_contract_address(common::badguy());
         shrine
             .add_yang(
-                ShrineUtils::yang1_addr(),
-                ShrineUtils::YANG1_THRESHOLD.into(),
-                ShrineUtils::YANG1_START_PRICE.into(),
-                ShrineUtils::YANG1_BASE_RATE.into(),
+                shrine_utils::yang1_addr(),
+                shrine_utils::YANG1_THRESHOLD.into(),
+                shrine_utils::YANG1_START_PRICE.into(),
+                shrine_utils::YANG1_BASE_RATE.into(),
                 WadZeroable::zero()
             );
     }
@@ -369,18 +375,18 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_set_threshold() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        let yang1_addr = ShrineUtils::yang1_addr();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        let yang1_addr = shrine_utils::yang1_addr();
         let new_threshold: Ray = 900000000000000000000000000_u128.into();
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.set_threshold(yang1_addr, new_threshold);
         let (raw_threshold, _) = shrine.get_yang_threshold(yang1_addr);
         assert(raw_threshold == new_threshold, 'threshold not updated');
 
-        let expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::ThresholdUpdated(
-                Shrine::ThresholdUpdated { yang: yang1_addr, threshold: new_threshold }
+        let expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::ThresholdUpdated(
+                shrine_contract::ThresholdUpdated { yang: yang1_addr, threshold: new_threshold }
             ),
         ]
             .span();
@@ -391,47 +397,48 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Threshold > max', 'ENTRYPOINT_FAILED'))]
     fn test_set_threshold_exceeds_max() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         let invalid_threshold: Ray = (RAY_SCALE + 1).into();
 
-        set_contract_address(ShrineUtils::admin());
-        shrine.set_threshold(ShrineUtils::yang1_addr(), invalid_threshold);
+        set_contract_address(shrine_utils::admin());
+        shrine.set_threshold(shrine_utils::yang1_addr(), invalid_threshold);
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_threshold_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         let new_threshold: Ray = 900000000000000000000000000_u128.into();
 
         set_contract_address(common::badguy());
-        shrine.set_threshold(ShrineUtils::yang1_addr(), new_threshold);
+        shrine.set_threshold(shrine_utils::yang1_addr(), new_threshold);
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_set_threshold_invalid_yang() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
-        shrine.set_threshold(ShrineUtils::invalid_yang_addr(), ShrineUtils::YANG1_THRESHOLD.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
+        shrine
+            .set_threshold(shrine_utils::invalid_yang_addr(), shrine_utils::YANG1_THRESHOLD.into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     fn test_update_rates_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
 
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         shrine
             .update_rates(
                 yangs,
                 array![
-                    Shrine::USE_PREV_BASE_RATE.into(),
-                    Shrine::USE_PREV_BASE_RATE.into(),
-                    Shrine::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
                 ]
                     .span()
             );
@@ -440,9 +447,9 @@ mod TestShrine {
         assert(shrine.get_current_rate_era() == expected_rate_era, 'wrong rate era');
 
         let mut expected_rates: Span<Ray> = array![
-            ShrineUtils::YANG1_BASE_RATE.into(),
-            ShrineUtils::YANG2_BASE_RATE.into(),
-            ShrineUtils::YANG3_BASE_RATE.into(),
+            shrine_utils::YANG1_BASE_RATE.into(),
+            shrine_utils::YANG2_BASE_RATE.into(),
+            shrine_utils::YANG3_BASE_RATE.into(),
         ]
             .span();
 
@@ -465,15 +472,15 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_update_rates_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         set_contract_address(common::badguy());
         shrine
             .update_rates(
-                ShrineUtils::three_yang_addrs(),
+                shrine_utils::three_yang_addrs(),
                 array![
-                    Shrine::USE_PREV_BASE_RATE.into(),
-                    Shrine::USE_PREV_BASE_RATE.into(),
-                    Shrine::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
                 ]
                     .span()
             );
@@ -483,12 +490,16 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: yangs.len != new_rates.len', 'ENTRYPOINT_FAILED'))]
     fn test_update_rates_array_length_mismatch() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
         shrine
             .update_rates(
-                ShrineUtils::three_yang_addrs(),
-                array![Shrine::USE_PREV_BASE_RATE.into(), Shrine::USE_PREV_BASE_RATE.into(),].span()
+                shrine_utils::three_yang_addrs(),
+                array![
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                ]
+                    .span()
             );
     }
 
@@ -496,12 +507,16 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Too few yangs', 'ENTRYPOINT_FAILED'))]
     fn test_update_rates_too_few_yangs() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
         shrine
             .update_rates(
-                ShrineUtils::two_yang_addrs_reversed(),
-                array![Shrine::USE_PREV_BASE_RATE.into(), Shrine::USE_PREV_BASE_RATE.into(),].span()
+                shrine_utils::two_yang_addrs_reversed(),
+                array![
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                ]
+                    .span()
             );
     }
 
@@ -509,20 +524,20 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_update_rates_invalid_yangs() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
         shrine
             .update_rates(
                 array![
-                    ShrineUtils::yang1_addr(),
-                    ShrineUtils::yang2_addr(),
-                    ShrineUtils::invalid_yang_addr(),
+                    shrine_utils::yang1_addr(),
+                    shrine_utils::yang2_addr(),
+                    shrine_utils::invalid_yang_addr(),
                 ]
                     .span(),
                 array![
-                    Shrine::USE_PREV_BASE_RATE.into(),
-                    Shrine::USE_PREV_BASE_RATE.into(),
-                    Shrine::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
                 ]
                     .span()
             );
@@ -532,17 +547,19 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Incorrect rate update', 'ENTRYPOINT_FAILED'))]
     fn test_update_rates_not_all_yangs() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
         shrine
             .update_rates(
                 array![
-                    ShrineUtils::yang1_addr(), ShrineUtils::yang2_addr(), ShrineUtils::yang1_addr(),
+                    shrine_utils::yang1_addr(),
+                    shrine_utils::yang2_addr(),
+                    shrine_utils::yang1_addr(),
                 ]
                     .span(),
                 array![
-                    Shrine::USE_PREV_BASE_RATE.into(),
-                    Shrine::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
+                    shrine_contract::USE_PREV_BASE_RATE.into(),
                     21000000000000000000000000_u128.into(), // 2.1% (Ray)
                 ]
                     .span()
@@ -556,14 +573,14 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_kill() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.kill();
 
         // Check eject pass
@@ -571,7 +588,9 @@ mod TestShrine {
 
         assert(!shrine.get_live(), 'should not be live');
 
-        let expected_events: Span<Shrine::Event> = array![Shrine::Event::Killed(Shrine::Killed {}),]
+        let expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::Killed(shrine_contract::Killed {}),
+        ]
             .span();
         common::assert_events_emitted(shrine.contract_address, expected_events, Option::None);
     }
@@ -580,82 +599,82 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: System is not live', 'ENTRYPOINT_FAILED'))]
     fn test_killed_deposit_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.kill();
         assert(!shrine.get_live(), 'should not be live');
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: System is not live', 'ENTRYPOINT_FAILED'))]
     fn test_killed_withdraw_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.kill();
         assert(!shrine.get_live(), 'should not be live');
 
-        ShrineUtils::trove1_withdraw(shrine, 1_u128.into());
+        shrine_utils::trove1_withdraw(shrine, 1_u128.into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: System is not live', 'ENTRYPOINT_FAILED'))]
     fn test_killed_forge_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.kill();
         assert(!shrine.get_live(), 'should not be live');
 
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: System is not live', 'ENTRYPOINT_FAILED'))]
     fn test_killed_melt_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.kill();
         assert(!shrine.get_live(), 'should not be live');
 
-        ShrineUtils::trove1_melt(shrine, 1_u128.into());
+        shrine_utils::trove1_melt(shrine, 1_u128.into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: System is not live', 'ENTRYPOINT_FAILED'))]
     fn test_killed_inject_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.kill();
         assert(!shrine.get_live(), 'should not be live');
 
-        shrine.inject(ShrineUtils::admin(), 1_u128.into());
+        shrine.inject(shrine_utils::admin(), 1_u128.into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_kill_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         assert(shrine.get_live(), 'should be live');
 
         set_contract_address(common::badguy());
@@ -669,21 +688,21 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_shrine_deposit_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        let deposit_amt: Wad = ShrineUtils::TROVE1_YANG1_DEPOSIT.into();
-        ShrineUtils::trove1_deposit(shrine, deposit_amt);
+        let deposit_amt: Wad = shrine_utils::TROVE1_YANG1_DEPOSIT.into();
+        shrine_utils::trove1_deposit(shrine, deposit_amt);
 
         let trove_id = common::TROVE_1;
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang = *yangs.at(0);
 
         assert(
-            shrine.get_yang_total(yang) == ShrineUtils::TROVE1_YANG1_DEPOSIT.into(),
+            shrine.get_yang_total(yang) == shrine_utils::TROVE1_YANG1_DEPOSIT.into(),
             'incorrect yang total'
         );
         assert(
-            shrine.get_deposit(yang, trove_id) == ShrineUtils::TROVE1_YANG1_DEPOSIT.into(),
+            shrine.get_deposit(yang, trove_id) == shrine_utils::TROVE1_YANG1_DEPOSIT.into(),
             'incorrect yang deposit'
         );
 
@@ -691,30 +710,32 @@ mod TestShrine {
         let max_forge_amt: Wad = shrine.get_max_forge(trove_id);
 
         let mut yang_prices: Array<Wad> = array![yang1_price];
-        let mut yang_amts: Array<Wad> = array![ShrineUtils::TROVE1_YANG1_DEPOSIT.into()];
-        let mut yang_thresholds: Array<Ray> = array![ShrineUtils::YANG1_THRESHOLD.into()];
+        let mut yang_amts: Array<Wad> = array![shrine_utils::TROVE1_YANG1_DEPOSIT.into()];
+        let mut yang_thresholds: Array<Ray> = array![shrine_utils::YANG1_THRESHOLD.into()];
 
-        let expected_max_forge: Wad = ShrineUtils::calculate_max_forge(
+        let expected_max_forge: Wad = shrine_utils::calculate_max_forge(
             yang_prices.span(), yang_amts.span(), yang_thresholds.span()
         );
         assert(max_forge_amt == expected_max_forge, 'incorrect max forge amt');
 
-        ShrineUtils::assert_total_yang_invariant(shrine, yangs, 1);
+        shrine_utils::assert_total_yang_invariant(shrine, yangs, 1);
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id: trove_id,
                     trove: Trove {
-                        charge_from: ShrineUtils::current_interval(),
+                        charge_from: shrine_utils::current_interval(),
                         debt: WadZeroable::zero(),
                         last_rate_era: 1
                     },
                 }
             ),
-            Shrine::Event::YangTotalUpdated(Shrine::YangTotalUpdated { yang, total: deposit_amt, }),
-            Shrine::Event::DepositUpdated(
-                Shrine::DepositUpdated { yang, trove_id, amount: deposit_amt, }
+            shrine_contract::Event::YangTotalUpdated(
+                shrine_contract::YangTotalUpdated { yang, total: deposit_amt, }
+            ),
+            shrine_contract::Event::DepositUpdated(
+                shrine_contract::DepositUpdated { yang, trove_id, amount: deposit_amt, }
             ),
         ]
             .span();
@@ -725,14 +746,14 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_deposit_invalid_yang_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
 
         shrine
             .deposit(
-                ShrineUtils::invalid_yang_addr(),
+                shrine_utils::invalid_yang_addr(),
                 common::TROVE_1,
-                ShrineUtils::TROVE1_YANG1_DEPOSIT.into()
+                shrine_utils::TROVE1_YANG1_DEPOSIT.into()
             );
     }
 
@@ -740,12 +761,14 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_deposit_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         set_contract_address(common::badguy());
 
         shrine
             .deposit(
-                ShrineUtils::yang1_addr(), common::TROVE_1, ShrineUtils::TROVE1_YANG1_DEPOSIT.into()
+                shrine_utils::yang1_addr(),
+                common::TROVE_1,
+                shrine_utils::TROVE1_YANG1_DEPOSIT.into()
             );
     }
 
@@ -756,17 +779,17 @@ mod TestShrine {
     #[test]
     #[available_gas(1000000000000)]
     fn test_shrine_withdraw_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        let withdraw_amt: Wad = (ShrineUtils::TROVE1_YANG1_DEPOSIT / 3).into();
-        ShrineUtils::trove1_withdraw(shrine, withdraw_amt);
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        let withdraw_amt: Wad = (shrine_utils::TROVE1_YANG1_DEPOSIT / 3).into();
+        shrine_utils::trove1_withdraw(shrine, withdraw_amt);
 
         let trove_id: u64 = common::TROVE_1;
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang1_addr = *yangs.at(0);
-        let remaining_amt: Wad = ShrineUtils::TROVE1_YANG1_DEPOSIT.into() - withdraw_amt;
+        let remaining_amt: Wad = shrine_utils::TROVE1_YANG1_DEPOSIT.into() - withdraw_amt;
         assert(shrine.get_yang_total(yang1_addr) == remaining_amt, 'incorrect yang total');
         assert(shrine.get_deposit(yang1_addr, trove_id) == remaining_amt, 'incorrect yang deposit');
 
@@ -780,31 +803,33 @@ mod TestShrine {
 
         let mut yang_prices: Array<Wad> = array![yang1_price];
         let mut yang_amts: Array<Wad> = array![remaining_amt];
-        let mut yang_thresholds: Array<Ray> = array![ShrineUtils::YANG1_THRESHOLD.into()];
+        let mut yang_thresholds: Array<Ray> = array![shrine_utils::YANG1_THRESHOLD.into()];
 
-        let expected_max_forge: Wad = ShrineUtils::calculate_max_forge(
+        let expected_max_forge: Wad = shrine_utils::calculate_max_forge(
             yang_prices.span(), yang_amts.span(), yang_thresholds.span()
         );
         assert(max_forge_amt == expected_max_forge, 'incorrect max forge amt');
 
-        ShrineUtils::assert_total_yang_invariant(shrine, yangs, 1);
+        shrine_utils::assert_total_yang_invariant(shrine, yangs, 1);
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id: trove_id,
                     trove: Trove {
-                        charge_from: ShrineUtils::current_interval(),
+                        charge_from: shrine_utils::current_interval(),
                         debt: WadZeroable::zero(),
                         last_rate_era: 1
                     },
                 }
             ),
-            Shrine::Event::YangTotalUpdated(
-                Shrine::YangTotalUpdated { yang: yang1_addr, total: remaining_amt }
+            shrine_contract::Event::YangTotalUpdated(
+                shrine_contract::YangTotalUpdated { yang: yang1_addr, total: remaining_amt }
             ),
-            Shrine::Event::DepositUpdated(
-                Shrine::DepositUpdated { yang: yang1_addr, trove_id, amount: remaining_amt }
+            shrine_contract::Event::DepositUpdated(
+                shrine_contract::DepositUpdated {
+                    yang: yang1_addr, trove_id, amount: remaining_amt
+                }
             ),
         ]
             .span();
@@ -814,16 +839,16 @@ mod TestShrine {
     #[test]
     #[available_gas(1000000000000)]
     fn test_shrine_forged_partial_withdraw_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        set_contract_address(ShrineUtils::admin());
-        let withdraw_amt: Wad = (ShrineUtils::TROVE1_YANG1_DEPOSIT / 3).into();
-        ShrineUtils::trove1_withdraw(shrine, withdraw_amt);
+        set_contract_address(shrine_utils::admin());
+        let withdraw_amt: Wad = (shrine_utils::TROVE1_YANG1_DEPOSIT / 3).into();
+        shrine_utils::trove1_withdraw(shrine, withdraw_amt);
 
-        let yang1_addr = ShrineUtils::yang1_addr();
-        let remaining_amt: Wad = ShrineUtils::TROVE1_YANG1_DEPOSIT.into() - withdraw_amt;
+        let yang1_addr = shrine_utils::yang1_addr();
+        let remaining_amt: Wad = shrine_utils::TROVE1_YANG1_DEPOSIT.into() - withdraw_amt;
         assert(shrine.get_yang_total(yang1_addr) == remaining_amt, 'incorrect yang total');
         assert(
             shrine.get_deposit(yang1_addr, common::TROVE_1) == remaining_amt,
@@ -832,7 +857,7 @@ mod TestShrine {
 
         let (yang1_price, _, _) = shrine.get_current_yang_price(yang1_addr);
         let expected_ltv: Ray = wadray::rdiv_ww(
-            ShrineUtils::TROVE1_FORGE_AMT.into(), (yang1_price * remaining_amt)
+            shrine_utils::TROVE1_FORGE_AMT.into(), (yang1_price * remaining_amt)
         );
         let (_, ltv, _, _) = shrine.get_trove_info(common::TROVE_1);
         assert(ltv == expected_ltv, 'incorrect LTV');
@@ -842,14 +867,14 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_withdraw_invalid_yang_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
 
         shrine
             .withdraw(
-                ShrineUtils::invalid_yang_addr(),
+                shrine_utils::invalid_yang_addr(),
                 common::TROVE_1,
-                ShrineUtils::TROVE1_YANG1_DEPOSIT.into()
+                shrine_utils::TROVE1_YANG1_DEPOSIT.into()
             );
     }
 
@@ -857,14 +882,16 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_withdraw_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
         set_contract_address(common::badguy());
 
         shrine
             .withdraw(
-                ShrineUtils::yang1_addr(), common::TROVE_1, ShrineUtils::TROVE1_YANG1_DEPOSIT.into()
+                shrine_utils::yang1_addr(),
+                common::TROVE_1,
+                shrine_utils::TROVE1_YANG1_DEPOSIT.into()
             );
     }
 
@@ -872,16 +899,16 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yang balance', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_withdraw_insufficient_yang_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         shrine
             .withdraw(
-                ShrineUtils::yang1_addr(),
+                shrine_utils::yang1_addr(),
                 common::TROVE_1,
-                (ShrineUtils::TROVE1_YANG1_DEPOSIT + 1).into()
+                (shrine_utils::TROVE1_YANG1_DEPOSIT + 1).into()
             );
     }
 
@@ -889,14 +916,14 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yang balance', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_withdraw_zero_yang_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        set_contract_address(shrine_utils::admin());
 
         shrine
             .withdraw(
-                ShrineUtils::yang2_addr(),
+                shrine_utils::yang2_addr(),
                 common::TROVE_1,
-                (ShrineUtils::TROVE1_YANG1_DEPOSIT + 1).into()
+                (shrine_utils::TROVE1_YANG1_DEPOSIT + 1).into()
             );
     }
 
@@ -904,23 +931,23 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Trove LTV is too high', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_withdraw_unsafe_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
         let (threshold, _, trove_value, debt) = shrine.get_trove_info(common::TROVE_1);
-        let (yang1_price, _, _) = shrine.get_current_yang_price(ShrineUtils::yang1_addr());
+        let (yang1_price, _, _) = shrine.get_current_yang_price(shrine_utils::yang1_addr());
 
         // Value of trove needed for existing forged amount to be safe
         let unsafe_trove_value: Wad = wadray::rdiv_wr(
-            ShrineUtils::TROVE1_FORGE_AMT.into(), threshold
+            shrine_utils::TROVE1_FORGE_AMT.into(), threshold
         );
         // Amount of yang to be withdrawn to decrease the trove's value to unsafe
         // `WAD_SCALE` is added to account for loss of precision from fixed point division
         let unsafe_withdraw_yang_amt: Wad = (trove_value - unsafe_trove_value) / yang1_price
             + WAD_SCALE.into();
-        set_contract_address(ShrineUtils::admin());
-        shrine.withdraw(ShrineUtils::yang1_addr(), common::TROVE_1, unsafe_withdraw_yang_amt);
+        set_contract_address(shrine_utils::admin());
+        shrine.withdraw(shrine_utils::yang1_addr(), common::TROVE_1, unsafe_withdraw_yang_amt);
     }
 
     //
@@ -930,17 +957,17 @@ mod TestShrine {
     #[test]
     #[available_gas(1000000000000)]
     fn test_shrine_forge_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang1_addr: ContractAddress = *yangs.at(0);
 
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
 
         let trove_id: u64 = common::TROVE_1;
         let before_max_forge_amt: Wad = shrine.get_max_forge(trove_id);
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
         assert(shrine.get_total_debt() == forge_amt, 'incorrect system debt');
 
@@ -948,7 +975,7 @@ mod TestShrine {
         assert(debt == forge_amt, 'incorrect trove debt');
 
         let (yang1_price, _, _) = shrine.get_current_yang_price(yang1_addr);
-        let expected_value: Wad = yang1_price * ShrineUtils::TROVE1_YANG1_DEPOSIT.into();
+        let expected_value: Wad = yang1_price * shrine_utils::TROVE1_YANG1_DEPOSIT.into();
         let expected_ltv: Ray = wadray::rdiv_ww(forge_amt, expected_value);
         assert(ltv == expected_ltv, 'incorrect ltv');
 
@@ -957,27 +984,29 @@ mod TestShrine {
         let after_max_forge_amt: Wad = shrine.get_max_forge(trove_id);
         assert(after_max_forge_amt == before_max_forge_amt - forge_amt, 'incorrect max forge amt');
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
+        let yin = shrine_utils::yin(shrine.contract_address);
         let trove1_owner_addr: ContractAddress = common::trove1_owner_addr();
         assert(yin.balance_of(trove1_owner_addr) == forge_amt.into(), 'incorrect ERC-20 balance');
         assert(yin.total_supply() == forge_amt.val.into(), 'incorrect ERC-20 balance');
 
-        ShrineUtils::assert_total_debt_invariant(shrine, yangs, 1);
+        shrine_utils::assert_total_debt_invariant(shrine, yangs, 1);
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: forge_amt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: forge_amt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
-                        charge_from: ShrineUtils::current_interval(),
+                        charge_from: shrine_utils::current_interval(),
                         debt: forge_amt,
                         last_rate_era: 1
                     },
                 }
             ),
-            Shrine::Event::Transfer(
-                Shrine::Transfer {
+            shrine_contract::Event::Transfer(
+                shrine_contract::Transfer {
                     from: ContractAddressZeroable::zero(),
                     to: trove1_owner_addr,
                     value: forge_amt.into(),
@@ -992,13 +1021,13 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Trove LTV is too high', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_forge_zero_deposit_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        set_contract_address(shrine_utils::admin());
 
         shrine
             .forge(
-                ShrineUtils::common::trove3_owner_addr(),
+                shrine_utils::common::trove3_owner_addr(),
                 common::TROVE_3,
                 1_u128.into(),
                 WadZeroable::zero()
@@ -1009,13 +1038,13 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Trove LTV is too high', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_forge_unsafe_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
         let max_forge_amt: Wad = shrine.get_max_forge(common::TROVE_1);
         let unsafe_forge_amt: Wad = (max_forge_amt.val + 1).into();
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine
             .forge(
                 common::trove1_owner_addr(), common::TROVE_1, unsafe_forge_amt, WadZeroable::zero()
@@ -1026,17 +1055,17 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Debt ceiling reached', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_forge_ceiling_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        set_contract_address(ShrineUtils::admin());
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        set_contract_address(shrine_utils::admin());
 
         // deposit more collateral
-        let additional_yang1_amt: Wad = (ShrineUtils::TROVE1_YANG1_DEPOSIT * 10).into();
-        shrine.deposit(ShrineUtils::yang1_addr(), common::TROVE_1, additional_yang1_amt);
+        let additional_yang1_amt: Wad = (shrine_utils::TROVE1_YANG1_DEPOSIT * 10).into();
+        shrine.deposit(shrine_utils::yang1_addr(), common::TROVE_1, additional_yang1_amt);
 
-        let unsafe_amt: Wad = (ShrineUtils::TROVE1_FORGE_AMT * 10).into();
+        let unsafe_amt: Wad = (shrine_utils::TROVE1_FORGE_AMT * 10).into();
         shrine.forge(common::trove1_owner_addr(), common::TROVE_1, unsafe_amt, WadZeroable::zero());
     }
 
@@ -1044,8 +1073,8 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_forge_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
         set_contract_address(common::badguy());
 
@@ -1053,7 +1082,7 @@ mod TestShrine {
             .forge(
                 common::trove1_owner_addr(),
                 common::TROVE_1,
-                ShrineUtils::TROVE1_FORGE_AMT.into(),
+                shrine_utils::TROVE1_FORGE_AMT.into(),
                 WadZeroable::zero(),
             );
     }
@@ -1062,16 +1091,16 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Event not emitted',))]
     fn test_shrine_forge_no_forgefee_emitted_when_zero() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
         let trove_id: u64 = common::TROVE_1;
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::ForgeFeePaid(
-                Shrine::ForgeFeePaid {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::ForgeFeePaid(
+                shrine_contract::ForgeFeePaid {
                     trove_id, fee: WadZeroable::zero(), fee_pct: WadZeroable::zero(),
                 }
             ),
@@ -1086,14 +1115,14 @@ mod TestShrine {
         let yin_price1: Wad = 980000000000000000_u128.into(); // 0.98 (wad)
         let yin_price2: Wad = 985000000000000000_u128.into(); // 0.985 (wad)
         let forge_amt: Wad = 100000000000000000000_u128.into(); // 100 (wad)
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         let trove_id: u64 = common::TROVE_1;
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         let before_max_forge_amt: Wad = shrine.get_max_forge(trove_id);
         shrine.update_yin_spot_price(yin_price1);
@@ -1112,8 +1141,10 @@ mod TestShrine {
         let fee = debt - forge_amt;
         assert(debt - forge_amt == fee_pct * forge_amt, 'wrong forge fee charged #1');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::ForgeFeePaid(Shrine::ForgeFeePaid { trove_id, fee, fee_pct }),
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::ForgeFeePaid(
+                shrine_contract::ForgeFeePaid { trove_id, fee, fee_pct }
+            ),
         ]
             .span();
         common::assert_events_emitted(shrine.contract_address, expected_events, Option::None);
@@ -1126,8 +1157,10 @@ mod TestShrine {
         let fee = new_debt - debt - forge_amt;
         assert(new_debt - debt - forge_amt == fee_pct * forge_amt, 'wrong forge fee charged #2');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::ForgeFeePaid(Shrine::ForgeFeePaid { trove_id, fee, fee_pct }),
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::ForgeFeePaid(
+                shrine_contract::ForgeFeePaid { trove_id, fee, fee_pct }
+            ),
         ]
             .span();
         common::assert_events_emitted(shrine.contract_address, expected_events, Option::None);
@@ -1141,9 +1174,9 @@ mod TestShrine {
         let yin_price2: Wad = 970000000000000000_u128.into(); // 0.985 (wad)
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
 
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        set_contract_address(ShrineUtils::admin());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        set_contract_address(shrine_utils::admin());
 
         shrine.update_yin_spot_price(yin_price1);
         // Front end fetches the forge fee for the user
@@ -1155,7 +1188,7 @@ mod TestShrine {
         // Should revert since the forge fee exceeds the maximum set by the frontend
         shrine
             .forge(
-                trove1_owner, common::TROVE_1, ShrineUtils::TROVE1_FORGE_AMT.into(), stale_fee_pct
+                trove1_owner, common::TROVE_1, shrine_utils::TROVE1_FORGE_AMT.into(), stale_fee_pct
             );
     }
 
@@ -1166,17 +1199,17 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_shrine_melt_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        let deposit_amt: Wad = ShrineUtils::TROVE1_YANG1_DEPOSIT.into();
-        ShrineUtils::trove1_deposit(shrine, deposit_amt);
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        let deposit_amt: Wad = shrine_utils::TROVE1_YANG1_DEPOSIT.into();
+        shrine_utils::trove1_deposit(shrine, deposit_amt);
 
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang1_addr: ContractAddress = *yangs.at(0);
 
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
+        let yin = shrine_utils::yin(shrine.contract_address);
         let trove_id: u64 = common::TROVE_1;
         let trove1_owner_addr = common::trove1_owner_addr();
 
@@ -1184,10 +1217,10 @@ mod TestShrine {
         let (_, _, _, before_trove_debt) = shrine.get_trove_info(trove_id);
         let before_yin_bal: u256 = yin.balance_of(trove1_owner_addr);
         let before_max_forge_amt: Wad = shrine.get_max_forge(trove_id);
-        let melt_amt: Wad = (ShrineUtils::TROVE1_YANG1_DEPOSIT / 3_u128).into();
+        let melt_amt: Wad = (shrine_utils::TROVE1_YANG1_DEPOSIT / 3_u128).into();
 
         let outstanding_amt: Wad = forge_amt - melt_amt;
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.melt(trove1_owner_addr, trove_id, melt_amt);
 
         assert(shrine.get_total_debt() == before_total_debt - melt_amt, 'incorrect total debt');
@@ -1209,22 +1242,24 @@ mod TestShrine {
             after_max_forge_amt == before_max_forge_amt + melt_amt, 'incorrect max forge amount'
         );
 
-        ShrineUtils::assert_total_debt_invariant(shrine, yangs, 1);
+        shrine_utils::assert_total_debt_invariant(shrine, yangs, 1);
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: after_trove_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: after_trove_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
-                        charge_from: ShrineUtils::current_interval(),
+                        charge_from: shrine_utils::current_interval(),
                         debt: after_trove_debt,
                         last_rate_era: 1
                     },
                 }
             ),
-            Shrine::Event::Transfer(
-                Shrine::Transfer {
+            shrine_contract::Event::Transfer(
+                shrine_contract::Transfer {
                     from: trove1_owner_addr,
                     to: ContractAddressZeroable::zero(),
                     value: melt_amt.into(),
@@ -1239,9 +1274,9 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_melt_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
 
         set_contract_address(common::badguy());
         shrine.melt(common::trove1_owner_addr(), common::TROVE_1, 1_u128.into());
@@ -1251,11 +1286,11 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yin balance', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_melt_insufficient_yin() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.melt(common::trove2_owner_addr(), common::TROVE_1, 1_u128.into());
     }
 
@@ -1266,30 +1301,30 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_yin_transfer_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        set_contract_address(ShrineUtils::admin());
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        set_contract_address(shrine_utils::admin());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
         set_contract_address(trove1_owner);
 
-        let success: bool = yin.transfer(yin_user, ShrineUtils::TROVE1_FORGE_AMT.into());
+        let success: bool = yin.transfer(yin_user, shrine_utils::TROVE1_FORGE_AMT.into());
 
         yin.transfer(yin_user, 0);
         assert(success, 'yin transfer fail');
         assert(yin.balance_of(trove1_owner).is_zero(), 'wrong transferor balance');
         assert(
-            yin.balance_of(yin_user) == ShrineUtils::TROVE1_FORGE_AMT.into(),
+            yin.balance_of(yin_user) == shrine_utils::TROVE1_FORGE_AMT.into(),
             'wrong transferee balance'
         );
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::Transfer(
-                Shrine::Transfer { from: trove1_owner, to: yin_user, value: 0, }
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::Transfer(
+                shrine_contract::Transfer { from: trove1_owner, to: yin_user, value: 0, }
             ),
         ]
             .span();
@@ -1300,28 +1335,28 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yin balance', 'ENTRYPOINT_FAILED'))]
     fn test_yin_transfer_fail_insufficient() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        set_contract_address(ShrineUtils::admin());
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        set_contract_address(shrine_utils::admin());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
         set_contract_address(trove1_owner);
 
-        yin.transfer(yin_user, (ShrineUtils::TROVE1_FORGE_AMT + 1).into());
+        yin.transfer(yin_user, (shrine_utils::TROVE1_FORGE_AMT + 1).into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yin balance', 'ENTRYPOINT_FAILED'))]
     fn test_yin_transfer_fail_zero_bal() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
         set_contract_address(trove1_owner);
 
@@ -1331,16 +1366,16 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_yin_transfer_from_pass() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
 
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
-        let transfer_amt: u256 = ShrineUtils::TROVE1_FORGE_AMT.into();
+        let transfer_amt: u256 = shrine_utils::TROVE1_FORGE_AMT.into();
         set_contract_address(trove1_owner);
         yin.approve(yin_user, transfer_amt);
 
@@ -1352,12 +1387,14 @@ mod TestShrine {
         assert(yin.balance_of(trove1_owner).is_zero(), 'wrong transferor balance');
         assert(yin.balance_of(yin_user) == transfer_amt, 'wrong transferee balance');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::Approval(
-                Shrine::Approval { owner: trove1_owner, spender: yin_user, value: transfer_amt, }
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::Approval(
+                shrine_contract::Approval {
+                    owner: trove1_owner, spender: yin_user, value: transfer_amt,
+                }
             ),
-            Shrine::Event::Transfer(
-                Shrine::Transfer { from: trove1_owner, to: yin_user, value: transfer_amt, }
+            shrine_contract::Event::Transfer(
+                shrine_contract::Transfer { from: trove1_owner, to: yin_user, value: transfer_amt, }
             ),
         ]
             .span();
@@ -1368,13 +1405,13 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yin allowance', 'ENTRYPOINT_FAILED'))]
     fn test_yin_transfer_from_unapproved_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
         set_contract_address(yin_user);
         yin.transfer_from(common::trove1_owner_addr(), yin_user, 1_u256);
     }
@@ -1383,25 +1420,25 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yin allowance', 'ENTRYPOINT_FAILED'))]
     fn test_yin_transfer_from_insufficient_allowance_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine
             .forge(
                 trove1_owner,
                 common::TROVE_1,
-                ShrineUtils::TROVE1_FORGE_AMT.into(),
+                shrine_utils::TROVE1_FORGE_AMT.into(),
                 WadZeroable::zero()
             );
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
 
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
         set_contract_address(trove1_owner);
-        let approve_amt: u256 = (ShrineUtils::TROVE1_FORGE_AMT / 2).into();
+        let approve_amt: u256 = (shrine_utils::TROVE1_FORGE_AMT / 2).into();
         yin.approve(yin_user, approve_amt);
 
         set_contract_address(yin_user);
@@ -1412,49 +1449,49 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Insufficient yin balance', 'ENTRYPOINT_FAILED'))]
     fn test_yin_transfer_from_insufficient_balance_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine
             .forge(
                 trove1_owner,
                 common::TROVE_1,
-                ShrineUtils::TROVE1_FORGE_AMT.into(),
+                shrine_utils::TROVE1_FORGE_AMT.into(),
                 WadZeroable::zero()
             );
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
 
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
         set_contract_address(trove1_owner);
         yin.approve(yin_user, BoundedU256::max());
 
         set_contract_address(yin_user);
-        yin.transfer_from(trove1_owner, yin_user, (ShrineUtils::TROVE1_FORGE_AMT + 1).into());
+        yin.transfer_from(trove1_owner, yin_user, (shrine_utils::TROVE1_FORGE_AMT + 1).into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: No transfer to 0 address', 'ENTRYPOINT_FAILED'))]
     fn test_yin_transfer_zero_address_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine
             .forge(
                 trove1_owner,
                 common::TROVE_1,
-                ShrineUtils::TROVE1_FORGE_AMT.into(),
+                shrine_utils::TROVE1_FORGE_AMT.into(),
                 WadZeroable::zero()
             );
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
 
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
         set_contract_address(trove1_owner);
@@ -1467,15 +1504,15 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_yin_melt_after_transfer() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
-        let yin = ShrineUtils::yin(shrine.contract_address);
-        let yin_user: ContractAddress = ShrineUtils::yin_user_addr();
+        let yin = shrine_utils::yin(shrine.contract_address);
+        let yin_user: ContractAddress = shrine_utils::yin_user_addr();
 
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
         set_contract_address(trove1_owner);
@@ -1485,7 +1522,7 @@ mod TestShrine {
 
         let melt_amt: Wad = forge_amt - transfer_amt;
 
-        ShrineUtils::trove1_melt(shrine, melt_amt);
+        shrine_utils::trove1_melt(shrine, melt_amt);
 
         let (_, _, _, debt) = shrine.get_trove_info(common::TROVE_1);
         let expected_debt: Wad = forge_amt - melt_amt;
@@ -1503,13 +1540,13 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_auth() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        let shrine = shrine_utils::shrine(shrine_addr);
         let shrine_accesscontrol: IAccessControlDispatcher = IAccessControlDispatcher {
             contract_address: shrine_addr
         };
 
-        let admin: ContractAddress = ShrineUtils::admin();
+        let admin: ContractAddress = shrine_utils::admin();
         let new_admin: ContractAddress = contract_address_try_from_felt252('new shrine admin')
             .unwrap();
 
@@ -1517,13 +1554,13 @@ mod TestShrine {
 
         // Authorizing an address and testing that it can use authorized functions
         set_contract_address(admin);
-        shrine_accesscontrol.grant_role(ShrineRoles::SET_DEBT_CEILING, new_admin);
+        shrine_accesscontrol.grant_role(shrine_roles::SET_DEBT_CEILING, new_admin);
         assert(
-            shrine_accesscontrol.has_role(ShrineRoles::SET_DEBT_CEILING, new_admin),
+            shrine_accesscontrol.has_role(shrine_roles::SET_DEBT_CEILING, new_admin),
             'role not granted'
         );
         assert(
-            shrine_accesscontrol.get_roles(new_admin) == ShrineRoles::SET_DEBT_CEILING,
+            shrine_accesscontrol.get_roles(new_admin) == shrine_roles::SET_DEBT_CEILING,
             'role not granted'
         );
 
@@ -1534,9 +1571,9 @@ mod TestShrine {
 
         // Revoking an address
         set_contract_address(admin);
-        shrine_accesscontrol.revoke_role(ShrineRoles::SET_DEBT_CEILING, new_admin);
+        shrine_accesscontrol.revoke_role(shrine_roles::SET_DEBT_CEILING, new_admin);
         assert(
-            !shrine_accesscontrol.has_role(ShrineRoles::SET_DEBT_CEILING, new_admin),
+            !shrine_accesscontrol.has_role(shrine_roles::SET_DEBT_CEILING, new_admin),
             'role not revoked'
         );
         assert(shrine_accesscontrol.get_roles(new_admin) == 0, 'role not revoked');
@@ -1546,19 +1583,19 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_revoke_role() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        let shrine = shrine_utils::shrine(shrine_addr);
         let shrine_accesscontrol: IAccessControlDispatcher = IAccessControlDispatcher {
             contract_address: shrine_addr
         };
 
-        let admin: ContractAddress = ShrineUtils::admin();
+        let admin: ContractAddress = shrine_utils::admin();
         let new_admin: ContractAddress = contract_address_try_from_felt252('new shrine admin')
             .unwrap();
 
         set_contract_address(admin);
-        shrine_accesscontrol.grant_role(ShrineRoles::SET_DEBT_CEILING, new_admin);
-        shrine_accesscontrol.revoke_role(ShrineRoles::SET_DEBT_CEILING, new_admin);
+        shrine_accesscontrol.grant_role(shrine_roles::SET_DEBT_CEILING, new_admin);
+        shrine_accesscontrol.revoke_role(shrine_roles::SET_DEBT_CEILING, new_admin);
 
         set_contract_address(new_admin);
         let new_ceiling: Wad = (WAD_SCALE + 1).into();
@@ -1574,27 +1611,27 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_advance_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         set_contract_address(common::badguy());
-        shrine.advance(ShrineUtils::yang1_addr(), ShrineUtils::YANG1_START_PRICE.into());
+        shrine.advance(shrine_utils::yang1_addr(), shrine_utils::YANG1_START_PRICE.into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_advance_invalid_yang() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        set_contract_address(ShrineUtils::admin());
-        shrine.advance(ShrineUtils::invalid_yang_addr(), ShrineUtils::YANG1_START_PRICE.into());
+        set_contract_address(shrine_utils::admin());
+        shrine.advance(shrine_utils::invalid_yang_addr(), shrine_utils::YANG1_START_PRICE.into());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_set_multiplier_unauthorized() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         set_contract_address(common::badguy());
         shrine.set_multiplier(RAY_SCALE.into());
@@ -1607,8 +1644,8 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_shrine_inject_and_eject() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        let yin = ShrineUtils::yin(shrine.contract_address);
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        let yin = shrine_utils::yin(shrine.contract_address);
         let trove1_owner = common::trove1_owner_addr();
 
         let before_total_supply: u256 = yin.total_supply();
@@ -1616,14 +1653,14 @@ mod TestShrine {
         let before_total_yin: Wad = shrine.get_total_yin();
         let before_user_yin: Wad = shrine.get_yin(trove1_owner);
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
-        let inject_amt = ShrineUtils::TROVE1_FORGE_AMT.into();
+        let inject_amt = shrine_utils::TROVE1_FORGE_AMT.into();
         shrine.inject(trove1_owner, inject_amt);
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::Transfer(
-                Shrine::Transfer {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::Transfer(
+                shrine_contract::Transfer {
                     from: ContractAddressZeroable::zero(),
                     to: trove1_owner,
                     value: inject_amt.into(),
@@ -1649,9 +1686,9 @@ mod TestShrine {
         assert(shrine.get_total_yin() == before_total_yin, 'incorrect total yin');
         assert(shrine.get_yin(trove1_owner) == before_user_yin, 'incorrect user yin');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::Transfer(
-                Shrine::Transfer {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::Transfer(
+                shrine_contract::Transfer {
                     from: trove1_owner,
                     to: ContractAddressZeroable::zero(),
                     value: inject_amt.into(),
@@ -1671,19 +1708,19 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Price cannot be 0', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_advance_zero_value_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        set_contract_address(ShrineUtils::admin());
-        shrine.advance(ShrineUtils::yang1_addr(), WadZeroable::zero());
+        set_contract_address(shrine_utils::admin());
+        shrine.advance(shrine_utils::yang1_addr(), WadZeroable::zero());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Multiplier cannot be 0', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_set_multiplier_zero_value_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.set_multiplier(RayZeroable::zero());
     }
 
@@ -1691,9 +1728,9 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Multiplier exceeds maximum', 'ENTRYPOINT_FAILED'))]
     fn test_shrine_set_multiplier_exceeds_max_fail() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.set_multiplier((RAY_SCALE * 3 + 1).into());
     }
 
@@ -1704,26 +1741,26 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_trove_unhealthy() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         // Depositing lots of collateral in another trove
         // to avoid entering recovery mode
-        set_contract_address(ShrineUtils::admin());
-        shrine.deposit(ShrineUtils::yang1_addr(), common::TROVE_2, (50 * WAD_ONE).into());
+        set_contract_address(shrine_utils::admin());
+        shrine.deposit(shrine_utils::yang1_addr(), common::TROVE_2, (50 * WAD_ONE).into());
 
-        let deposit_amt: Wad = ShrineUtils::TROVE1_YANG1_DEPOSIT.into();
-        ShrineUtils::trove1_deposit(shrine, deposit_amt);
+        let deposit_amt: Wad = shrine_utils::TROVE1_YANG1_DEPOSIT.into();
+        shrine_utils::trove1_deposit(shrine, deposit_amt);
         let trove1_owner: ContractAddress = common::trove1_owner_addr();
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
         let (_, _, _, debt) = shrine.get_trove_info(common::TROVE_1);
 
-        let unsafe_price: Wad = wadray::rdiv_wr(debt, ShrineUtils::YANG1_THRESHOLD.into())
+        let unsafe_price: Wad = wadray::rdiv_wr(debt, shrine_utils::YANG1_THRESHOLD.into())
             / deposit_amt;
 
-        set_contract_address(ShrineUtils::admin());
-        shrine.advance(ShrineUtils::yang1_addr(), unsafe_price);
+        set_contract_address(shrine_utils::admin());
+        shrine.advance(shrine_utils::yang1_addr(), unsafe_price);
 
         assert(shrine.is_healthy(common::TROVE_1), 'should be unhealthy');
     }
@@ -1731,14 +1768,14 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_get_trove_info() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        let yang1_addr: ContractAddress = ShrineUtils::yang1_addr();
-        let yang2_addr: ContractAddress = ShrineUtils::yang2_addr();
+        let yang1_addr: ContractAddress = shrine_utils::yang1_addr();
+        let yang2_addr: ContractAddress = shrine_utils::yang2_addr();
 
         let mut yangs: Array<ContractAddress> = array![yang1_addr, yang2_addr];
         let mut yang_amts: Array<Wad> = array![
-            ShrineUtils::TROVE1_YANG1_DEPOSIT.into(), ShrineUtils::TROVE1_YANG2_DEPOSIT.into(),
+            shrine_utils::TROVE1_YANG1_DEPOSIT.into(), shrine_utils::TROVE1_YANG2_DEPOSIT.into(),
         ];
 
         // Manually set the prices
@@ -1750,7 +1787,7 @@ mod TestShrine {
         let mut yangs_copy: Span<ContractAddress> = yangs.span();
         let mut yang_prices_copy: Span<Wad> = yang_prices.span();
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         loop {
             match yang_amts_copy.pop_front() {
                 Option::Some(yang_amt) => {
@@ -1763,17 +1800,18 @@ mod TestShrine {
             };
         };
         let mut yang_thresholds: Array<Ray> = array![
-            ShrineUtils::YANG1_THRESHOLD.into(), ShrineUtils::YANG2_THRESHOLD.into(),
+            shrine_utils::YANG1_THRESHOLD.into(), shrine_utils::YANG2_THRESHOLD.into(),
         ];
 
-        let (expected_threshold, expected_value) = ShrineUtils::calculate_trove_threshold_and_value(
+        let (expected_threshold, expected_value) =
+            shrine_utils::calculate_trove_threshold_and_value(
             yang_prices.span(), yang_amts.span(), yang_thresholds.span()
         );
         let (threshold, _, value, _) = shrine.get_trove_info(common::TROVE_1);
         assert(threshold == expected_threshold, 'wrong threshold');
 
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
         let (_, ltv, _, _) = shrine.get_trove_info(common::TROVE_1);
         let expected_ltv: Ray = wadray::rdiv_ww(forge_amt, expected_value);
         assert(ltv == expected_ltv, 'wrong LTV');
@@ -1782,7 +1820,7 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_zero_value_trove() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         let (threshold, ltv, value, debt) = shrine.get_trove_info(common::TROVE_3);
         assert(threshold.is_zero(), 'threshold should be 0');
@@ -1798,15 +1836,15 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_get_shrine_info() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        let yang1_addr: ContractAddress = ShrineUtils::yang1_addr();
-        let yang2_addr: ContractAddress = ShrineUtils::yang2_addr();
+        let yang1_addr: ContractAddress = shrine_utils::yang1_addr();
+        let yang2_addr: ContractAddress = shrine_utils::yang2_addr();
 
         let mut yangs: Array<ContractAddress> = array![yang1_addr, yang2_addr];
 
         let mut yang_amts: Array<Wad> = array![
-            ShrineUtils::TROVE1_YANG1_DEPOSIT.into(), ShrineUtils::TROVE1_YANG2_DEPOSIT.into(),
+            shrine_utils::TROVE1_YANG1_DEPOSIT.into(), shrine_utils::TROVE1_YANG2_DEPOSIT.into(),
         ];
 
         // Manually set the prices
@@ -1820,7 +1858,7 @@ mod TestShrine {
 
         // Deposit into troves 1 and 2, with trove 2 getting twice
         // the amount of trove 1
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         loop {
             match yang_amts_copy.pop_front() {
                 Option::Some(yang_amt) => {
@@ -1837,15 +1875,16 @@ mod TestShrine {
 
         // Update the amounts with the total amount deposited into troves 1 and 2
         let mut yang_amts: Array<Wad> = array![
-            (ShrineUtils::TROVE1_YANG1_DEPOSIT * 3).into(),
-            (ShrineUtils::TROVE1_YANG2_DEPOSIT * 3).into(),
+            (shrine_utils::TROVE1_YANG1_DEPOSIT * 3).into(),
+            (shrine_utils::TROVE1_YANG2_DEPOSIT * 3).into(),
         ];
 
         let mut yang_thresholds: Array<Ray> = array![
-            ShrineUtils::YANG1_THRESHOLD.into(), ShrineUtils::YANG2_THRESHOLD.into(),
+            shrine_utils::YANG1_THRESHOLD.into(), shrine_utils::YANG2_THRESHOLD.into(),
         ];
 
-        let (expected_threshold, expected_value) = ShrineUtils::calculate_trove_threshold_and_value(
+        let (expected_threshold, expected_value) =
+            shrine_utils::calculate_trove_threshold_and_value(
             yang_prices.span(), yang_amts.span(), yang_thresholds.span()
         );
         let (threshold, value) = shrine.get_shrine_threshold_and_value();
@@ -1862,20 +1901,22 @@ mod TestShrine {
         let first_yin_price: Wad = 995000000000000000_u128.into(); // 0.995 (wad)
         let second_yin_price: Wad = 994999999999999999_u128.into(); // 0.994999... (wad)
         let third_yin_price: Wad = 980000000000000000_u128.into(); // 0.98 (wad)
-        let fourth_yin_price: Wad = (Shrine::FORGE_FEE_CAP_PRICE - 1).into();
+        let fourth_yin_price: Wad = (shrine_contract::FORGE_FEE_CAP_PRICE - 1).into();
 
         let third_forge_fee: Wad = 39810717055349725_u128.into(); // 0.039810717055349725 (wad)
 
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         shrine.update_yin_spot_price(first_yin_price);
         assert(shrine.get_forge_fee_pct().is_zero(), 'wrong forge fee #1');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::YinPriceUpdated(
-                Shrine::YinPriceUpdated { old_price: WAD_ONE.into(), new_price: first_yin_price, }
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::YinPriceUpdated(
+                shrine_contract::YinPriceUpdated {
+                    old_price: WAD_ONE.into(), new_price: first_yin_price,
+                }
             ),
         ]
             .span();
@@ -1886,9 +1927,11 @@ mod TestShrine {
             shrine.get_forge_fee_pct(), WAD_PERCENT.into(), error_margin, 'wrong forge fee #2'
         );
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::YinPriceUpdated(
-                Shrine::YinPriceUpdated { old_price: first_yin_price, new_price: second_yin_price, }
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::YinPriceUpdated(
+                shrine_contract::YinPriceUpdated {
+                    old_price: first_yin_price, new_price: second_yin_price,
+                }
             ),
         ]
             .span();
@@ -1900,9 +1943,11 @@ mod TestShrine {
             shrine.get_forge_fee_pct(), third_forge_fee, error_margin, 'wrong forge fee #3'
         );
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::YinPriceUpdated(
-                Shrine::YinPriceUpdated { old_price: second_yin_price, new_price: third_yin_price, }
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::YinPriceUpdated(
+                shrine_contract::YinPriceUpdated {
+                    old_price: second_yin_price, new_price: third_yin_price,
+                }
             ),
         ]
             .span();
@@ -1911,12 +1956,15 @@ mod TestShrine {
         // forge fee should be `FORGE_FEE_CAP_PCT` for yin price <= `MIN_ZERO_FEE_YIN_PRICE`
         shrine.update_yin_spot_price(fourth_yin_price);
         assert(
-            shrine.get_forge_fee_pct() == Shrine::FORGE_FEE_CAP_PCT.into(), 'wrong forge fee #4'
+            shrine.get_forge_fee_pct() == shrine_contract::FORGE_FEE_CAP_PCT.into(),
+            'wrong forge fee #4'
         );
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::YinPriceUpdated(
-                Shrine::YinPriceUpdated { old_price: third_yin_price, new_price: fourth_yin_price, }
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::YinPriceUpdated(
+                shrine_contract::YinPriceUpdated {
+                    old_price: third_yin_price, new_price: fourth_yin_price,
+                }
             ),
         ]
             .span();
@@ -1930,15 +1978,15 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_get_yang_suspension_status_basic() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
 
-        let status_yang1 = shrine.get_yang_suspension_status(ShrineUtils::yang1_addr());
+        let status_yang1 = shrine.get_yang_suspension_status(shrine_utils::yang1_addr());
         assert(status_yang1 == YangSuspensionStatus::None, 'yang1');
-        let status_yang2 = shrine.get_yang_suspension_status(ShrineUtils::yang2_addr());
+        let status_yang2 = shrine.get_yang_suspension_status(shrine_utils::yang2_addr());
         assert(status_yang2 == YangSuspensionStatus::None, 'yang2');
-        let status_yang3 = shrine.get_yang_suspension_status(ShrineUtils::yang3_addr());
+        let status_yang3 = shrine.get_yang_suspension_status(shrine_utils::yang3_addr());
         assert(status_yang3 == YangSuspensionStatus::None, 'yang3');
     }
 
@@ -1946,43 +1994,43 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_get_yang_suspension_status_nonexisting_yang() {
-        let shrine = ShrineUtils::shrine(ShrineUtils::shrine_deploy());
-        shrine.get_yang_suspension_status(ShrineUtils::invalid_yang_addr());
+        let shrine = shrine_utils::shrine(shrine_utils::shrine_deploy());
+        shrine.get_yang_suspension_status(shrine_utils::invalid_yang_addr());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_suspend_yang_non_existing_yang() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
-        set_contract_address(ShrineUtils::admin());
-        shrine.suspend_yang(ShrineUtils::invalid_yang_addr());
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
+        set_contract_address(shrine_utils::admin());
+        shrine.suspend_yang(shrine_utils::invalid_yang_addr());
     }
 
     #[test]
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Yang does not exist', 'ENTRYPOINT_FAILED'))]
     fn test_unsuspend_yang_non_existing_yang() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
-        set_contract_address(ShrineUtils::admin());
-        shrine.unsuspend_yang(ShrineUtils::invalid_yang_addr());
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
+        set_contract_address(shrine_utils::admin());
+        shrine.unsuspend_yang(shrine_utils::invalid_yang_addr());
     }
 
     #[test]
     #[available_gas(20000000000)]
     fn test_yang_suspend_and_unsuspend() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
-        let yang = ShrineUtils::yang1_addr();
-        let start_ts = ShrineUtils::DEPLOYMENT_TIMESTAMP;
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
+        let yang = shrine_utils::yang1_addr();
+        let start_ts = shrine_utils::DEPLOYMENT_TIMESTAMP;
 
         set_block_timestamp(start_ts);
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         // initiate yang's suspension, starting now
         shrine.suspend_yang(yang);
@@ -1995,8 +2043,8 @@ mod TestShrine {
         common::assert_events_emitted(
             shrine_addr,
             array![
-                Shrine::Event::YangSuspended(
-                    Shrine::YangSuspended { yang, timestamp: get_block_timestamp() }
+                shrine_contract::Event::YangSuspended(
+                    shrine_contract::YangSuspended { yang, timestamp: get_block_timestamp() }
                 ),
             ]
                 .span(),
@@ -2004,7 +2052,7 @@ mod TestShrine {
         );
 
         // setting block time to a second before the suspension would be permanent
-        set_block_timestamp(start_ts + Shrine::SUSPENSION_GRACE_PERIOD - 1);
+        set_block_timestamp(start_ts + shrine_contract::SUSPENSION_GRACE_PERIOD - 1);
 
         // reset the suspension by setting yang's ts to 0
         shrine.unsuspend_yang(yang);
@@ -2017,8 +2065,8 @@ mod TestShrine {
         common::assert_events_emitted(
             shrine_addr,
             array![
-                Shrine::Event::YangUnsuspended(
-                    Shrine::YangUnsuspended { yang, timestamp: get_block_timestamp() }
+                shrine_contract::Event::YangUnsuspended(
+                    shrine_contract::YangUnsuspended { yang, timestamp: get_block_timestamp() }
                 ),
             ]
                 .span(),
@@ -2030,10 +2078,10 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_suspend_yang_not_authorized() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
-        let yang = ShrineUtils::yang1_addr();
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
+        let yang = shrine_utils::yang1_addr();
         set_contract_address(common::badguy());
 
         shrine.suspend_yang(yang);
@@ -2043,10 +2091,10 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('Caller missing role', 'ENTRYPOINT_FAILED'))]
     fn test_unsuspend_yang_not_authorized() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
-        let yang = ShrineUtils::yang1_addr();
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
+        let yang = shrine_utils::yang1_addr();
 
         // We directly unsuspend the yang instead of suspending it first, because
         // an unauthorized call to `suspend_yang` has the same error message, which
@@ -2058,15 +2106,15 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_yang_suspension_progress_temp_to_permanent() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
 
-        let yang = ShrineUtils::yang1_addr();
-        let start_ts = ShrineUtils::DEPLOYMENT_TIMESTAMP;
+        let yang = shrine_utils::yang1_addr();
+        let start_ts = shrine_utils::DEPLOYMENT_TIMESTAMP;
 
         set_block_timestamp(start_ts);
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         // initiate yang's suspension, starting now
         shrine.suspend_yang(yang);
@@ -2079,8 +2127,8 @@ mod TestShrine {
         common::assert_events_emitted(
             shrine_addr,
             array![
-                Shrine::Event::YangSuspended(
-                    Shrine::YangSuspended { yang, timestamp: get_block_timestamp() }
+                shrine_contract::Event::YangSuspended(
+                    shrine_contract::YangSuspended { yang, timestamp: get_block_timestamp() }
                 ),
             ]
                 .span(),
@@ -2089,10 +2137,10 @@ mod TestShrine {
 
         // check threshold (should be the same at the beginning)
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
-        assert(raw_threshold == ShrineUtils::YANG1_THRESHOLD.into(), 'threshold 1');
+        assert(raw_threshold == shrine_utils::YANG1_THRESHOLD.into(), 'threshold 1');
 
         // the threshold should decrease by 1% in this amount of time
-        let one_pct = Shrine::SUSPENSION_GRACE_PERIOD / 100;
+        let one_pct = shrine_contract::SUSPENSION_GRACE_PERIOD / 100;
 
         // move time forward
         set_block_timestamp(start_ts + one_pct);
@@ -2103,7 +2151,7 @@ mod TestShrine {
 
         // check threshold
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
-        assert(raw_threshold == (ShrineUtils::YANG1_THRESHOLD / 100 * 99).into(), 'threshold 2');
+        assert(raw_threshold == (shrine_utils::YANG1_THRESHOLD / 100 * 99).into(), 'threshold 2');
 
         // move time forward
         set_block_timestamp(start_ts + one_pct * 20);
@@ -2114,10 +2162,10 @@ mod TestShrine {
 
         // check threshold
         let (raw_threshold, _) = shrine.get_yang_threshold(yang);
-        assert(raw_threshold == (ShrineUtils::YANG1_THRESHOLD / 100 * 80).into(), 'threshold 3');
+        assert(raw_threshold == (shrine_utils::YANG1_THRESHOLD / 100 * 80).into(), 'threshold 3');
 
         // move time forward to a second before permanent suspension
-        set_block_timestamp(start_ts + Shrine::SUSPENSION_GRACE_PERIOD - 1);
+        set_block_timestamp(start_ts + shrine_contract::SUSPENSION_GRACE_PERIOD - 1);
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
@@ -2135,7 +2183,7 @@ mod TestShrine {
         );
 
         // move time forward to end of temp suspension, start of permanent one
-        set_block_timestamp(start_ts + Shrine::SUSPENSION_GRACE_PERIOD);
+        set_block_timestamp(start_ts + shrine_contract::SUSPENSION_GRACE_PERIOD);
 
         // check suspension status
         let status = shrine.get_yang_suspension_status(yang);
@@ -2150,19 +2198,19 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Suspension is permanent', 'ENTRYPOINT_FAILED'))]
     fn test_yang_suspension_cannot_reset_after_permanent() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
 
-        let yang = ShrineUtils::yang1_addr();
-        let start_ts = ShrineUtils::DEPLOYMENT_TIMESTAMP;
+        let yang = shrine_utils::yang1_addr();
+        let start_ts = shrine_utils::DEPLOYMENT_TIMESTAMP;
 
         set_block_timestamp(start_ts);
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         // mark permanent
         shrine.suspend_yang(yang);
-        set_block_timestamp(start_ts + Shrine::SUSPENSION_GRACE_PERIOD);
+        set_block_timestamp(start_ts + shrine_contract::SUSPENSION_GRACE_PERIOD);
 
         // sanity check
         let status = shrine.get_yang_suspension_status(yang);
@@ -2176,15 +2224,15 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Already suspended', 'ENTRYPOINT_FAILED'))]
     fn test_yang_already_suspended_temporary() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
 
-        let yang = ShrineUtils::yang1_addr();
-        let start_ts = ShrineUtils::DEPLOYMENT_TIMESTAMP;
+        let yang = shrine_utils::yang1_addr();
+        let start_ts = shrine_utils::DEPLOYMENT_TIMESTAMP;
 
         set_block_timestamp(start_ts);
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         // suspend yang
         shrine.suspend_yang(yang);
@@ -2201,21 +2249,21 @@ mod TestShrine {
     #[available_gas(20000000000)]
     #[should_panic(expected: ('SH: Already suspended', 'ENTRYPOINT_FAILED'))]
     fn test_yang_already_suspended_permanent() {
-        let shrine_addr: ContractAddress = ShrineUtils::shrine_deploy();
-        ShrineUtils::shrine_setup(shrine_addr);
-        let shrine = ShrineUtils::shrine(shrine_addr);
+        let shrine_addr: ContractAddress = shrine_utils::shrine_deploy();
+        shrine_utils::shrine_setup(shrine_addr);
+        let shrine = shrine_utils::shrine(shrine_addr);
 
-        let yang = ShrineUtils::yang1_addr();
-        let start_ts = ShrineUtils::DEPLOYMENT_TIMESTAMP;
+        let yang = shrine_utils::yang1_addr();
+        let start_ts = shrine_utils::DEPLOYMENT_TIMESTAMP;
 
         set_block_timestamp(start_ts);
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
         // suspend yang
         shrine.suspend_yang(yang);
 
         // make permanent
-        set_block_timestamp(start_ts + Shrine::SUSPENSION_GRACE_PERIOD);
+        set_block_timestamp(start_ts + shrine_contract::SUSPENSION_GRACE_PERIOD);
 
         // sanity check
         let status = shrine.get_yang_suspension_status(yang);
@@ -2232,7 +2280,7 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_recovery_mode_previously_healthy_trove_now_unhealthy() {
-        let shrine: IShrineDispatcher = ShrineUtils::recovery_mode_test_setup();
+        let shrine: IShrineDispatcher = shrine_utils::recovery_mode_test_setup();
 
         // Trove 1 should be healthy
         assert(shrine.is_healthy(common::TROVE_1), 'should be healthy #1');
@@ -2248,25 +2296,25 @@ mod TestShrine {
         //  x = whale_trove_deposit_value - whale_trove_forge_amt/(rm_threshold * 1.01)
 
         let threshold_scalar: Ray = (RAY_ONE + RAY_PERCENT).into();
-        let whale_trove_deposit_value: Wad = ShrineUtils::WHALE_TROVE_YANG1_DEPOSIT.into()
-            * ShrineUtils::YANG1_START_PRICE.into();
-        let whale_trove_forge_amt: Wad = ShrineUtils::WHALE_TROVE_FORGE_AMT.into();
+        let whale_trove_deposit_value: Wad = shrine_utils::WHALE_TROVE_YANG1_DEPOSIT.into()
+            * shrine_utils::YANG1_START_PRICE.into();
+        let whale_trove_forge_amt: Wad = shrine_utils::WHALE_TROVE_FORGE_AMT.into();
         let initial_collateral_value_to_withdraw: Wad = whale_trove_deposit_value
             - wadray::rdiv_wr(whale_trove_forge_amt, rm_threshold * threshold_scalar);
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
 
-        let (_, prev_yang1_threshold) = shrine.get_yang_threshold(ShrineUtils::yang1_addr());
+        let (_, prev_yang1_threshold) = shrine.get_yang_threshold(shrine_utils::yang1_addr());
         shrine
             .withdraw(
-                ShrineUtils::yang1_addr(),
+                shrine_utils::yang1_addr(),
                 common::WHALE_TROVE,
-                initial_collateral_value_to_withdraw / ShrineUtils::YANG1_START_PRICE.into()
+                initial_collateral_value_to_withdraw / shrine_utils::YANG1_START_PRICE.into()
             );
 
         // At this point, recovery mode should be activated but trove 1 should still be healthy,
         // since the liquidation threshold decrease is gradual
-        let (_, current_threshold) = shrine.get_yang_threshold(ShrineUtils::yang1_addr());
+        let (_, current_threshold) = shrine.get_yang_threshold(shrine_utils::yang1_addr());
         assert(current_threshold < prev_yang1_threshold, 'recovery mode not active');
         assert(shrine.is_healthy(common::TROVE_1), 'should be healthy #2');
 
@@ -2282,10 +2330,10 @@ mod TestShrine {
         // z = whale_trove_deposit_value - ((trove1_ltv - 10^(-24)) * whale_trove_forge_amt) / (trove1_threshold * THRESHOLD_DECREASE_FACTOR * rm_threshold)
 
         let trove1_ltv: Ray = wadray::rdiv_ww(
-            ShrineUtils::RECOVERY_TESTS_TROVE1_FORGE_AMT.into(),
-            ShrineUtils::TROVE1_YANG1_DEPOSIT.into() * ShrineUtils::YANG1_START_PRICE.into()
+            shrine_utils::RECOVERY_TESTS_TROVE1_FORGE_AMT.into(),
+            shrine_utils::TROVE1_YANG1_DEPOSIT.into() * shrine_utils::YANG1_START_PRICE.into()
         );
-        let trove1_threshold: Ray = ShrineUtils::YANG1_THRESHOLD.into();
+        let trove1_threshold: Ray = shrine_utils::YANG1_THRESHOLD.into();
 
         let (_, shrine_value) = shrine.get_shrine_threshold_and_value();
         let shrine_ltv: Ray = wadray::rdiv_ww(shrine.get_total_debt(), shrine_value);
@@ -2293,7 +2341,7 @@ mod TestShrine {
         let total_collateral_value_to_withdraw = whale_trove_deposit_value
             - wadray::rdiv_wr(
                 wadray::rmul_rw((trove1_ltv - 1000_u128.into()), whale_trove_forge_amt),
-                trove1_threshold * Shrine::THRESHOLD_DECREASE_FACTOR.into() * rm_threshold
+                trove1_threshold * shrine_contract::THRESHOLD_DECREASE_FACTOR.into() * rm_threshold
             );
 
         // y = z - x
@@ -2301,9 +2349,9 @@ mod TestShrine {
             - initial_collateral_value_to_withdraw;
         shrine
             .withdraw(
-                ShrineUtils::yang1_addr(),
+                shrine_utils::yang1_addr(),
                 common::WHALE_TROVE,
-                remaining_collateral_value_to_withdraw / ShrineUtils::YANG1_START_PRICE.into()
+                remaining_collateral_value_to_withdraw / shrine_utils::YANG1_START_PRICE.into()
             );
 
         // Now trove1 should be underwater, while the whale trove should still be healthy.
@@ -2317,33 +2365,33 @@ mod TestShrine {
     #[test]
     #[available_gas(20000000000)]
     fn test_recovery_mode_invariant() {
-        let shrine: IShrineDispatcher = ShrineUtils::recovery_mode_test_setup();
+        let shrine: IShrineDispatcher = shrine_utils::recovery_mode_test_setup();
 
         let yang2_deposit: Wad = (2 * WAD_ONE).into();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         // We deposit some yang2 into trove1 in order to alter its collateral composition,
         // and subsequently its threshold
-        shrine.deposit(ShrineUtils::yang2_addr(), common::TROVE_1, yang2_deposit);
+        shrine.deposit(shrine_utils::yang2_addr(), common::TROVE_1, yang2_deposit);
 
         // We then withdraw collateral from the whale trove in order to bring up the global LTV
         // and activate recovery mode
-        shrine.withdraw(ShrineUtils::yang1_addr(), common::WHALE_TROVE, (200 * WAD_ONE).into());
+        shrine.withdraw(shrine_utils::yang1_addr(), common::WHALE_TROVE, (200 * WAD_ONE).into());
 
         // Sanity check that recovery mode is active
-        let (_, threshold) = shrine.get_yang_threshold(ShrineUtils::yang1_addr());
-        assert(threshold < ShrineUtils::YANG1_THRESHOLD.into(), 'recovery mode not active');
+        let (_, threshold) = shrine.get_yang_threshold(shrine_utils::yang1_addr());
+        assert(threshold < shrine_utils::YANG1_THRESHOLD.into(), 'recovery mode not active');
 
         // Getting the trove threshold as calculated by Shrine
         let (trove_threshold, _, _, _) = shrine.get_trove_info(common::TROVE_1);
 
         // Getting the trove threshold as calculated by scaling each yang threshold individually
 
-        let (_, yang1_threshold) = shrine.get_yang_threshold(ShrineUtils::yang1_addr());
-        let (_, yang2_threshold) = shrine.get_yang_threshold(ShrineUtils::yang2_addr());
+        let (_, yang1_threshold) = shrine.get_yang_threshold(shrine_utils::yang1_addr());
+        let (_, yang2_threshold) = shrine.get_yang_threshold(shrine_utils::yang2_addr());
 
-        let yang1_deposit_value = ShrineUtils::TROVE1_YANG1_DEPOSIT.into()
-            * ShrineUtils::YANG1_START_PRICE.into();
-        let yang2_deposit_value = yang2_deposit * ShrineUtils::YANG2_START_PRICE.into();
+        let yang1_deposit_value = shrine_utils::TROVE1_YANG1_DEPOSIT.into()
+            * shrine_utils::YANG1_START_PRICE.into();
+        let yang2_deposit_value = yang2_deposit * shrine_utils::YANG2_START_PRICE.into();
 
         let alternative_threshold: Ray = wadray::wdiv_rw(
             wadray::wmul_wr(yang1_deposit_value, yang1_threshold)

--- a/src/tests/shrine/test_shrine_compound.cairo
+++ b/src/tests/shrine/test_shrine_compound.cairo
@@ -1,8 +1,8 @@
-mod TestShrineCompound {
+mod test_shrine_compound {
     use starknet::{ContractAddress, get_block_timestamp};
     use starknet::testing::{set_block_timestamp, set_contract_address};
 
-    use opus::core::shrine::Shrine;
+    use opus::core::shrine::shrine as shrine_contract;
 
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::Trove;
@@ -10,7 +10,7 @@ mod TestShrineCompound {
     use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RayZeroable, RAY_SCALE, Wad, WadZeroable};
 
-    use opus::tests::shrine::utils::ShrineUtils;
+    use opus::tests::shrine::utils::shrine_utils;
     use opus::tests::common;
 
     //
@@ -23,39 +23,39 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn test_compound_and_charge_scenario_1() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         // Advance one interval to avoid overwriting the last price
-        ShrineUtils::advance_interval();
+        shrine_utils::advance_interval();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        let start_interval: u64 = ShrineUtils::current_interval();
+        let start_interval: u64 = shrine_utils::current_interval();
 
         let trove_id: u64 = common::TROVE_1;
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang1_addr = *yangs.at(0);
         // Note that this is the price at `start_interval - 1` because we advanced one interval
         // after the last price update
-        let yang_prices: Span<Wad> = ShrineUtils::get_yang_prices(shrine, yangs);
+        let yang_prices: Span<Wad> = shrine_utils::get_yang_prices(shrine, yangs);
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
 
-        ShrineUtils::advance_prices_and_set_multiplier(
-            shrine, ShrineUtils::FEED_LEN, yangs, yang_prices
+        shrine_utils::advance_prices_and_set_multiplier(
+            shrine, shrine_utils::FEED_LEN, yangs, yang_prices
         );
 
         // Offset by 1 because `advance_prices_and_set_multiplier` updates `start_interval`.
-        let end_interval: u64 = start_interval + ShrineUtils::FEED_LEN - 1;
+        let end_interval: u64 = start_interval + shrine_utils::FEED_LEN - 1;
         // commented out because of gas usage error
         assert(
-            ShrineUtils::current_interval() == end_interval, 'wrong end interval'
+            shrine_utils::current_interval() == end_interval, 'wrong end interval'
         ); // sanity check
 
         let expected_avg_multiplier: Ray = RAY_SCALE.into();
 
-        let expected_debt: Wad = ShrineUtils::compound_for_single_yang(
-            ShrineUtils::YANG1_BASE_RATE.into(),
+        let expected_debt: Wad = shrine_utils::compound_for_single_yang(
+            shrine_utils::YANG1_BASE_RATE.into(),
             expected_avg_multiplier,
             start_interval,
             end_interval,
@@ -66,14 +66,16 @@ mod TestShrineCompound {
         assert(estimated_debt == expected_debt, 'wrong compounded debt');
 
         // Trigger charge and check interest is accrued
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.melt(common::trove1_owner_addr(), trove_id, WadZeroable::zero());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: expected_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
                         charge_from: end_interval, debt: expected_debt, last_rate_era: 1
@@ -94,26 +96,26 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn test_charge_scenario_1b() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         // Advance one interval to avoid overwriting the last price
-        ShrineUtils::advance_interval();
+        shrine_utils::advance_interval();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        ShrineUtils::trove1_forge(shrine, ShrineUtils::TROVE1_FORGE_AMT.into());
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        shrine_utils::trove1_forge(shrine, shrine_utils::TROVE1_FORGE_AMT.into());
 
-        let start_interval: u64 = ShrineUtils::current_interval();
+        let start_interval: u64 = shrine_utils::current_interval();
 
         let trove_id: u64 = common::TROVE_1;
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang1_addr = *yangs.at(0);
         // Note that this is the price at `start_interval - 1` because we advanced one interval
         // after the last price update
-        let yang_prices: Span<Wad> = ShrineUtils::get_yang_prices(shrine, yangs);
+        let yang_prices: Span<Wad> = shrine_utils::get_yang_prices(shrine, yangs);
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
 
         let num_intervals_before_skip: u64 = 5;
-        ShrineUtils::advance_prices_and_set_multiplier(
+        shrine_utils::advance_prices_and_set_multiplier(
             shrine, num_intervals_before_skip, yangs, yang_prices
         );
 
@@ -121,14 +123,14 @@ mod TestShrineCompound {
 
         // Skip to the next interval after the last price update, and then skip this interval
         // to mock no price update
-        ShrineUtils::advance_interval();
-        ShrineUtils::advance_interval();
+        shrine_utils::advance_interval();
+        shrine_utils::advance_interval();
 
         let num_intervals_after_skip: u64 = 4;
 
-        let yang_prices: Span<Wad> = ShrineUtils::get_yang_prices(shrine, yangs);
+        let yang_prices: Span<Wad> = shrine_utils::get_yang_prices(shrine, yangs);
 
-        ShrineUtils::advance_prices_and_set_multiplier(
+        shrine_utils::advance_prices_and_set_multiplier(
             shrine, num_intervals_after_skip, yangs, yang_prices
         );
 
@@ -146,16 +148,16 @@ mod TestShrineCompound {
             + (num_intervals_before_skip + num_intervals_after_skip);
         // commented out because of gas usage error
         assert(
-            ShrineUtils::current_interval() == end_interval, 'wrong end interval'
+            shrine_utils::current_interval() == end_interval, 'wrong end interval'
         ); // sanity check
 
-        let expected_avg_price: Wad = ShrineUtils::get_avg_yang_price(
+        let expected_avg_price: Wad = shrine_utils::get_avg_yang_price(
             shrine, yang1_addr, start_interval, end_interval
         );
         let expected_avg_multiplier: Ray = RAY_SCALE.into();
 
-        let expected_debt: Wad = ShrineUtils::compound_for_single_yang(
-            ShrineUtils::YANG1_BASE_RATE.into(),
+        let expected_debt: Wad = shrine_utils::compound_for_single_yang(
+            shrine_utils::YANG1_BASE_RATE.into(),
             expected_avg_multiplier,
             start_interval,
             end_interval,
@@ -165,14 +167,16 @@ mod TestShrineCompound {
         assert(estimated_debt == expected_debt, 'wrong compounded debt');
 
         // Trigger charge and check interest is accrued
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.melt(common::trove1_owner_addr(), trove_id, WadZeroable::zero());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: expected_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
                         charge_from: end_interval, debt: expected_debt, last_rate_era: 1
@@ -193,34 +197,34 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn test_charge_scenario_2() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         // Advance one interval to avoid overwriting the last price
-        ShrineUtils::advance_interval();
+        shrine_utils::advance_interval();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
         let trove_id: u64 = common::TROVE_1;
-        let yang1_addr = ShrineUtils::yang1_addr();
+        let yang1_addr = shrine_utils::yang1_addr();
 
         // Advance timestamp by 2 intervals and set price for interval - `T+LAST_UPDATED`
-        let time_to_skip: u64 = 2 * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = 2 * shrine_contract::TIME_INTERVAL;
         let last_updated_timestamp: u64 = get_block_timestamp() + time_to_skip;
         set_block_timestamp(last_updated_timestamp);
         let start_price: Wad = 2222000000000000000000_u128.into(); // 2_222 (Wad)
         let start_multiplier: Ray = RAY_SCALE.into();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.advance(yang1_addr, start_price);
         shrine.set_multiplier(start_multiplier);
 
         // Advance timestamp to `T+START`, assuming that price has not been updated since `T+LAST_UPDATED`.
         // Trigger charge to update the trove's debt to `T+START`.
         let intervals_after_last_update: u64 = 3;
-        let time_to_skip: u64 = intervals_after_last_update * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_after_last_update * shrine_contract::TIME_INTERVAL;
         let start_timestamp: u64 = last_updated_timestamp + time_to_skip;
-        let start_interval: u64 = ShrineUtils::get_interval(start_timestamp);
+        let start_interval: u64 = shrine_utils::get_interval(start_timestamp);
         set_block_timestamp(start_timestamp);
 
         shrine.deposit(yang1_addr, trove_id, WadZeroable::zero());
@@ -232,7 +236,7 @@ mod TestShrineCompound {
         // Advance timestamp to `T+END`, assuming price is still not updated since `T+LAST_UPDATED`.
         // Trigger charge to update the trove's debt to `T+END`.
         let intervals_after_last_charge: u64 = 17;
-        let time_to_skip: u64 = intervals_after_last_charge * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_after_last_charge * shrine_contract::TIME_INTERVAL;
         let end_timestamp: u64 = start_timestamp + time_to_skip;
 
         // No need for offset here because we are incrementing the intervals directly
@@ -244,8 +248,8 @@ mod TestShrineCompound {
 
         // As the price and multiplier have not been updated since `T+LAST_UPDATED`, we expect the
         // average values to be that at `T+LAST_UPDATED`.
-        let expected_debt: Wad = ShrineUtils::compound_for_single_yang(
-            ShrineUtils::YANG1_BASE_RATE.into(),
+        let expected_debt: Wad = shrine_utils::compound_for_single_yang(
+            shrine_utils::YANG1_BASE_RATE.into(),
             start_multiplier,
             start_interval,
             end_interval,
@@ -258,10 +262,12 @@ mod TestShrineCompound {
         shrine.melt(common::trove1_owner_addr(), trove_id, WadZeroable::zero());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: expected_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
                         charge_from: end_interval, debt: expected_debt, last_rate_era: 1
@@ -282,26 +288,26 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn test_charge_scenario_3() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
         // Advance one interval to avoid overwriting the last price
-        ShrineUtils::advance_interval();
+        shrine_utils::advance_interval();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
         let trove_id: u64 = common::TROVE_1;
-        let yang1_addr = ShrineUtils::yang1_addr();
+        let yang1_addr = shrine_utils::yang1_addr();
 
         // Advance timestamp by 2 intervals and set price for interval - `T+LAST_UPDATED`
-        let time_to_skip: u64 = 2 * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = 2 * shrine_contract::TIME_INTERVAL;
         let start_timestamp: u64 = get_block_timestamp() + time_to_skip;
-        let start_interval: u64 = ShrineUtils::get_interval(start_timestamp);
+        let start_interval: u64 = shrine_utils::get_interval(start_timestamp);
         set_block_timestamp(start_timestamp);
         let start_price: Wad = 2222000000000000000000_u128.into(); // 2_222 (Wad)
         let start_multiplier: Ray = RAY_SCALE.into();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.advance(yang1_addr, start_price);
         shrine.set_multiplier(start_multiplier);
 
@@ -314,7 +320,7 @@ mod TestShrineCompound {
         // Advance timestamp to `T+END`, to mock lack of price updates since `T+START/LAST_UPDATED`.
         // Trigger charge to update the trove's debt to `T+END`.
         let intervals_after_last_update: u64 = 17;
-        let time_to_skip: u64 = intervals_after_last_update * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_after_last_update * shrine_contract::TIME_INTERVAL;
         let end_timestamp: u64 = start_timestamp + time_to_skip;
 
         // No need for offset here because we are incrementing the intervals directly
@@ -322,15 +328,15 @@ mod TestShrineCompound {
         let end_interval: u64 = start_interval + intervals_after_last_update;
         set_block_timestamp(end_timestamp);
         assert(
-            ShrineUtils::current_interval() == end_interval, 'wrong end interval'
+            shrine_utils::current_interval() == end_interval, 'wrong end interval'
         ); // sanity check
 
         shrine.withdraw(yang1_addr, trove_id, WadZeroable::zero());
 
         // As the price and multiplier have not been updated since `T+START/LAST_UPDATED`, we expect the
         // average values to be that at `T+START/LAST_UPDATED`.
-        let expected_debt: Wad = ShrineUtils::compound_for_single_yang(
-            ShrineUtils::YANG1_BASE_RATE.into(),
+        let expected_debt: Wad = shrine_utils::compound_for_single_yang(
+            shrine_utils::YANG1_BASE_RATE.into(),
             start_multiplier,
             start_interval,
             end_interval,
@@ -343,10 +349,12 @@ mod TestShrineCompound {
         shrine.forge(common::trove1_owner_addr(), trove_id, WadZeroable::zero(), 0_u128.into());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: expected_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
                         charge_from: end_interval, debt: expected_debt, last_rate_era: 1
@@ -368,26 +376,26 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn test_charge_scenario_4() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
         let trove_id: u64 = common::TROVE_1;
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang1_addr = *yangs.at(0);
 
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
-        let start_interval: u64 = ShrineUtils::current_interval();
+        let start_interval: u64 = shrine_utils::current_interval();
 
         // Advance one interval to avoid overwriting the last price
-        ShrineUtils::advance_interval();
+        shrine_utils::advance_interval();
 
         // Advance timestamp by given intervals and set last updated price - `T+LAST_UPDATED`
         let intervals_to_skip: u64 = 5;
-        ShrineUtils::advance_prices_and_set_multiplier(
-            shrine, intervals_to_skip, yangs, ShrineUtils::three_yang_start_prices(),
+        shrine_utils::advance_prices_and_set_multiplier(
+            shrine, intervals_to_skip, yangs, shrine_utils::three_yang_start_prices(),
         );
         // Offset by 1 because of a single call to `advance_prices_and_set_multiplier`
         let last_updated_interval: u64 = start_interval + intervals_to_skip - 1;
@@ -395,16 +403,16 @@ mod TestShrineCompound {
         // Advance timestamp to `T+END`, to mock lack of price updates since `T+LAST_UPDATED`.
         // Trigger charge to update the trove's debt to `T+END`.
         let intervals_after_last_update: u64 = 15;
-        let time_to_skip: u64 = intervals_after_last_update * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_after_last_update * shrine_contract::TIME_INTERVAL;
         let end_timestamp: u64 = get_block_timestamp() + time_to_skip;
 
         let end_interval: u64 = start_interval + intervals_to_skip + intervals_after_last_update;
         set_block_timestamp(end_timestamp);
         assert(
-            ShrineUtils::current_interval() == end_interval, 'wrong end interval'
+            shrine_utils::current_interval() == end_interval, 'wrong end interval'
         ); // sanity check
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.withdraw(yang1_addr, trove_id, WadZeroable::zero());
 
         // Manually calculate the average since end interval does not have a cumulative value
@@ -419,8 +427,8 @@ mod TestShrineCompound {
             .into();
         let expected_avg_multiplier: Ray = RAY_SCALE.into();
 
-        let expected_debt: Wad = ShrineUtils::compound_for_single_yang(
-            ShrineUtils::YANG1_BASE_RATE.into(),
+        let expected_debt: Wad = shrine_utils::compound_for_single_yang(
+            shrine_utils::YANG1_BASE_RATE.into(),
             expected_avg_multiplier,
             start_interval,
             end_interval,
@@ -430,14 +438,16 @@ mod TestShrineCompound {
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
         assert(expected_debt == debt, 'wrong compounded debt');
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.forge(common::trove1_owner_addr(), trove_id, WadZeroable::zero(), 0_u128.into());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: expected_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
                         charge_from: end_interval, debt: expected_debt, last_rate_era: 1
@@ -459,60 +469,62 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn test_charge_scenario_5() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         let trove_id: u64 = common::TROVE_1;
-        let yang1_addr = ShrineUtils::yang1_addr();
+        let yang1_addr = shrine_utils::yang1_addr();
 
         // Advance one interval to avoid overwriting the last price
-        ShrineUtils::advance_interval();
+        shrine_utils::advance_interval();
 
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
         let yang1_addr = *yangs.at(0);
-        let yang_prices: Span<Wad> = ShrineUtils::get_yang_prices(shrine, yangs);
+        let yang_prices: Span<Wad> = shrine_utils::get_yang_prices(shrine, yangs);
 
         // Advance timestamp by given intervals and set last updated price - `T+LAST_UPDATED_BEFORE_START`'
         let intervals_to_skip: u64 = 5;
-        ShrineUtils::advance_prices_and_set_multiplier(
+        shrine_utils::advance_prices_and_set_multiplier(
             shrine, intervals_to_skip, yangs, yang_prices
         );
-        let last_updated_interval_before_start: u64 = ShrineUtils::current_interval();
+        let last_updated_interval_before_start: u64 = shrine_utils::current_interval();
 
         // Advance timestamp to `T+START`.
         let intervals_without_update_before_start: u64 = 10;
-        let time_to_skip: u64 = intervals_without_update_before_start * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_without_update_before_start
+            * shrine_contract::TIME_INTERVAL;
         let timestamp: u64 = get_block_timestamp() + time_to_skip;
         set_block_timestamp(timestamp);
-        let start_interval: u64 = ShrineUtils::current_interval();
+        let start_interval: u64 = shrine_utils::current_interval();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
 
         // Advance timestamp to `T+LAST_UPDATED_AFTER_START` and set the price
         let intervals_to_last_update_after_start: u64 = 5;
-        let time_to_skip: u64 = intervals_to_last_update_after_start * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_to_last_update_after_start
+            * shrine_contract::TIME_INTERVAL;
         let timestamp: u64 = get_block_timestamp() + time_to_skip;
         set_block_timestamp(timestamp);
-        let last_updated_interval_after_start: u64 = ShrineUtils::current_interval();
+        let last_updated_interval_after_start: u64 = shrine_utils::current_interval();
 
         let start_price: Wad = 2222000000000000000000_u128.into(); // 2_222 (Wad)
         let start_multiplier: Ray = RAY_SCALE.into();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.advance(yang1_addr, start_price);
         shrine.set_multiplier(start_multiplier);
 
         // Advance timestamp to `T+END`.
         let intervals_from_last_update_to_end: u64 = 10;
-        let time_to_skip: u64 = intervals_from_last_update_to_end * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_from_last_update_to_end * shrine_contract::TIME_INTERVAL;
         let end_timestamp: u64 = get_block_timestamp() + time_to_skip;
         set_block_timestamp(end_timestamp);
         let end_interval: u64 = start_interval
             + intervals_to_last_update_after_start
             + intervals_from_last_update_to_end;
         assert(
-            ShrineUtils::current_interval() == end_interval, 'wrong end interval'
+            shrine_utils::current_interval() == end_interval, 'wrong end interval'
         ); // sanity check
 
         shrine.withdraw(yang1_addr, trove_id, WadZeroable::zero());
@@ -546,8 +558,8 @@ mod TestShrineCompound {
             .into();
         let expected_avg_multiplier: Ray = RAY_SCALE.into();
 
-        let expected_debt: Wad = ShrineUtils::compound_for_single_yang(
-            ShrineUtils::YANG1_BASE_RATE.into(),
+        let expected_debt: Wad = shrine_utils::compound_for_single_yang(
+            shrine_utils::YANG1_BASE_RATE.into(),
             expected_avg_multiplier,
             start_interval,
             end_interval,
@@ -560,10 +572,12 @@ mod TestShrineCompound {
         shrine.forge(common::trove1_owner_addr(), trove_id, WadZeroable::zero(), 0_u128.into());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: expected_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
                         charge_from: end_interval, debt: expected_debt, last_rate_era: 1
@@ -585,49 +599,50 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn setup_charge_scenario_6() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
         let trove_id: u64 = common::TROVE_1;
-        let yang1_addr = ShrineUtils::yang1_addr();
+        let yang1_addr = shrine_utils::yang1_addr();
 
         // Advance timestamp by given intervals and set last updated price - `T+LAST_UPDATED`
         let intervals_to_skip: u64 = 5;
-        let time_to_skip: u64 = intervals_to_skip * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_to_skip * shrine_contract::TIME_INTERVAL;
         let timestamp: u64 = get_block_timestamp() + time_to_skip;
         set_block_timestamp(timestamp);
-        let last_updated_interval: u64 = ShrineUtils::current_interval();
+        let last_updated_interval: u64 = shrine_utils::current_interval();
 
         let start_price: Wad = 2222000000000000000000_u128.into(); // 2_222 (Wad)
         let start_multiplier: Ray = RAY_SCALE.into();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.advance(yang1_addr, start_price);
         shrine.set_multiplier(start_multiplier);
 
         // Advance timestamp by given intervals to `T+START` to mock missed updates.
         let intervals_after_last_update_to_start: u64 = 5;
-        let time_to_skip: u64 = intervals_after_last_update_to_start * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_after_last_update_to_start
+            * shrine_contract::TIME_INTERVAL;
         let timestamp: u64 = get_block_timestamp() + time_to_skip;
         set_block_timestamp(timestamp);
-        let start_interval: u64 = ShrineUtils::current_interval();
+        let start_interval: u64 = shrine_utils::current_interval();
 
-        ShrineUtils::trove1_deposit(shrine, ShrineUtils::TROVE1_YANG1_DEPOSIT.into());
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
-        ShrineUtils::trove1_forge(shrine, forge_amt);
+        shrine_utils::trove1_deposit(shrine, shrine_utils::TROVE1_YANG1_DEPOSIT.into());
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
+        shrine_utils::trove1_forge(shrine, forge_amt);
 
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
 
         // Advance timestamp by given intervals to `T+END`, to mock missed updates.
         let intervals_from_start_to_end: u64 = 13;
-        let time_to_skip: u64 = intervals_from_start_to_end * Shrine::TIME_INTERVAL;
+        let time_to_skip: u64 = intervals_from_start_to_end * shrine_contract::TIME_INTERVAL;
         let timestamp: u64 = get_block_timestamp() + time_to_skip;
         set_block_timestamp(timestamp);
         let end_interval: u64 = start_interval + intervals_from_start_to_end;
         assert(
-            ShrineUtils::current_interval() == end_interval, 'wrong end interval'
+            shrine_utils::current_interval() == end_interval, 'wrong end interval'
         ); // sanity check
 
         let end_price: Wad = 2333000000000000000000_u128.into(); // 2_333 (Wad)
         let start_multiplier: Ray = RAY_SCALE.into();
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.advance(yang1_addr, start_price);
         shrine.set_multiplier(start_multiplier);
 
@@ -649,8 +664,8 @@ mod TestShrineCompound {
             .into();
         let expected_avg_multiplier: Ray = RAY_SCALE.into();
 
-        let expected_debt: Wad = ShrineUtils::compound_for_single_yang(
-            ShrineUtils::YANG1_BASE_RATE.into(),
+        let expected_debt: Wad = shrine_utils::compound_for_single_yang(
+            shrine_utils::YANG1_BASE_RATE.into(),
             expected_avg_multiplier,
             start_interval,
             end_interval,
@@ -660,14 +675,16 @@ mod TestShrineCompound {
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
         assert(expected_debt == debt, 'wrong compounded debt');
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.deposit(yang1_addr, trove_id, WadZeroable::zero());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
-        let mut expected_events: Span<Shrine::Event> = array![
-            Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt }),
-            Shrine::Event::TroveUpdated(
-                Shrine::TroveUpdated {
+        let mut expected_events: Span<shrine_contract::Event> = array![
+            shrine_contract::Event::DebtTotalUpdated(
+                shrine_contract::DebtTotalUpdated { total: expected_debt }
+            ),
+            shrine_contract::Event::TroveUpdated(
+                shrine_contract::TroveUpdated {
                     trove_id,
                     trove: Trove {
                         charge_from: end_interval, debt: expected_debt, last_rate_era: 1
@@ -684,10 +701,10 @@ mod TestShrineCompound {
     #[test]
     #[available_gas(20000000000)]
     fn test_charge_scenario_7() {
-        let shrine: IShrineDispatcher = ShrineUtils::shrine_setup_with_feed();
-        let yangs: Span<ContractAddress> = ShrineUtils::three_yang_addrs();
-        ShrineUtils::advance_prices_and_set_multiplier(
-            shrine, ShrineUtils::FEED_LEN, yangs, ShrineUtils::three_yang_start_prices(),
+        let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed();
+        let yangs: Span<ContractAddress> = shrine_utils::three_yang_addrs();
+        shrine_utils::advance_prices_and_set_multiplier(
+            shrine, shrine_utils::FEED_LEN, yangs, shrine_utils::three_yang_start_prices(),
         );
 
         let trove_id: u64 = common::TROVE_1;
@@ -695,7 +712,7 @@ mod TestShrineCompound {
         let yang1_addr: ContractAddress = *yangs.at(0);
         let yang2_addr: ContractAddress = *yangs.at(1);
 
-        let mut expected_events: Array<Shrine::Event> = ArrayTrait::new();
+        let mut expected_events: Array<shrine_contract::Event> = ArrayTrait::new();
 
         // Setup base rates for calling `Shrine.update_rates`.
         // The base rates are set in the following format:
@@ -719,9 +736,9 @@ mod TestShrineCompound {
 
         // Add initial base rates for rates history to calculate compound interest
         let mut first_rate_history_to_compound: Array<Ray> = array![
-            ShrineUtils::YANG1_BASE_RATE.into(),
-            ShrineUtils::YANG2_BASE_RATE.into(),
-            ShrineUtils::YANG3_BASE_RATE.into(),
+            shrine_utils::YANG1_BASE_RATE.into(),
+            shrine_utils::YANG2_BASE_RATE.into(),
+            shrine_utils::YANG3_BASE_RATE.into(),
         ];
 
         // For first rate update, yang 1 is updated and yang 2 uses previous base rate
@@ -731,8 +748,8 @@ mod TestShrineCompound {
         ];
         let mut second_rate_history_to_compound: Array<Ray> = array![
             yang1_first_rate_update,
-            ShrineUtils::YANG2_BASE_RATE.into(),
-            ShrineUtils::YANG3_BASE_RATE.into(),
+            shrine_utils::YANG2_BASE_RATE.into(),
+            shrine_utils::YANG3_BASE_RATE.into(),
         ];
 
         // For second rate update, yang 1 uses previous base rate and yang 2 is updated
@@ -741,7 +758,7 @@ mod TestShrineCompound {
             (RAY_SCALE + 1).into(), yang2_second_rate_update, (RAY_SCALE + 1).into(),
         ];
         let mut third_rate_history_to_compound: Array<Ray> = array![
-            yang1_first_rate_update, yang2_second_rate_update, ShrineUtils::YANG3_BASE_RATE.into(),
+            yang1_first_rate_update, yang2_second_rate_update, shrine_utils::YANG3_BASE_RATE.into(),
         ];
 
         // For third rate update, yang 1 is updated and yang 2 uses previous base rate
@@ -750,7 +767,7 @@ mod TestShrineCompound {
             yang1_third_rate_update, (RAY_SCALE + 1).into(), (RAY_SCALE + 1).into(),
         ];
         let mut fourth_rate_history_to_compound: Array<Ray> = array![
-            yang1_third_rate_update, yang2_second_rate_update, ShrineUtils::YANG3_BASE_RATE.into(),
+            yang1_third_rate_update, yang2_second_rate_update, shrine_utils::YANG3_BASE_RATE.into(),
         ];
 
         let mut yang_base_rates_history_to_update: Array<Span<Ray>> = array![
@@ -776,7 +793,7 @@ mod TestShrineCompound {
         // the base rates set in `add_yang` and the first base rate update
         let num_eras: u64 = num_base_rate_updates + 1;
         let current_timestamp: u64 = get_block_timestamp();
-        let start_interval: u64 = ShrineUtils::current_interval();
+        let start_interval: u64 = shrine_utils::current_interval();
         let end_interval: u64 = start_interval + BASE_RATE_UPDATE_SPACING * num_eras;
         let charging_period: u64 = end_interval - start_interval;
 
@@ -798,12 +815,12 @@ mod TestShrineCompound {
         let mut avg_yang_prices_by_era: Array<Span<Wad>> = ArrayTrait::new();
 
         // Deposit yangs into trove and forge debt
-        set_contract_address(ShrineUtils::admin());
-        let yang1_deposit_amt: Wad = ShrineUtils::TROVE1_YANG1_DEPOSIT.into();
+        set_contract_address(shrine_utils::admin());
+        let yang1_deposit_amt: Wad = shrine_utils::TROVE1_YANG1_DEPOSIT.into();
         shrine.deposit(yang1_addr, trove_id, yang1_deposit_amt);
-        let yang2_deposit_amt: Wad = ShrineUtils::TROVE1_YANG2_DEPOSIT.into();
+        let yang2_deposit_amt: Wad = shrine_utils::TROVE1_YANG2_DEPOSIT.into();
         shrine.deposit(yang2_addr, trove_id, yang2_deposit_amt);
-        let forge_amt: Wad = ShrineUtils::TROVE1_FORGE_AMT.into();
+        let forge_amt: Wad = shrine_utils::TROVE1_FORGE_AMT.into();
         shrine.forge(trove1_owner, trove_id, forge_amt, 0_u128.into());
 
         let mut yangs_deposited: Array<Wad> = array![
@@ -827,12 +844,12 @@ mod TestShrineCompound {
             }
 
             // Fetch the latest yang prices
-            let yang_prices: Span<Wad> = ShrineUtils::get_yang_prices(shrine, yangs);
+            let yang_prices: Span<Wad> = shrine_utils::get_yang_prices(shrine, yangs);
 
             // First, we advance an interval so the last price is not overwritten.
             // Next, Advance the prices by the number of intervals between each base rate update
-            ShrineUtils::advance_interval();
-            ShrineUtils::advance_prices_and_set_multiplier(
+            shrine_utils::advance_interval();
+            shrine_utils::advance_prices_and_set_multiplier(
                 shrine, BASE_RATE_UPDATE_SPACING, yangs, yang_prices
             );
 
@@ -844,7 +861,7 @@ mod TestShrineCompound {
             loop {
                 match yangs_copy.pop_front() {
                     Option::Some(yang) => {
-                        let yang_avg_price: Wad = ShrineUtils::get_avg_yang_price(
+                        let yang_avg_price: Wad = shrine_utils::get_avg_yang_price(
                             shrine, *yang, era_start_interval, era_end_interval
                         );
                         avg_yang_prices_for_era.append(yang_avg_price);
@@ -865,7 +882,7 @@ mod TestShrineCompound {
                     .pop_front()
                     .unwrap();
 
-                set_contract_address(ShrineUtils::admin());
+                set_contract_address(shrine_utils::admin());
                 shrine.update_rates(yangs, yang_base_rates_to_update);
                 let expected_era: u64 = i + 2;
                 assert(shrine.get_current_rate_era() == expected_era, 'wrong rate era');
@@ -889,8 +906,8 @@ mod TestShrineCompound {
 
                 expected_events
                     .append(
-                        Shrine::Event::YangRatesUpdated(
-                            Shrine::YangRatesUpdated {
+                        shrine_contract::Event::YangRatesUpdated(
+                            shrine_contract::YangRatesUpdated {
                                 rate_era: expected_era,
                                 current_interval: era_end_interval,
                                 yangs: yangs,
@@ -908,7 +925,7 @@ mod TestShrineCompound {
         };
 
         let (_, _, _, debt) = shrine.get_trove_info(trove_id);
-        let expected_debt: Wad = ShrineUtils::compound(
+        let expected_debt: Wad = shrine_utils::compound(
             yang_base_rates_history_to_compound.span(),
             rate_update_intervals.span(),
             yangs_deposited.span(),
@@ -921,18 +938,20 @@ mod TestShrineCompound {
 
         assert(debt == expected_debt, 'wrong compounded debt');
 
-        set_contract_address(ShrineUtils::admin());
+        set_contract_address(shrine_utils::admin());
         shrine.withdraw(yang1_addr, trove_id, WadZeroable::zero());
         assert(shrine.get_total_debt() == expected_debt, 'debt not updated');
 
         expected_events
             .append(
-                Shrine::Event::DebtTotalUpdated(Shrine::DebtTotalUpdated { total: expected_debt })
+                shrine_contract::Event::DebtTotalUpdated(
+                    shrine_contract::DebtTotalUpdated { total: expected_debt }
+                )
             );
         expected_events
             .append(
-                Shrine::Event::TroveUpdated(
-                    Shrine::TroveUpdated {
+                shrine_contract::Event::TroveUpdated(
+                    shrine_contract::TroveUpdated {
                         trove_id,
                         trove: Trove {
                             charge_from: end_interval, debt: expected_debt, last_rate_era: num_eras

--- a/src/tests/shrine/utils.cairo
+++ b/src/tests/shrine/utils.cairo
@@ -1,4 +1,4 @@
-mod ShrineUtils {
+mod shrine_utils {
     use integer::{
         U128sFromFelt252Result, u128s_from_felt252, u128_safe_divmod, u128_try_as_non_zero
     };
@@ -10,8 +10,8 @@ mod ShrineUtils {
     use starknet::contract_address::ContractAddressZeroable;
     use starknet::testing::{set_block_timestamp, set_contract_address};
 
-    use opus::core::shrine::Shrine;
-    use opus::core::roles::ShrineRoles;
+    use opus::core::shrine::shrine as shrine_contract;
+    use opus::core::roles::shrine_roles;
 
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
@@ -115,7 +115,7 @@ mod ShrineUtils {
     // Returns the interval ID for the given timestamp
     #[inline(always)]
     fn get_interval(timestamp: u64) -> u64 {
-        timestamp / Shrine::TIME_INTERVAL
+        timestamp / shrine_contract::TIME_INTERVAL
     }
 
     #[inline(always)]
@@ -176,7 +176,9 @@ mod ShrineUtils {
             contract_address_to_felt252(admin()), YIN_NAME, YIN_SYMBOL,
         ];
 
-        let shrine_class_hash: ClassHash = class_hash_try_from_felt252(Shrine::TEST_CLASS_HASH)
+        let shrine_class_hash: ClassHash = class_hash_try_from_felt252(
+            shrine_contract::TEST_CLASS_HASH
+        )
             .unwrap();
         let (shrine_addr, _) = deploy_syscall(shrine_class_hash, 0, calldata.span(), false)
             .unwrap_syscall();
@@ -187,7 +189,7 @@ mod ShrineUtils {
     fn make_root(shrine_addr: ContractAddress, user: ContractAddress) {
         set_contract_address(admin());
         IAccessControlDispatcher { contract_address: shrine_addr }
-            .grant_role(ShrineRoles::all_roles(), user);
+            .grant_role(shrine_roles::all_roles(), user);
         set_contract_address(ContractAddressZeroable::zero());
     }
 
@@ -284,7 +286,7 @@ mod ShrineUtils {
 
             shrine.set_multiplier(RAY_ONE.into());
 
-            timestamp += Shrine::TIME_INTERVAL;
+            timestamp += shrine_contract::TIME_INTERVAL;
 
             idx += 1;
         };
@@ -556,7 +558,7 @@ mod ShrineUtils {
                 intervals_in_era = *yang_rate_update_intervals[i + 1] - era_start_interval;
             }
 
-            let t: u128 = intervals_in_era.into() * Shrine::TIME_INTERVAL_DIV_YEAR;
+            let t: u128 = intervals_in_era.into() * shrine_contract::TIME_INTERVAL_DIV_YEAR;
 
             debt *= exp(wadray::rmul_rw(rate, t.into()));
             i += 1;
@@ -568,7 +570,7 @@ mod ShrineUtils {
         base_rate: Ray, avg_multiplier: Ray, start_interval: u64, end_interval: u64, debt: Wad,
     ) -> Wad {
         let intervals: u128 = (end_interval - start_interval).into();
-        let t: Wad = (intervals * Shrine::TIME_INTERVAL_DIV_YEAR).into();
+        let t: Wad = (intervals * shrine_contract::TIME_INTERVAL_DIV_YEAR).into();
         debt * exp(wadray::rmul_rw(base_rate * avg_multiplier, t))
     }
 

--- a/src/tests/utils/mock_access_control.cairo
+++ b/src/tests/utils/mock_access_control.cairo
@@ -1,5 +1,5 @@
 #[starknet::contract]
-mod MockAccessControl {
+mod mock_access_control {
     use starknet::ContractAddress;
 
     use opus::utils::access_control::access_control_component;

--- a/src/tests/utils/test_access_control.cairo
+++ b/src/tests/utils/test_access_control.cairo
@@ -1,4 +1,4 @@
-mod tests {
+mod test_access_control {
     use starknet::contract_address::{
         ContractAddress, ContractAddressZeroable, contract_address_try_from_felt252
     };
@@ -10,7 +10,7 @@ mod tests {
     };
 
     use opus::tests::common;
-    use opus::tests::utils::mock_access_control::MockAccessControl;
+    use opus::tests::utils::mock_access_control::mock_access_control;
 
     //
     // Constants
@@ -38,11 +38,11 @@ mod tests {
     // Test setup
     //
 
-    fn state() -> MockAccessControl::ContractState {
-        MockAccessControl::contract_state_for_testing()
+    fn state() -> mock_access_control::ContractState {
+        mock_access_control::contract_state_for_testing()
     }
 
-    fn setup(caller: ContractAddress) -> MockAccessControl::ContractState {
+    fn setup(caller: ContractAddress) -> mock_access_control::ContractState {
         let mut state = state();
         state.access_control.initializer(admin(), Option::None);
 
@@ -52,7 +52,7 @@ mod tests {
     }
 
     fn set_pending_admin(
-        ref state: MockAccessControl::ContractState,
+        ref state: mock_access_control::ContractState,
         caller: ContractAddress,
         pending_admin: ContractAddress
     ) {
@@ -60,7 +60,7 @@ mod tests {
         state.set_pending_admin(pending_admin);
     }
 
-    fn default_grant(ref state: MockAccessControl::ContractState) {
+    fn default_grant(ref state: mock_access_control::ContractState) {
         let u = user();
         state.grant_role(R1, u);
         state.grant_role(R2, u);

--- a/src/tests/utils/test_exp.cairo
+++ b/src/tests/utils/test_exp.cairo
@@ -1,4 +1,4 @@
-mod tests {
+mod test_exp {
     use opus::utils::exp::exp;
     use opus::utils::wadray;
     use opus::utils::wadray::{WAD_ONE, WAD_PERCENT, Wad};

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -1,4 +1,4 @@
-mod tests {
+mod test_math {
     use debug::PrintTrait;
 
     use integer::BoundedU128;

--- a/src/tests/utils/test_reentrancy_guard.cairo
+++ b/src/tests/utils/test_reentrancy_guard.cairo
@@ -1,14 +1,14 @@
-mod tests {
-    use opus::utils::reentrancy_guard::ReentrancyGuard;
+mod test_reentrancy_guard {
+    use opus::utils::reentrancy_guard::reentrancy_guard;
 
     fn guarded_func(recurse_once: bool) {
-        ReentrancyGuard::start();
+        reentrancy_guard::start();
 
         if recurse_once {
             guarded_func(false);
         }
 
-        ReentrancyGuard::end();
+        reentrancy_guard::end();
     }
 
     #[test]

--- a/src/tests/utils/test_wadray.cairo
+++ b/src/tests/utils/test_wadray.cairo
@@ -1,4 +1,4 @@
-mod tests {
+mod test_wadray {
     use opus::utils::wadray;
     use opus::utils::wadray::{
         DIFF, fixed_point_to_wad, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, rdiv_wr, rmul_rw, rmul_wr, Wad,

--- a/src/tests/utils/test_wadray_signed.cairo
+++ b/src/tests/utils/test_wadray_signed.cairo
@@ -1,4 +1,4 @@
-mod tests {
+mod test_wadray_signed {
     use debug::PrintTrait;
     use math::Oneable;
 

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -5,9 +5,9 @@ use opus::utils::wadray::Wad;
 
 #[derive(Copy, Drop, PartialEq, Serde)]
 enum YangSuspensionStatus {
-    None: (),
-    Temporary: (),
-    Permanent: ()
+    None,
+    Temporary,
+    Permanent
 }
 
 #[derive(Copy, Drop, Serde)]
@@ -79,7 +79,7 @@ struct Request {
 // Pragma
 //
 
-mod Pragma {
+mod pragma {
     #[derive(Copy, Drop, Serde)]
     enum DataType {
         Spot: u256,

--- a/src/utils/reentrancy_guard.cairo
+++ b/src/utils/reentrancy_guard.cairo
@@ -1,4 +1,4 @@
-mod ReentrancyGuard {
+mod reentrancy_guard {
     use starknet::SyscallResultTrait;
 
     use starknet::storage_access::StoreBool;


### PR DESCRIPTION
As per this [comment](https://github.com/lindy-labs/opus_contracts/pull/474#discussion_r1369126629), we should adopt the naming [conventions](https://cairo-by-example.com/examples/naming_convention/) for Starknet.

One complication is that in the test suite, the name of the imported contract module clashes with the local instance of the deployed contract in a test (e.g. `use opus::core::shrine::shrine` and `let shrine = shrine_deploy();`). The current workaround is to qualify the imported contract module i.e. `use opus::core::shrine::shrine as shrine_contract;`.

I have also renamed all `FlashMint` and `Flashmint` to `flash_mint` for consistency.