### PR TITLE
style: import formatting

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -18,3 +18,6 @@ starknet = ">=2.3.0"
 
 [scripts]
 ktn = "katana --disable-fee --accounts 6 --seed 0x6f707573"
+
+[tool.fmt]
+sort-module-level-items = true

--- a/src/core/abbot.cairo
+++ b/src/core/abbot.cairo
@@ -1,13 +1,12 @@
 #[starknet::contract]
 mod abbot {
-    use starknet::{ContractAddress, get_caller_address};
-
     use opus::interfaces::IAbbot::IAbbot;
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::AssetBalance;
     use opus::utils::reentrancy_guard::reentrancy_guard_component;
     use opus::utils::wadray::{BoundedWad, Wad};
+    use starknet::{ContractAddress, get_caller_address};
 
     // 
     // Components 

--- a/src/core/absorber.cairo
+++ b/src/core/absorber.cairo
@@ -8,18 +8,16 @@
 mod absorber {
     use cmp::min;
     use integer::u256_safe_divmod;
-    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
-
     use opus::core::roles::absorber_roles;
-
     use opus::interfaces::IAbsorber::{IAbsorber, IBlesserDispatcher, IBlesserDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::{AssetBalance, DistributionInfo, Provision, Request, Reward};
     use opus::utils::access_control::access_control_component;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RayZeroable, Wad, WadZeroable};
+    use opus::utils::wadray;
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
 
     //
     // Components
@@ -341,7 +339,7 @@ mod absorber {
         }
 
 
-        // Returns the absorbed assets and rewards that a provider will receive based on 
+        // Returns the absorbed assets and rewards that a provider will receive based on
         // the current on-chain conditions
         fn preview_reap(
             self: @ContractState, provider: ContractAddress
@@ -1058,7 +1056,7 @@ mod absorber {
         }
 
         // Helper function to loop over all rewards and calculate the amounts for a provider.
-        // Returns an array of `AssetBalance` struct for accumulated rewards, or accumulated plus 
+        // Returns an array of `AssetBalance` struct for accumulated rewards, or accumulated plus
         // pending rewards, depending on the `include_pending_rewards` flag.
         fn get_provider_rewards(
             self: @ContractState,

--- a/src/core/allocator.cairo
+++ b/src/core/allocator.cairo
@@ -1,12 +1,10 @@
 #[starknet::contract]
 mod allocator {
-    use starknet::ContractAddress;
-
     use opus::core::roles::allocator_roles;
-
     use opus::interfaces::IAllocator::IAllocator;
     use opus::utils::access_control::access_control_component;
     use opus::utils::wadray::{Ray, RayZeroable, RAY_ONE};
+    use starknet::ContractAddress;
 
     //
     // Components

--- a/src/core/caretaker.cairo
+++ b/src/core/caretaker.cairo
@@ -1,21 +1,19 @@
 #[starknet::contract]
 mod caretaker {
     use cmp::min;
-    use starknet::{ContractAddress, get_caller_address, get_contract_address};
-
     use opus::core::roles::caretaker_roles;
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::ICaretaker::ICaretaker;
-    use opus::interfaces::IEqualizer::{IEqualizerDispatcher, IEqualizerDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use opus::interfaces::IEqualizer::{IEqualizerDispatcher, IEqualizerDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::AssetBalance;
     use opus::utils::access_control::access_control_component;
     use opus::utils::reentrancy_guard::reentrancy_guard_component;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RAY_ONE, Wad};
+    use opus::utils::wadray;
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
 
     //
     // Components

--- a/src/core/controller.cairo
+++ b/src/core/controller.cairo
@@ -1,17 +1,15 @@
 #[starknet::contract]
 mod controller {
-    use starknet::{ContractAddress, contract_address, get_block_timestamp};
-
     use opus::core::roles::controller_roles;
-
     use opus::interfaces::IController::IController;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::utils::access_control::access_control_component;
     use opus::utils::math;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Wad, Ray, RAY_ONE};
-    use opus::utils::wadray_signed;
+    use opus::utils::wadray;
     use opus::utils::wadray_signed::{SignedRay, SignedRayZeroable};
+    use opus::utils::wadray_signed;
+    use starknet::{ContractAddress, contract_address, get_block_timestamp};
 
     //
     // Components
@@ -24,7 +22,7 @@ mod controller {
         access_control_component::AccessControl<ContractState>;
     impl AccessControlHelpers = access_control_component::AccessControlHelpers<ContractState>;
 
-    // 
+    //
     // Constants
     //
 
@@ -36,7 +34,7 @@ mod controller {
     const MIN_MULTIPLIER: u128 = 200000000000000000000000000; // 0.2
     const MAX_MULTIPLIER: u128 = 2000000000000000000000000000; // 2
 
-    // 
+    //
     // Storage
     //
 

--- a/src/core/equalizer.cairo
+++ b/src/core/equalizer.cairo
@@ -1,15 +1,13 @@
 #[starknet::contract]
 mod equalizer {
-    use starknet::ContractAddress;
-
     use opus::core::roles::equalizer_roles;
-
     use opus::interfaces::IAllocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
     use opus::interfaces::IEqualizer::IEqualizer;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::utils::access_control::access_control_component;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Ray, Wad, WadZeroable};
+    use opus::utils::wadray;
+    use starknet::ContractAddress;
 
     //
     // Components

--- a/src/core/flash_mint.cairo
+++ b/src/core/flash_mint.cairo
@@ -16,13 +16,12 @@
 
 #[starknet::contract]
 mod flash_mint {
-    use starknet::{ContractAddress, get_caller_address};
-
     use opus::interfaces::IFlashBorrower::{IFlashBorrowerDispatcher, IFlashBorrowerDispatcherTrait};
     use opus::interfaces::IFlashMint::IFlashMint;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::utils::reentrancy_guard::reentrancy_guard_component;
     use opus::utils::wadray::Wad;
+    use starknet::{ContractAddress, get_caller_address};
 
     // The value of keccak256("ERC3156FlashBorrower.onFlashLoan") as per EIP3156
     // it is supposed to be returned from the onFlashLoan function by the receiver

--- a/src/core/gate.cairo
+++ b/src/core/gate.cairo
@@ -1,13 +1,12 @@
 #[starknet::contract]
 mod gate {
-    use starknet::{ContractAddress, get_caller_address, get_contract_address};
-
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::IGate;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::utils::math::pow;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Wad, WadZeroable, WAD_DECIMALS, WAD_ONE};
+    use opus::utils::wadray;
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
 
     // As the Gate is similar to a ERC-4626 vault, it therefore faces a similar issue whereby
     // the first depositor can artificially inflate a share price by depositing the smallest

--- a/src/core/purger.cairo
+++ b/src/core/purger.cairo
@@ -1,20 +1,18 @@
 #[starknet::contract]
 mod purger {
     use cmp::min;
-    use starknet::{ContractAddress, get_caller_address};
-
     use opus::core::roles::purger_roles;
-
     use opus::interfaces::IAbsorber::{IAbsorberDispatcher, IAbsorberDispatcherTrait};
     use opus::interfaces::IOracle::{IOracleDispatcher, IOracleDispatcherTrait};
     use opus::interfaces::IPurger::IPurger;
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::types::AssetBalance;
     use opus::utils::access_control::access_control_component;
     use opus::utils::reentrancy_guard::reentrancy_guard_component;
-    use opus::types::AssetBalance;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RayZeroable, RAY_ONE, Wad, WadZeroable};
+    use opus::utils::wadray;
+    use starknet::{ContractAddress, get_caller_address};
 
     //
     // Components
@@ -466,7 +464,7 @@ mod purger {
             // return the maximum penalty to avoid division by zero/overflow, or the largest possible penalty,
             // whichever is smaller.
             if threshold < MIN_THRESHOLD_FOR_PENALTY_CALCS.into() {
-                // This check is to avoid overflow in the event that the 
+                // This check is to avoid overflow in the event that the
                 // trove's LTV is also extremely low.
                 if ltv >= MIN_THRESHOLD_FOR_PENALTY_CALCS.into() {
                     return Option::Some(
@@ -586,7 +584,7 @@ mod purger {
         // return the minimum penalty to avoid division by zero/overflow, or the largest possible penalty,
         // whichever is smaller.
         if threshold < MIN_THRESHOLD_FOR_PENALTY_CALCS.into() {
-            // This check is to avoid overflow in the event that the 
+            // This check is to avoid overflow in the event that the
             // trove's LTV is also extremely low.
             if ltv >= MIN_THRESHOLD_FOR_PENALTY_CALCS.into() {
                 return Option::Some(min(MAX_PENALTY.into(), (RAY_ONE.into() - ltv) / ltv));

--- a/src/core/sentinel.cairo
+++ b/src/core/sentinel.cairo
@@ -1,18 +1,16 @@
 #[starknet::contract]
 mod sentinel {
-    use starknet::{get_block_timestamp, get_caller_address};
-    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
-
     use opus::core::roles::sentinel_roles;
-
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::ISentinel::ISentinel;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::YangSuspensionStatus;
     use opus::utils::access_control::access_control_component;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Ray, Wad, WadZeroable};
+    use opus::utils::wadray;
+    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
+    use starknet::{get_block_timestamp, get_caller_address};
 
     //
     // Components

--- a/src/core/shrine.cairo
+++ b/src/core/shrine.cairo
@@ -1,13 +1,9 @@
 #[starknet::contract]
 mod shrine {
-    use core::starknet::event::EventEmitter;
     use cmp::{max, min};
+    use core::starknet::event::EventEmitter;
     use integer::{BoundedU256, U256Zeroable, u256_safe_div_rem};
-    use starknet::{get_block_timestamp, get_caller_address};
-    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
-
     use opus::core::roles::shrine_roles;
-
     use opus::interfaces::IERC20::IERC20;
     use opus::interfaces::IShrine::IShrine;
     use opus::types::{
@@ -15,10 +11,12 @@ mod shrine {
     };
     use opus::utils::access_control::access_control_component;
     use opus::utils::exp::{exp, neg_exp};
-    use opus::utils::wadray;
     use opus::utils::wadray::{
         BoundedRay, Ray, RayZeroable, RAY_ONE, Wad, WadZeroable, WAD_DECIMALS, WAD_ONE, WAD_SCALE
     };
+    use opus::utils::wadray;
+    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
+    use starknet::{get_block_timestamp, get_caller_address};
 
     //
     // Components

--- a/src/external/pragma.cairo
+++ b/src/external/pragma.cairo
@@ -7,19 +7,17 @@
 
 #[starknet::contract]
 mod pragma {
-    use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
-
     use opus::core::roles::pragma_roles;
-
-    use opus::interfaces::external::{IPragmaOracleDispatcher, IPragmaOracleDispatcherTrait};
     use opus::interfaces::IOracle::IOracle;
     use opus::interfaces::IPragma::IPragma;
-    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::interfaces::external::{IPragmaOracleDispatcher, IPragmaOracleDispatcherTrait};
     use opus::types::pragma::{DataType, PricesResponse, PriceValidityThresholds, YangSettings};
     use opus::utils::access_control::access_control_component;
-    use opus::utils::wadray;
     use opus::utils::wadray::Wad;
+    use opus::utils::wadray;
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
 
     //
     // Components

--- a/src/interfaces/IAbbot.cairo
+++ b/src/interfaces/IAbbot.cairo
@@ -1,8 +1,6 @@
-use starknet::ContractAddress;
-
 use opus::types::AssetBalance;
 use opus::utils::wadray::Wad;
-
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IAbbot<TContractState> {

--- a/src/interfaces/IAbsorber.cairo
+++ b/src/interfaces/IAbsorber.cairo
@@ -1,7 +1,6 @@
-use starknet::ContractAddress;
-
 use opus::types::{AssetBalance, DistributionInfo, Provision, Request, Reward};
 use opus::utils::wadray::{Ray, Wad};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IAbsorber<TContractState> {

--- a/src/interfaces/IAllocator.cairo
+++ b/src/interfaces/IAllocator.cairo
@@ -1,6 +1,5 @@
-use starknet::ContractAddress;
-
 use opus::utils::wadray::Ray;
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IAllocator<TContractState> {

--- a/src/interfaces/IController.cairo
+++ b/src/interfaces/IController.cairo
@@ -1,7 +1,6 @@
-use starknet::ContractAddress;
-
 use opus::utils::wadray::Ray;
 use opus::utils::wadray_signed::SignedRay;
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IController<TContractState> {

--- a/src/interfaces/IEqualizer.cairo
+++ b/src/interfaces/IEqualizer.cairo
@@ -1,6 +1,5 @@
-use starknet::ContractAddress;
-
 use opus::utils::wadray::Wad;
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IEqualizer<TContractState> {

--- a/src/interfaces/IGate.cairo
+++ b/src/interfaces/IGate.cairo
@@ -1,6 +1,5 @@
-use starknet::ContractAddress;
-
 use opus::utils::wadray::Wad;
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IGate<TContractState> {

--- a/src/interfaces/IPurger.cairo
+++ b/src/interfaces/IPurger.cairo
@@ -1,7 +1,6 @@
-use starknet::ContractAddress;
-
 use opus::types::AssetBalance;
 use opus::utils::wadray::{Ray, Wad};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IPurger<TContractState> {

--- a/src/interfaces/ISentinel.cairo
+++ b/src/interfaces/ISentinel.cairo
@@ -1,6 +1,5 @@
-use starknet::ContractAddress;
-
 use opus::utils::wadray::{Ray, Wad};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait ISentinel<TContractState> {

--- a/src/interfaces/IShrine.cairo
+++ b/src/interfaces/IShrine.cairo
@@ -1,9 +1,8 @@
-use starknet::ContractAddress;
-
 use opus::types::{
     ExceptionalYangRedistribution, Trove, YangBalance, YangRedistribution, YangSuspensionStatus
 };
 use opus::utils::wadray::{Ray, Wad};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IShrine<TContractState> {

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,3 +1,4 @@
+mod types;
 mod core {
     mod abbot;
     mod absorber;
@@ -18,14 +19,13 @@ mod external {
 }
 
 mod interfaces {
-    mod external;
     mod IAbbot;
     mod IAbsorber;
     mod IAllocator;
     mod ICaretaker;
     mod IController;
-    mod IEqualizer;
     mod IERC20;
+    mod IEqualizer;
     mod IFlashBorrower;
     mod IFlashMint;
     mod IGate;
@@ -34,9 +34,8 @@ mod interfaces {
     mod IPurger;
     mod ISentinel;
     mod IShrine;
+    mod external;
 }
-
-mod types;
 
 mod utils {
     mod access_control;
@@ -55,6 +54,8 @@ mod mock {
 
 #[cfg(test)]
 mod tests {
+    mod common;
+    mod erc20;
     mod abbot {
         mod test_abbot;
         mod utils;
@@ -68,12 +69,10 @@ mod tests {
         mod test_caretaker;
         mod utils;
     }
-    mod common;
     mod controller {
         mod test_controller;
         mod utils;
     }
-    mod erc20;
     mod equalizer {
         mod test_allocator;
         mod test_equalizer;
@@ -115,7 +114,7 @@ mod tests {
         mod test_exp;
         mod test_math;
         mod test_reentrancy_guard;
-        mod test_wadray_signed;
         mod test_wadray;
+        mod test_wadray_signed;
     }
 }

--- a/src/mock/oracle.cairo
+++ b/src/mock/oracle.cairo
@@ -1,8 +1,8 @@
+use opus::utils::wadray::Wad;
 // mock oracle contract for storing token prices
 // and advancing shrine on request
 
 use starknet::ContractAddress;
-use opus::utils::wadray::Wad;
 
 #[starknet::interface]
 trait MockOracle<TContractState> {

--- a/src/tests/abbot/test_abbot.cairo
+++ b/src/tests/abbot/test_abbot.cairo
@@ -1,24 +1,20 @@
 mod test_abbot {
-    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
-    use starknet::testing::set_contract_address;
-
+    use debug::PrintTrait;
     use opus::core::abbot::abbot as abbot_contract;
     use opus::core::sentinel::sentinel as sentinel_contract;
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::AssetBalance;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Wad, WadZeroable, WAD_SCALE};
-
     use opus::tests::abbot::utils::abbot_utils;
+    use opus::tests::common;
     use opus::tests::sentinel::utils::sentinel_utils;
     use opus::tests::shrine::utils::shrine_utils;
-    use opus::tests::common;
-
-    use debug::PrintTrait;
+    use opus::types::AssetBalance;
+    use opus::utils::wadray::{Wad, WadZeroable, WAD_SCALE};
+    use opus::utils::wadray;
+    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
+    use starknet::testing::set_contract_address;
 
     //
     // Tests

--- a/src/tests/abbot/utils.cairo
+++ b/src/tests/abbot/utils.cairo
@@ -1,25 +1,22 @@
 mod abbot_utils {
-    use starknet::{
-        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
-        deploy_syscall, SyscallResultTrait
-    };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::set_contract_address;
-
     use opus::core::abbot::abbot as abbot_contract;
     use opus::core::roles::{sentinel_roles, shrine_roles};
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::Wad;
-
     use opus::tests::common;
     use opus::tests::sentinel::utils::sentinel_utils;
     use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::Wad;
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::set_contract_address;
+    use starknet::{
+        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
+        deploy_syscall, SyscallResultTrait
+    };
 
     //
     // Constants

--- a/src/tests/absorber/mock_blesser.cairo
+++ b/src/tests/absorber/mock_blesser.cairo
@@ -1,12 +1,10 @@
 #[starknet::contract]
 mod mock_blesser {
-    use starknet::{ContractAddress, get_contract_address};
-
     use opus::core::roles::blesser_roles;
-
     use opus::interfaces::IAbsorber::IBlesser;
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::utils::access_control::access_control_component;
+    use starknet::{ContractAddress, get_contract_address};
 
     component!(path: access_control_component, storage: access_control, event: AccessControlEvent);
 

--- a/src/tests/absorber/test_absorber.cairo
+++ b/src/tests/absorber/test_absorber.cairo
@@ -1,32 +1,28 @@
 mod test_absorber {
     use cmp::min;
+    use debug::PrintTrait;
     use integer::BoundedU256;
-    use starknet::{ContractAddress, contract_address_try_from_felt252, get_block_timestamp};
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
     use opus::core::absorber::absorber as absorber_contract;
     use opus::core::roles::absorber_roles;
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IAbsorber::{
         IAbsorberDispatcher, IAbsorberDispatcherTrait, IBlesserDispatcher, IBlesserDispatcherTrait
     };
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::absorber::utils::absorber_utils;
+    use opus::tests::common::{AddressIntoSpan, RewardPartialEq};
+    use opus::tests::common;
+    use opus::tests::shrine::utils::shrine_utils;
     use opus::types::{AssetBalance, DistributionInfo, Provision, Request, Reward};
     use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
     use opus::utils::wadray::{
         BoundedWad, Ray, RAY_ONE, RAY_SCALE, Wad, WadZeroable, WAD_ONE, WAD_SCALE
     };
-
-    use opus::tests::absorber::utils::absorber_utils;
-    use opus::tests::common;
-    use opus::tests::common::{AddressIntoSpan, RewardPartialEq};
-    use opus::tests::shrine::utils::shrine_utils;
-
-    use debug::PrintTrait;
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
+    use starknet::{ContractAddress, contract_address_try_from_felt252, get_block_timestamp};
 
     //
     // Tests - Setup

--- a/src/tests/absorber/utils.cairo
+++ b/src/tests/absorber/utils.cairo
@@ -1,16 +1,9 @@
 mod absorber_utils {
     use cmp::min;
+    use debug::PrintTrait;
     use integer::BoundedU256;
-    use starknet::{
-        deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
-        contract_address_to_felt252, contract_address_try_from_felt252, SyscallResultTrait
-    };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::set_contract_address;
-
     use opus::core::absorber::absorber as absorber_contract;
     use opus::core::roles::absorber_roles;
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IAbsorber::{
         IAbsorberDispatcher, IAbsorberDispatcherTrait, IBlesserDispatcher, IBlesserDispatcherTrait
@@ -21,18 +14,21 @@ mod absorber_utils {
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::{AssetBalance, DistributionInfo, Reward};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, Wad, WadZeroable, WAD_ONE, WAD_SCALE};
-
     use opus::tests::abbot::utils::abbot_utils;
     use opus::tests::absorber::mock_blesser::mock_blesser;
     use opus::tests::common;
     use opus::tests::erc20::ERC20;
     use opus::tests::shrine::utils::shrine_utils;
-
-    use debug::PrintTrait;
+    use opus::types::{AssetBalance, DistributionInfo, Reward};
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::{Ray, Wad, WadZeroable, WAD_ONE, WAD_SCALE};
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::set_contract_address;
+    use starknet::{
+        deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
+        contract_address_to_felt252, contract_address_try_from_felt252, SyscallResultTrait
+    };
 
     //
     // Constants

--- a/src/tests/caretaker/test_caretaker.cairo
+++ b/src/tests/caretaker/test_caretaker.cairo
@@ -1,25 +1,21 @@
 mod test_caretaker {
     use debug::PrintTrait;
-    use starknet::{ContractAddress};
-    use starknet::testing::set_contract_address;
-
     use opus::core::caretaker::caretaker as caretaker_contract;
     use opus::core::roles::{caretaker_roles, shrine_roles};
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::ICaretaker::{ICaretakerDispatcher, ICaretakerDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::AssetBalance;
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, Wad, WadZeroable, WAD_ONE};
-
     use opus::tests::abbot::utils::abbot_utils;
     use opus::tests::caretaker::utils::caretaker_utils;
     use opus::tests::common;
     use opus::tests::shrine::utils::shrine_utils;
-
+    use opus::types::AssetBalance;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::{Ray, Wad, WadZeroable, WAD_ONE};
+    use opus::utils::wadray;
+    use starknet::testing::set_contract_address;
+    use starknet::{ContractAddress};
 
     #[test]
     #[available_gas(100000000)]
@@ -568,17 +564,17 @@ mod test_caretaker {
         );
 
         // Transferring some of user1's yin to someone else
-        // This is because in `shrine.melt_helper`, which is called by `shrine.eject`, which is called by `reclaim`, 
+        // This is because in `shrine.melt_helper`, which is called by `shrine.eject`, which is called by `reclaim`,
         // the yin `amount` is deducted first from the user's balance and only then from the total.
-        // 
+        //
         // This means that if the user attempts to deduct more yin than exists, the transaction will obviously fail
-        // since the user can't have more yin than the total supply. However, if the yin was first deducted from 
-        // `total_yin` in `shrine.melt_helper`, then the transaction would still fail, but this test wouldn't 
-        // actually be testing the correct thing, which is that users shouldn't be able to deduct more yin than they personally 
+        // since the user can't have more yin than the total supply. However, if the yin was first deducted from
+        // `total_yin` in `shrine.melt_helper`, then the transaction would still fail, but this test wouldn't
+        // actually be testing the correct thing, which is that users shouldn't be able to deduct more yin than they personally
         // have.
         //
         // In other words, we do the transfer to ensure that the test still tests the correct thing regardless of the order
-        // of operations in `shrine.melt_helper`. 
+        // of operations in `shrine.melt_helper`.
         let user2 = common::trove2_owner_addr();
         let transfer_amt: u256 = (4000 * WAD_ONE).into();
         set_contract_address(user1);
@@ -589,7 +585,7 @@ mod test_caretaker {
         set_contract_address(caretaker_utils::admin());
         caretaker.shut();
 
-        // User1 attempts to reclaim more yin than they have 
+        // User1 attempts to reclaim more yin than they have
         set_contract_address(user1);
         let user1_yin: Wad = shrine.get_yin(user1);
         // This should revert

--- a/src/tests/caretaker/utils.cairo
+++ b/src/tests/caretaker/utils.cairo
@@ -1,25 +1,22 @@
 mod caretaker_utils {
     use debug::PrintTrait;
-    use starknet::{
-        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_try_from_felt252,
-        contract_address_to_felt252, deploy_syscall, SyscallResultTrait
-    };
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
     use opus::core::caretaker::caretaker as caretaker_contract;
     use opus::core::roles::{sentinel_roles, shrine_roles};
-
     use opus::interfaces::IAbbot::IAbbotDispatcher;
     use opus::interfaces::ICaretaker::ICaretakerDispatcher;
     use opus::interfaces::IGate::IGateDispatcher;
     use opus::interfaces::ISentinel::ISentinelDispatcher;
     use opus::interfaces::IShrine::IShrineDispatcher;
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-
     use opus::tests::abbot::utils::abbot_utils;
     use opus::tests::equalizer::utils::equalizer_utils;
     use opus::tests::sentinel::utils::sentinel_utils;
     use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use starknet::testing::{set_block_timestamp, set_contract_address};
+    use starknet::{
+        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_try_from_felt252,
+        contract_address_to_felt252, deploy_syscall, SyscallResultTrait
+    };
 
     fn admin() -> ContractAddress {
         contract_address_try_from_felt252('caretaker admin').unwrap()

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -1,14 +1,5 @@
 use debug::PrintTrait;
-use starknet::{
-    deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
-    contract_address_to_felt252, contract_address_try_from_felt252, get_block_timestamp,
-    SyscallResultTrait
-};
-use starknet::contract_address::ContractAddressZeroable;
-use starknet::testing::{pop_log_raw, set_block_timestamp, set_contract_address};
-
 use opus::core::shrine::shrine;
-
 use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
 use opus::interfaces::IERC20::{
     IERC20Dispatcher, IERC20DispatcherTrait, IMintableDispatcher, IMintableDispatcherTrait
@@ -16,12 +7,18 @@ use opus::interfaces::IERC20::{
 use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
 use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
 use opus::tests::erc20::ERC20;
-use opus::types::{AssetBalance, Reward, YangBalance};
-use opus::utils::wadray;
-use opus::utils::wadray::{Ray, Wad, WadZeroable};
-
 use opus::tests::sentinel::utils::sentinel_utils;
 use opus::tests::shrine::utils::shrine_utils;
+use opus::types::{AssetBalance, Reward, YangBalance};
+use opus::utils::wadray::{Ray, Wad, WadZeroable};
+use opus::utils::wadray;
+use starknet::contract_address::ContractAddressZeroable;
+use starknet::testing::{pop_log_raw, set_block_timestamp, set_contract_address};
+use starknet::{
+    deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
+    contract_address_to_felt252, contract_address_try_from_felt252, get_block_timestamp,
+    SyscallResultTrait
+};
 
 //
 // Constants

--- a/src/tests/controller/test_controller.cairo
+++ b/src/tests/controller/test_controller.cairo
@@ -1,20 +1,17 @@
 mod test_controller {
     use debug::PrintTrait;
-    use starknet::testing::set_contract_address;
-
     use opus::core::controller::controller as controller_contract;
-
     use opus::interfaces::IController::{IControllerDispatcher, IControllerDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::wadray_signed;
-    use opus::utils::wadray_signed::{SignedRay, SignedRayZeroable};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, Wad};
-
-    use opus::tests::common;
     use opus::tests::common::{assert_equalish, badguy};
+    use opus::tests::common;
     use opus::tests::controller::utils::controller_utils;
     use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::wadray::{Ray, Wad};
+    use opus::utils::wadray;
+    use opus::utils::wadray_signed::{SignedRay, SignedRayZeroable};
+    use opus::utils::wadray_signed;
+    use starknet::testing::set_contract_address;
 
     const YIN_PRICE1: u128 = 999942800000000000; // wad
     const YIN_PRICE2: u128 = 999879000000000000; // wad

--- a/src/tests/controller/utils.cairo
+++ b/src/tests/controller/utils.cairo
@@ -1,24 +1,21 @@
 mod controller_utils {
     use debug::PrintTrait;
+    use opus::core::controller::controller as controller_contract;
+    use opus::core::roles::shrine_roles;
+    use opus::interfaces::IController::{IControllerDispatcher, IControllerDispatcherTrait};
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::{Ray, Wad};
+    use opus::utils::wadray;
+    use opus::utils::wadray_signed::SignedRay;
+    use opus::utils::wadray_signed;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
     use starknet::{
         ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
         contract_address_try_from_felt252, deploy_syscall, get_block_timestamp, SyscallResultTrait
     };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
-    use opus::core::controller::controller as controller_contract;
-    use opus::core::roles::shrine_roles;
-
-    use opus::interfaces::IController::{IControllerDispatcher, IControllerDispatcherTrait};
-    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray_signed;
-    use opus::utils::wadray_signed::SignedRay;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, Wad};
-
-    use opus::tests::shrine::utils::shrine_utils;
 
     // Controller update interval
     const ONE_HOUR: u64 = consteval_int!(60 * 60); // 1 hour

--- a/src/tests/equalizer/test_allocator.cairo
+++ b/src/tests/equalizer/test_allocator.cairo
@@ -1,17 +1,14 @@
 mod test_allocator {
-    use starknet::ContractAddress;
-    use starknet::testing::set_contract_address;
-
     use opus::core::allocator::allocator as allocator_contract;
     use opus::core::roles::allocator_roles;
-
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
     use opus::interfaces::IAllocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
-    use opus::utils::wadray::Ray;
-
+    use opus::tests::common;
     use opus::tests::equalizer::utils::equalizer_utils;
     use opus::tests::shrine::utils::shrine_utils;
-    use opus::tests::common;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::Ray;
+    use starknet::ContractAddress;
+    use starknet::testing::set_contract_address;
 
     #[test]
     #[available_gas(20000000000)]

--- a/src/tests/equalizer/test_equalizer.cairo
+++ b/src/tests/equalizer/test_equalizer.cairo
@@ -1,21 +1,18 @@
 mod test_equalizer {
-    use starknet::{ContractAddress, get_block_timestamp};
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
     use opus::core::equalizer::equalizer as equalizer_contract;
     use opus::core::roles::equalizer_roles;
     use opus::core::shrine::shrine;
-
     use opus::interfaces::IAllocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
     use opus::interfaces::IEqualizer::{IEqualizerDispatcher, IEqualizerDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, Wad, WadZeroable};
-
+    use opus::tests::common;
     use opus::tests::equalizer::utils::equalizer_utils;
     use opus::tests::shrine::utils::shrine_utils;
-    use opus::tests::common;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::{Ray, Wad, WadZeroable};
+    use opus::utils::wadray;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
+    use starknet::{ContractAddress, get_block_timestamp};
 
     #[test]
     #[available_gas(20000000000)]

--- a/src/tests/equalizer/utils.cairo
+++ b/src/tests/equalizer/utils.cairo
@@ -1,22 +1,19 @@
 mod equalizer_utils {
+    use opus::core::allocator::allocator as allocator_contract;
+    use opus::core::equalizer::equalizer as equalizer_contract;
+    use opus::core::roles::shrine_roles;
+    use opus::interfaces::IAllocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
+    use opus::interfaces::IEqualizer::{IEqualizerDispatcher, IEqualizerDispatcherTrait};
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::Ray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::set_contract_address;
     use starknet::{
         deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
         contract_address_to_felt252, contract_address_try_from_felt252, SyscallResultTrait
     };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::set_contract_address;
-
-    use opus::core::allocator::allocator as allocator_contract;
-    use opus::core::equalizer::equalizer as equalizer_contract;
-    use opus::core::roles::shrine_roles;
-
-    use opus::interfaces::IAllocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
-    use opus::interfaces::IEqualizer::{IEqualizerDispatcher, IEqualizerDispatcherTrait};
-    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray::Ray;
-
-    use opus::tests::shrine::utils::shrine_utils;
 
     //
     // Convenience helpers

--- a/src/tests/erc20.cairo
+++ b/src/tests/erc20.cairo
@@ -1,9 +1,8 @@
 #[starknet::contract]
 mod ERC20 {
-    use starknet::get_caller_address;
-    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
-
     use opus::interfaces::IERC20::{IERC20, IMintable};
+    use starknet::contract_address::{ContractAddress, ContractAddressZeroable};
+    use starknet::get_caller_address;
 
     #[storage]
     struct Storage {

--- a/src/tests/external/mock_pragma.cairo
+++ b/src/tests/external/mock_pragma.cairo
@@ -12,7 +12,6 @@ trait IMockPragma<TContractState> {
 mod mock_pragma {
     use opus::interfaces::external::IPragmaOracle;
     use opus::types::pragma::{DataType, PricesResponse};
-
     use super::IMockPragma;
 
     #[storage]

--- a/src/tests/external/test_pragma.cairo
+++ b/src/tests/external/test_pragma.cairo
@@ -1,30 +1,27 @@
 mod test_pragma {
     use debug::PrintTrait;
     use integer::U256Zeroable;
-    use starknet::{ContractAddress, contract_address_try_from_felt252, get_block_timestamp};
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
     use opus::core::roles::pragma_roles;
     use opus::core::shrine::shrine;
     use opus::external::pragma::pragma as pragma_contract;
-
-    use opus::interfaces::external::{IPragmaOracleDispatcher, IPragmaOracleDispatcherTrait};
     use opus::interfaces::IERC20::{IMintableDispatcher, IMintableDispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::IOracle::{IOracleDispatcher, IOracleDispatcherTrait};
     use opus::interfaces::IPragma::{IPragmaDispatcher, IPragmaDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::pragma::{PricesResponse, PriceValidityThresholds, YangSettings};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::math::pow;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{WadZeroable, WAD_DECIMALS, WAD_ONE, WAD_SCALE};
-
+    use opus::interfaces::external::{IPragmaOracleDispatcher, IPragmaOracleDispatcherTrait};
     use opus::tests::common;
     use opus::tests::external::mock_pragma::{IMockPragmaDispatcher, IMockPragmaDispatcherTrait};
     use opus::tests::external::utils::pragma_utils;
     use opus::tests::sentinel::utils::sentinel_utils;
+    use opus::types::pragma::{PricesResponse, PriceValidityThresholds, YangSettings};
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::math::pow;
+    use opus::utils::wadray::{WadZeroable, WAD_DECIMALS, WAD_ONE, WAD_SCALE};
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
+    use starknet::{ContractAddress, contract_address_try_from_felt252, get_block_timestamp};
 
     //
     // Constants

--- a/src/tests/external/utils.cairo
+++ b/src/tests/external/utils.cairo
@@ -1,30 +1,27 @@
 mod pragma_utils {
-    use starknet::{
-        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
-        contract_address_try_from_felt252, deploy_syscall, get_block_timestamp, SyscallResultTrait
-    };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::set_contract_address;
-
     use opus::core::roles::shrine_roles;
     use opus::external::pragma::pragma as pragma_contract;
-
-    use opus::interfaces::external::{IPragmaOracleDispatcher, IPragmaOracleDispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::IOracle::{IOracleDispatcher, IOracleDispatcherTrait};
     use opus::interfaces::IPragma::{IPragmaDispatcher, IPragmaDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::pragma::PricesResponse;
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::math::pow;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{WAD_DECIMALS, WAD_SCALE};
-
+    use opus::interfaces::external::{IPragmaOracleDispatcher, IPragmaOracleDispatcherTrait};
     use opus::tests::external::mock_pragma::mock_pragma as mock_pragma_contract;
     use opus::tests::external::mock_pragma::{IMockPragmaDispatcher, IMockPragmaDispatcherTrait};
     use opus::tests::sentinel::utils::sentinel_utils;
     use opus::tests::shrine::utils::shrine_utils;
+    use opus::types::pragma::PricesResponse;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::math::pow;
+    use opus::utils::wadray::{WAD_DECIMALS, WAD_SCALE};
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::set_contract_address;
+    use starknet::{
+        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
+        contract_address_try_from_felt252, deploy_syscall, get_block_timestamp, SyscallResultTrait
+    };
 
     //
     // Constants

--- a/src/tests/flash_mint/flash_borrower.cairo
+++ b/src/tests/flash_mint/flash_borrower.cairo
@@ -1,11 +1,9 @@
 #[starknet::contract]
 mod flash_borrower {
-    use starknet::{contract_address_const, get_contract_address, ContractAddress};
-
     use opus::core::flash_mint::flash_mint::ON_FLASH_MINT_SUCCESS;
-
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IFlashMint::{IFlashMintDispatcher, IFlashMintDispatcherTrait};
+    use starknet::{contract_address_const, get_contract_address, ContractAddress};
 
     const VALID_USAGE: felt252 = 0;
     const ATTEMPT_TO_STEAL: felt252 = 1;
@@ -15,7 +13,6 @@ mod flash_borrower {
     struct Storage {
         flashmint: IFlashMintDispatcher,
     }
-
 
     #[event]
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
@@ -31,7 +28,6 @@ mod flash_borrower {
         fee: u256,
         call_data: Span<felt252>
     }
-
 
     #[constructor]
     fn constructor(ref self: ContractState, flashmint: ContractAddress) {

--- a/src/tests/flash_mint/test_flash_mint.cairo
+++ b/src/tests/flash_mint/test_flash_mint.cairo
@@ -1,20 +1,17 @@
 mod test_flash_mint {
-    use starknet::ContractAddress;
-    use starknet::testing::set_contract_address;
-
     use opus::core::flash_mint::flash_mint as flash_mint_contract;
-
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IFlashBorrower::{IFlashBorrowerDispatcher, IFlashBorrowerDispatcherTrait};
     use opus::interfaces::IFlashMint::{IFlashMintDispatcher, IFlashMintDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Wad, WAD_ONE};
-
     use opus::tests::common;
     use opus::tests::flash_mint::flash_borrower::flash_borrower as flash_borrower_contract;
     use opus::tests::flash_mint::utils::flash_mint_utils;
     use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::wadray::{Wad, WAD_ONE};
+    use opus::utils::wadray;
+    use starknet::ContractAddress;
+    use starknet::testing::set_contract_address;
 
     //
     // Tests

--- a/src/tests/flash_mint/utils.cairo
+++ b/src/tests/flash_mint/utils.cairo
@@ -1,22 +1,19 @@
 mod flash_mint_utils {
+    use opus::core::flash_mint::flash_mint as flash_mint_contract;
+    use opus::core::roles::shrine_roles;
+    use opus::interfaces::IFlashMint::{IFlashMintDispatcher, IFlashMintDispatcherTrait};
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::flash_mint::flash_borrower::flash_borrower as flash_borrower_contract;
+    use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::{Wad, WAD_ONE};
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::set_contract_address;
     use starknet::{
         deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
         contract_address_to_felt252, SyscallResultTrait
     };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::set_contract_address;
-
-    use opus::core::flash_mint::flash_mint as flash_mint_contract;
-    use opus::core::roles::shrine_roles;
-
-    use opus::interfaces::IFlashMint::{IFlashMintDispatcher, IFlashMintDispatcherTrait};
-    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Wad, WAD_ONE};
-
-    use opus::tests::flash_mint::flash_borrower::flash_borrower as flash_borrower_contract;
-    use opus::tests::shrine::utils::shrine_utils;
 
     const YIN_TOTAL_SUPPLY: u128 = 20000000000000000000000; // 20000 * WAD_ONE
     const DEFAULT_MINT_AMOUNT: u256 = 500000000000000000000; // 500 * WAD_ONE

--- a/src/tests/gate/test_gate.cairo
+++ b/src/tests/gate/test_gate.cairo
@@ -3,21 +3,18 @@
 
 mod test_gate {
     use debug::PrintTrait;
-    use starknet::{ContractAddress, contract_address_try_from_felt252};
-    use starknet::testing::set_contract_address;
-
     use opus::core::gate::gate as gate_contract;
-
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{WAD_SCALE, Wad};
-
-    use opus::tests::gate::utils::gate_utils;
-    use opus::tests::gate::utils::gate_utils::WBTC_SCALE;
-    use opus::tests::shrine::utils::shrine_utils;
     use opus::tests::common;
+    use opus::tests::gate::utils::gate_utils::WBTC_SCALE;
+    use opus::tests::gate::utils::gate_utils;
+    use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::wadray::{WAD_SCALE, Wad};
+    use opus::utils::wadray;
+    use starknet::testing::set_contract_address;
+    use starknet::{ContractAddress, contract_address_try_from_felt252};
 
     #[test]
     #[available_gas(10000000000)]

--- a/src/tests/gate/utils.cairo
+++ b/src/tests/gate/utils.cairo
@@ -1,24 +1,22 @@
 mod gate_utils {
     use debug::PrintTrait;
     use integer::BoundedInt;
-    use starknet::{
-        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
-        contract_address_try_from_felt252, deploy_syscall, SyscallResultTrait
-    };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
     use opus::core::gate::gate as gate_contract;
     use opus::interfaces::IERC20::{
         IERC20Dispatcher, IERC20DispatcherTrait, IMintableDispatcher, IMintableDispatcherTrait
     };
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, Wad, WadZeroable};
-
     use opus::tests::common;
     use opus::tests::erc20::ERC20;
     use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::wadray::{Ray, Wad, WadZeroable};
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
+    use starknet::{
+        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
+        contract_address_try_from_felt252, deploy_syscall, SyscallResultTrait
+    };
 
     //
     // Constants

--- a/src/tests/purger/flash_liquidator.cairo
+++ b/src/tests/purger/flash_liquidator.cairo
@@ -1,6 +1,5 @@
-use starknet::ContractAddress;
-
 use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IFlashLiquidator<TContractState> {
@@ -15,10 +14,7 @@ trait IFlashLiquidator<TContractState> {
 #[starknet::contract]
 mod flash_liquidator {
     use integer::BoundedInt;
-    use starknet::{get_contract_address, ContractAddress};
-
     use opus::core::flash_mint::flash_mint::ON_FLASH_MINT_SUCCESS;
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IFlashBorrower::IFlashBorrower;
@@ -26,12 +22,12 @@ mod flash_liquidator {
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::IPurger::{IPurgerDispatcher, IPurgerDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::AssetBalance;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Wad, WadZeroable};
-
     use opus::tests::absorber::utils::absorber_utils;
     use opus::tests::common;
+    use opus::types::AssetBalance;
+    use opus::utils::wadray::{Wad, WadZeroable};
+    use opus::utils::wadray;
+    use starknet::{get_contract_address, ContractAddress};
 
     #[storage]
     struct Storage {

--- a/src/tests/purger/test_purger.cairo
+++ b/src/tests/purger/test_purger.cairo
@@ -1,27 +1,18 @@
 mod test_purger {
     use cmp::{max, min};
+    use debug::PrintTrait;
     use integer::BoundedU256;
-    use starknet::{ContractAddress, get_block_timestamp};
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
     use opus::core::absorber::absorber as absorber_contract;
     use opus::core::purger::purger as purger_contract;
     use opus::core::roles::purger_roles;
     use opus::core::shrine::shrine as shrine_contract;
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IAbsorber::{IAbsorberDispatcher, IAbsorberDispatcherTrait};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::IPurger::{IPurgerDispatcher, IPurgerDispatcherTrait};
-    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::types::AssetBalance;
-    use opus::utils::math::pow;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{BoundedWad, Ray, RayZeroable, RAY_ONE, RAY_PERCENT, Wad, WAD_ONE};
-
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::tests::absorber::utils::absorber_utils;
     use opus::tests::common;
     use opus::tests::external::utils::pragma_utils;
@@ -31,8 +22,13 @@ mod test_purger {
     };
     use opus::tests::purger::utils::purger_utils;
     use opus::tests::shrine::utils::shrine_utils;
-
-    use debug::PrintTrait;
+    use opus::types::AssetBalance;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::math::pow;
+    use opus::utils::wadray::{BoundedWad, Ray, RayZeroable, RAY_ONE, RAY_PERCENT, Wad, WAD_ONE};
+    use opus::utils::wadray;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
+    use starknet::{ContractAddress, get_block_timestamp};
 
     //
     // Tests - Setup
@@ -279,14 +275,14 @@ mod test_purger {
                     // we get the desired ltv for the trove from the get-go in order to
                     // avoid overflow issues in lower_prices_to_raise_trove_ltv.
                     //
-                    // This is because lower_prices_to_raise_trove_ltv is designed for 
+                    // This is because lower_prices_to_raise_trove_ltv is designed for
                     // raising the trove's LTV to the given *higher* LTV,
-                    // not lowering it. 
+                    // not lowering it.
                     //
-                    // NOTE: This 2% cut off is completely arbitrary and meant only for excluding 
-                    // the two test cases in `interesting_thresholds_for_liquidation`: 0% and 1%. 
-                    // If more low thresholds were added that were above 2% but below the 
-                    // starting LTV of the trove, then this cutoff would need to be adjusted. 
+                    // NOTE: This 2% cut off is completely arbitrary and meant only for excluding
+                    // the two test cases in `interesting_thresholds_for_liquidation`: 0% and 1%.
+                    // If more low thresholds were added that were above 2% but below the
+                    // starting LTV of the trove, then this cutoff would need to be adjusted.
                     let trove_debt = if *threshold > (RAY_PERCENT * 2).into() {
                         default_trove_debt
                     } else {
@@ -544,8 +540,8 @@ mod test_purger {
                         .span();
 
                     // Assert that we hit the branch for safety margin check at least once per threshold
-                    // If the threshold is zero we add to the `safe_ltv_count` and set this to true, 
-                    // thereby skipping this check for the given threshold, since a 
+                    // If the threshold is zero we add to the `safe_ltv_count` and set this to true,
+                    // thereby skipping this check for the given threshold, since a
                     // threshold of zero necessitates a full liquidation in all cases.
                     let mut safety_margin_achieved: bool = if (*threshold).is_non_zero() {
                         false
@@ -566,24 +562,24 @@ mod test_purger {
 
                                 purger_utils::create_whale_trove(abbot, yangs, gates);
 
-                                // NOTE: This 2% cut off is completely arbitrary and meant only for excluding 
-                                // the two test cases in `interesting_thresholds_for_liquidation`: 0% and 1%. 
-                                // If more low thresholds were added that were above 2% but below the 
-                                // starting LTV of the trove, then this cutoff would need to be adjusted. 
+                                // NOTE: This 2% cut off is completely arbitrary and meant only for excluding
+                                // the two test cases in `interesting_thresholds_for_liquidation`: 0% and 1%.
+                                // If more low thresholds were added that were above 2% but below the
+                                // starting LTV of the trove, then this cutoff would need to be adjusted.
                                 let target_ltv_above_cutoff = *target_ltv > low_ltv_cutoff;
                                 let trove_debt: Wad = if target_ltv_above_cutoff {
                                     // If target_ltv is above 2%, then we can set the trove's debt
-                                    // to `TARGET_TROVE_YIN` and adjust prices in order to reach 
+                                    // to `TARGET_TROVE_YIN` and adjust prices in order to reach
                                     // the target LTV
                                     purger_utils::TARGET_TROVE_YIN.into()
                                 } else {
-                                    // Otherwise, we set the debt for the trove such that we get 
+                                    // Otherwise, we set the debt for the trove such that we get
                                     // the desired ltv for the trove from the get-go in order
                                     // to avoid overflow issues in lower_prices_to_raise_trove_ltv
                                     //
-                                    // This is because lower_prices_to_raise_trove_ltv is designed for 
+                                    // This is because lower_prices_to_raise_trove_ltv is designed for
                                     // raising the trove's LTV to the given *higher* LTV,
-                                    // not lowering it. 
+                                    // not lowering it.
                                     let target_trove_yang_amts: Span<Wad> = array![
                                         purger_utils::TARGET_TROVE_ETH_DEPOSIT_AMT.into(),
                                         (purger_utils::TARGET_TROVE_WBTC_DEPOSIT_AMT
@@ -622,8 +618,8 @@ mod test_purger {
                                         *target_ltv
                                     );
 
-                                    // If the prices have been adjusted, we need to 
-                                    // get the new value of the trove in order for 
+                                    // If the prices have been adjusted, we need to
+                                    // get the new value of the trove in order for
                                     // following calculations to be correct
                                     let (_, _, before_value_temp, _) = shrine
                                         .get_trove_info(target_trove);
@@ -2075,8 +2071,8 @@ mod test_purger {
 
                                             // Check Purger events
 
-                                            // Note that this indirectly asserts that `Purged` 
-                                            // is not emitted if it does not revert because 
+                                            // Note that this indirectly asserts that `Purged`
+                                            // is not emitted if it does not revert because
                                             // `Purged` would have been emitted before `Compensate`
                                             let compensate_event: purger_contract::Compensate =
                                                 common::pop_event_with_indexed_keys(
@@ -2597,7 +2593,7 @@ mod test_purger {
         );
 
         // user 1 opens a trove with ETH and BTC that is close to liquidation
-        // `funded_healthy_trove` supplies 2 ETH and 0.5 BTC totalling $9000 in value, so we 
+        // `funded_healthy_trove` supplies 2 ETH and 0.5 BTC totalling $9000 in value, so we
         // create $6000 of debt to ensure the trove is closer to liquidation
         let trove_debt: Wad = (6000 * WAD_ONE).into();
         let target_trove: u64 = purger_utils::funded_healthy_trove(abbot, yangs, gates, trove_debt);
@@ -2627,7 +2623,7 @@ mod test_purger {
         let eth_weight: Ray = wadray::rdiv_ww(eth_value, value);
         let btc_weight: Ray = wadray::rdiv_ww(btc_value, value);
 
-        // We need to decrease BTC's threshold until the trove threshold equals `ltv` 
+        // We need to decrease BTC's threshold until the trove threshold equals `ltv`
         // we derive the decrease factor from the following equation:
         //
         // NOTE: decrease factor is the value which, if we multiply BTC's threshold by it, will give us
@@ -2686,7 +2682,7 @@ mod test_purger {
             purger_utils::SEARCHER_YIN.into()
         );
 
-        // We run the same tests using both searcher liquidations and absorptions as the liquidation methods. 
+        // We run the same tests using both searcher liquidations and absorptions as the liquidation methods.
         let mut liquidate_via_absorption_param: Span<bool> = array![
             false, //true - we comment this parametrization out for now, due to failing in CI
         ]
@@ -2701,7 +2697,7 @@ mod test_purger {
             RAY_PERCENT.into(),
             (RAY_PERCENT / 4).into(),
             // This is the smallest possible desired threshold that
-            // doesn't result in advancing the time enough to make 
+            // doesn't result in advancing the time enough to make
             // the suspension permanent
             (RAY_ONE + 1).into()
                 / (RAY_ONE * shrine_contract::SUSPENSION_GRACE_PERIOD.into()).into(),
@@ -2780,9 +2776,9 @@ mod test_purger {
                                                 'wrong eth threshold'
                                             );
 
-                                            // We want to compare the yin balance of the liquidator 
-                                            // before and after the liquidation. In the case of absorption 
-                                            // we check the absorber's balance, and in the case of 
+                                            // We want to compare the yin balance of the liquidator
+                                            // before and after the liquidation. In the case of absorption
+                                            // we check the absorber's balance, and in the case of
                                             // searcher liquidation we check the searcher's balance.
                                             let before_liquidation_yin_balance: u256 =
                                                 if *liquidate_via_absorption {
@@ -2791,7 +2787,7 @@ mod test_purger {
                                                 yin_erc20.balance_of(searcher)
                                             };
 
-                                            // Liquidate the trove 
+                                            // Liquidate the trove
                                             set_contract_address(searcher);
 
                                             if *liquidate_via_absorption {
@@ -2816,7 +2812,7 @@ mod test_purger {
                                                 'trove not correctly liquidated'
                                             );
 
-                                            // Checking that the liquidator's yin balance has decreased 
+                                            // Checking that the liquidator's yin balance has decreased
                                             // after liquidation
                                             if *liquidate_via_absorption {
                                                 assert(
@@ -2876,7 +2872,7 @@ mod test_purger {
 
         let searcher = purger_utils::searcher();
 
-        // Approve absorber for maximum yin 
+        // Approve absorber for maximum yin
         set_contract_address(searcher);
         yin_erc20.approve(absorber.contract_address, BoundedU256::max());
 
@@ -2928,9 +2924,9 @@ mod test_purger {
                                             )
                                                 + 1_u128.into();
 
-                                            // We skip test cases of partial liquidations where 
+                                            // We skip test cases of partial liquidations where
                                             // the trove debt is less than the minimum shares in absorber.
-                                            // While it can be done, it is complicated to set up the absorber in such a 
+                                            // While it can be done, it is complicated to set up the absorber in such a
                                             // way that the remaining yin is less than the minimum shares.
                                             if *absorb_type == AbsorbType::Partial
                                                 && trove_debt <= absorber_contract::MINIMUM_SHARES
@@ -2943,8 +2939,8 @@ mod test_purger {
                                                 shrine, yangs, (80 * RAY_PERCENT).into()
                                             );
 
-                                            // Clearing/"resetting" the absorber 
-                                            // if it needs to be reset 
+                                            // Clearing/"resetting" the absorber
+                                            // if it needs to be reset
                                             if yin_erc20
                                                 .balance_of(absorber.contract_address)
                                                 .is_non_zero() {
@@ -2973,8 +2969,8 @@ mod test_purger {
 
                                                 let searcher_provided_yin: Wad = absorber
                                                     .preview_remove(searcher);
-                                                // Removing any remaining yin, and/or 
-                                                // remaining absorbed assets due to the 
+                                                // Removing any remaining yin, and/or
+                                                // remaining absorbed assets due to the
                                                 // provider.
 
                                                 if searcher_provided_yin.is_non_zero() {
@@ -2991,7 +2987,7 @@ mod test_purger {
                                             );
 
                                             // Now, the searcher deposits some yin into the absorber
-                                            // The amount depends on whether we want a full or partial absorption, or 
+                                            // The amount depends on whether we want a full or partial absorption, or
                                             // a full redistribution
 
                                             set_contract_address(searcher);
@@ -3009,7 +3005,7 @@ mod test_purger {
                                                         );
                                                 },
                                                 AbsorbType::Partial => {
-                                                    // We add 1 wei in the event that `trove_debt` is extremely small, 
+                                                    // We add 1 wei in the event that `trove_debt` is extremely small,
                                                     // to avoid the provision amount from being zero.
 
                                                     absorber
@@ -3114,8 +3110,8 @@ mod test_purger {
                                                 'wrong compensation value'
                                             );
 
-                                            // If the trove wasn't fully liquidated, check 
-                                            // that it is healthy 
+                                            // If the trove wasn't fully liquidated, check
+                                            // that it is healthy
                                             if max_close_amt < trove_debt {
                                                 assert(
                                                     shrine.is_healthy(target_trove),
@@ -3123,13 +3119,13 @@ mod test_purger {
                                                 );
                                             }
 
-                                            // Checking that the absorbed assets are equal in value to the 
-                                            // debt liquidated, plus the penalty  
+                                            // Checking that the absorbed assets are equal in value to the
+                                            // debt liquidated, plus the penalty
                                             if *absorb_type != AbsorbType::None {
                                                 // We subtract the absorber balance before the liquidation
-                                                //  in order to avoid including any leftover 
+                                                //  in order to avoid including any leftover
                                                 // absorbed assets from previous liquidations
-                                                // in the calculation for the value of the 
+                                                // in the calculation for the value of the
                                                 // absorption that *just* occured
 
                                                 let absorbed_eth: Wad =

--- a/src/tests/purger/utils.cairo
+++ b/src/tests/purger/utils.cairo
@@ -1,31 +1,15 @@
 mod purger_utils {
     use cmp::min;
-    use starknet::{
-        deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
-        contract_address_to_felt252, contract_address_try_from_felt252, get_block_timestamp,
-        SyscallResultTrait
-    };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::set_contract_address;
-
+    use debug::PrintTrait;
     use opus::core::absorber::absorber as absorber_contract;
     use opus::core::purger::purger as purger_contract;
     use opus::core::roles::{absorber_roles, pragma_roles, sentinel_roles, shrine_roles};
-
     use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
     use opus::interfaces::IAbsorber::{IAbsorberDispatcher, IAbsorberDispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::IOracle::{IOracleDispatcher, IOracleDispatcherTrait};
     use opus::interfaces::IPurger::{IPurgerDispatcher, IPurgerDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::types::AssetBalance;
-    use opus::utils::math::pow;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{
-        Ray, RayZeroable, RAY_ONE, RAY_PERCENT, Wad, WadZeroable, WAD_DECIMALS, WAD_ONE
-    };
-
     use opus::tests::absorber::utils::absorber_utils;
     use opus::tests::common;
     use opus::tests::external::mock_pragma::{IMockPragmaDispatcher, IMockPragmaDispatcherTrait};
@@ -35,8 +19,20 @@ mod purger_utils {
     };
     use opus::tests::sentinel::utils::sentinel_utils;
     use opus::tests::shrine::utils::shrine_utils;
-
-    use debug::PrintTrait;
+    use opus::types::AssetBalance;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::math::pow;
+    use opus::utils::wadray::{
+        Ray, RayZeroable, RAY_ONE, RAY_PERCENT, Wad, WadZeroable, WAD_DECIMALS, WAD_ONE
+    };
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::set_contract_address;
+    use starknet::{
+        deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
+        contract_address_to_felt252, contract_address_try_from_felt252, get_block_timestamp,
+        SyscallResultTrait
+    };
 
     //
     // Constants
@@ -558,7 +554,7 @@ mod purger_utils {
         common::scale_span_by_pct(trove_asset_amts, expected_compensation_pct)
     }
 
-    // Returns a tuple of the expected freed percentage of trove value and the 
+    // Returns a tuple of the expected freed percentage of trove value and the
     // freed asset amounts
     fn get_expected_liquidation_assets(
         trove_asset_amts: Span<u128>,

--- a/src/tests/sentinel/test_sentinel.cairo
+++ b/src/tests/sentinel/test_sentinel.cairo
@@ -1,25 +1,22 @@
 mod test_sentinel {
     use debug::PrintTrait;
-    use starknet::ContractAddress;
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
-    use opus::core::sentinel::sentinel as sentinel_contract;
     use opus::core::roles::sentinel_roles;
-
+    use opus::core::sentinel::sentinel as sentinel_contract;
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::types::YangSuspensionStatus;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, Wad, WAD_ONE};
-
+    use opus::tests::common;
     use opus::tests::gate::utils::gate_utils;
     use opus::tests::sentinel::utils::sentinel_utils;
     use opus::tests::shrine::utils::shrine_utils;
-    use opus::tests::common;
+    use opus::types::YangSuspensionStatus;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::{Ray, Wad, WAD_ONE};
+    use opus::utils::wadray;
+    use starknet::ContractAddress;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
 
     #[test]
     #[available_gas(10000000000)]

--- a/src/tests/sentinel/utils.cairo
+++ b/src/tests/sentinel/utils.cairo
@@ -1,26 +1,23 @@
 mod sentinel_utils {
     use debug::PrintTrait;
     use integer::BoundedU256;
-    use starknet::{
-        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
-        contract_address_try_from_felt252, deploy_syscall, get_caller_address, SyscallResultTrait
-    };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::set_contract_address;
-
     use opus::core::roles::{sentinel_roles, shrine_roles};
     use opus::core::sentinel::sentinel as sentinel_contract;
-
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Wad, Ray};
-
     use opus::tests::gate::utils::gate_utils;
     use opus::tests::shrine::utils::shrine_utils;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::wadray::{Wad, Ray};
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::set_contract_address;
+    use starknet::{
+        ClassHash, class_hash_try_from_felt252, ContractAddress, contract_address_to_felt252,
+        contract_address_try_from_felt252, deploy_syscall, get_caller_address, SyscallResultTrait
+    };
 
     const ETH_ASSET_MAX: u128 = 1000000000000000000000; // 1000 (wad)
     const WBTC_ASSET_MAX: u128 = 100000000000; // 1000 * 10**8

--- a/src/tests/shrine/test_shrine.cairo
+++ b/src/tests/shrine/test_shrine.cairo
@@ -1,27 +1,24 @@
 mod test_shrine {
     use debug::PrintTrait;
     use integer::BoundedU256;
-    use starknet::get_block_timestamp;
-    use starknet::contract_address::{
-        ContractAddress, ContractAddressZeroable, contract_address_try_from_felt252
-    };
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
-    use opus::core::shrine::shrine as shrine_contract;
     use opus::core::roles::shrine_roles;
-
+    use opus::core::shrine::shrine as shrine_contract;
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::common;
+    use opus::tests::shrine::utils::shrine_utils;
     use opus::types::{Trove, YangSuspensionStatus};
     use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::wadray;
     use opus::utils::wadray::{
         BoundedRay, Ray, RayZeroable, RAY_ONE, RAY_PERCENT, RAY_SCALE, Wad, WadZeroable,
         WAD_DECIMALS, WAD_PERCENT, WAD_ONE, WAD_SCALE
     };
-
-    use opus::tests::shrine::utils::shrine_utils;
-    use opus::tests::common;
+    use opus::utils::wadray;
+    use starknet::contract_address::{
+        ContractAddress, ContractAddressZeroable, contract_address_try_from_felt252
+    };
+    use starknet::get_block_timestamp;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
 
     //
     // Tests - Deployment and initial setup of Shrine
@@ -2098,7 +2095,7 @@ mod test_shrine {
 
         // We directly unsuspend the yang instead of suspending it first, because
         // an unauthorized call to `suspend_yang` has the same error message, which
-        // can be ambiguous when trying to understand which part of the test failed. 
+        // can be ambiguous when trying to understand which part of the test failed.
         set_contract_address(common::badguy());
         shrine.unsuspend_yang(yang);
     }

--- a/src/tests/shrine/test_shrine_compound.cairo
+++ b/src/tests/shrine/test_shrine_compound.cairo
@@ -1,17 +1,14 @@
 mod test_shrine_compound {
-    use starknet::{ContractAddress, get_block_timestamp};
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
     use opus::core::shrine::shrine as shrine_contract;
-
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::common;
+    use opus::tests::shrine::utils::shrine_utils;
     use opus::types::Trove;
     use opus::utils::exp::exp;
-    use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RayZeroable, RAY_SCALE, Wad, WadZeroable};
-
-    use opus::tests::shrine::utils::shrine_utils;
-    use opus::tests::common;
+    use opus::utils::wadray;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
+    use starknet::{ContractAddress, get_block_timestamp};
 
     //
     // Tests - Trove estimate and charge

--- a/src/tests/shrine/test_shrine_redistribution.cairo
+++ b/src/tests/shrine/test_shrine_redistribution.cairo
@@ -1,18 +1,14 @@
 mod test_shrine_redistribution {
+    use debug::PrintTrait;
+    use opus::core::shrine::shrine as shrine_contract;
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::common;
+    use opus::tests::shrine::utils::shrine_utils;
+    use opus::types::{ExceptionalYangRedistribution, YangBalance, YangRedistribution};
+    use opus::utils::wadray::{Ray, RayZeroable, RAY_ONE, RAY_PERCENT, Wad, WadZeroable, WAD_ONE};
+    use opus::utils::wadray;
     use starknet::ContractAddress;
     use starknet::testing::set_contract_address;
-
-    use opus::core::shrine::shrine as shrine_contract;
-
-    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::{ExceptionalYangRedistribution, YangBalance, YangRedistribution};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, RayZeroable, RAY_ONE, RAY_PERCENT, Wad, WadZeroable, WAD_ONE};
-
-    use opus::tests::shrine::utils::shrine_utils;
-    use opus::tests::common;
-
-    use debug::PrintTrait;
 
     //
     // Setup
@@ -555,8 +551,8 @@ mod test_shrine_redistribution {
                                 );
 
                                 shrine_utils::assert_shrine_invariants(shrine, yangs, 3);
-                            // We are unable to test the trove value in a sensible way here because 
-                            // the yang price has not been updated to reflect any rebasing of the 
+                            // We are unable to test the trove value in a sensible way here because
+                            // the yang price has not been updated to reflect any rebasing of the
                             // asset amount per yang wad. Instead, refer to the tests for purger
                             // for assertions on the redistributed trove's value.
                             },
@@ -1154,7 +1150,7 @@ mod test_shrine_redistribution {
         );
 
         let expected_recipient_trove1_attr_debt: Wad = {
-            // Redistributed debt from yang 1 to yang 2 
+            // Redistributed debt from yang 1 to yang 2
             wadray::rmul_wr(yang1_debt_redistributed_to_yang2, recipient_trove1_yang2_pct)
                 + // Redistributed debt from yang 1 to yang 3
                 wadray::rmul_wr(yang1_debt_redistributed_to_yang3, recipient_trove1_yang3_pct)
@@ -1165,7 +1161,7 @@ mod test_shrine_redistribution {
         };
 
         let expected_recipient_trove2_attr_debt: Wad = {
-            // Redistributed debt from yang 1 to yang 2 
+            // Redistributed debt from yang 1 to yang 2
             wadray::rmul_wr(yang1_debt_redistributed_to_yang2, recipient_trove2_yang2_pct)
                 + // Redistributed debt from yang 1 to yang 3
                 wadray::rmul_wr(yang1_debt_redistributed_to_yang3, recipient_trove2_yang3_pct)
@@ -1503,7 +1499,7 @@ mod test_shrine_redistribution {
         let expected_recipient_trove_yang1_amt: Wad = wadray::rmul_wr(
             shrine_utils::TROVE1_YANG1_DEPOSIT.into(), expected_recipient_trove1_pct
         );
-        // Recipient trove's yang 3 amount should be the amount received from the first 
+        // Recipient trove's yang 3 amount should be the amount received from the first
         // redistribution, since the second redistribution would have rebased
         let expected_recipient_trove_yang3_amt: Wad = wadray::rmul_wr(
             shrine_utils::TROVE1_YANG3_DEPOSIT.into(), expected_recipient_trove1_pct

--- a/src/tests/shrine/utils.cairo
+++ b/src/tests/shrine/utils.cairo
@@ -1,29 +1,25 @@
 mod shrine_utils {
+    use debug::PrintTrait;
     use integer::{
         U128sFromFelt252Result, u128s_from_felt252, u128_safe_divmod, u128_try_as_non_zero
     };
+    use opus::core::roles::shrine_roles;
+    use opus::core::shrine::shrine as shrine_contract;
+    use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::common;
+    use opus::types::YangRedistribution;
+    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
+    use opus::utils::exp::exp;
+    use opus::utils::wadray::{Ray, RayZeroable, RAY_ONE, Wad, WadZeroable, WAD_ONE};
+    use opus::utils::wadray;
+    use starknet::contract_address::ContractAddressZeroable;
+    use starknet::testing::{set_block_timestamp, set_contract_address};
     use starknet::{
         deploy_syscall, ClassHash, class_hash_try_from_felt252, ContractAddress,
         contract_address_to_felt252, contract_address_try_from_felt252, get_block_timestamp,
         SyscallResultTrait
     };
-    use starknet::contract_address::ContractAddressZeroable;
-    use starknet::testing::{set_block_timestamp, set_contract_address};
-
-    use opus::core::shrine::shrine as shrine_contract;
-    use opus::core::roles::shrine_roles;
-
-    use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::types::YangRedistribution;
-    use opus::utils::access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use opus::utils::exp::exp;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, RayZeroable, RAY_ONE, Wad, WadZeroable, WAD_ONE};
-
-    use opus::tests::common;
-
-    use debug::PrintTrait;
 
     //
     // Constants
@@ -638,10 +634,10 @@ mod shrine_utils {
     // Invariant helpers
     //
 
-    // Asserts that for each yang, the total yang amount is less than or equal to the sum of 
-    // all troves' deposited amount, including any unpulled exceptional redistributions, and 
+    // Asserts that for each yang, the total yang amount is less than or equal to the sum of
+    // all troves' deposited amount, including any unpulled exceptional redistributions, and
     // the initial yang amount.
-    // We do not check for strict equality because there may be loss of precision when 
+    // We do not check for strict equality because there may be loss of precision when
     // exceptionally redistributed yang are pulled into troves.
     fn assert_total_yang_invariant(
         shrine: IShrineDispatcher, mut yangs: Span<ContractAddress>, troves_count: u64,
@@ -698,7 +694,7 @@ mod shrine_utils {
 
     // Asserts that the total system debt is less than or equal to the sum of all troves' debt, including
     // all unpulled redistributions.
-    // We do not check for strict equality because there may be loss of precision when 
+    // We do not check for strict equality because there may be loss of precision when
     // redistributed debt are pulled into troves.
     fn assert_total_debt_invariant(
         shrine: IShrineDispatcher, mut yangs: Span<ContractAddress>, troves_count: u64,

--- a/src/tests/utils/mock_access_control.cairo
+++ b/src/tests/utils/mock_access_control.cairo
@@ -1,8 +1,7 @@
 #[starknet::contract]
 mod mock_access_control {
-    use starknet::ContractAddress;
-
     use opus::utils::access_control::access_control_component;
+    use starknet::ContractAddress;
 
     component!(path: access_control_component, storage: access_control, event: AccessControlEvent);
 

--- a/src/tests/utils/test_access_control.cairo
+++ b/src/tests/utils/test_access_control.cairo
@@ -1,16 +1,14 @@
 mod test_access_control {
+    use opus::tests::common;
+    use opus::tests::utils::mock_access_control::mock_access_control;
+    use opus::utils::access_control::access_control_component::{
+        AccessControlPublic, AccessControlHelpers
+    };
+    use opus::utils::access_control::access_control_component;
     use starknet::contract_address::{
         ContractAddress, ContractAddressZeroable, contract_address_try_from_felt252
     };
     use starknet::testing::{pop_log, pop_log_raw, set_caller_address};
-
-    use opus::utils::access_control::access_control_component;
-    use opus::utils::access_control::access_control_component::{
-        AccessControlPublic, AccessControlHelpers
-    };
-
-    use opus::tests::common;
-    use opus::tests::utils::mock_access_control::mock_access_control;
 
     //
     // Constants

--- a/src/tests/utils/test_exp.cairo
+++ b/src/tests/utils/test_exp.cairo
@@ -1,9 +1,8 @@
 mod test_exp {
-    use opus::utils::exp::exp;
-    use opus::utils::wadray;
-    use opus::utils::wadray::{WAD_ONE, WAD_PERCENT, Wad};
-
     use opus::tests::common::assert_equalish;
+    use opus::utils::exp::exp;
+    use opus::utils::wadray::{WAD_ONE, WAD_PERCENT, Wad};
+    use opus::utils::wadray;
 
     // Acceptable error for e^x where x <= 20. Corresponds to 0.000000000001 (10^-12) precision
     const ACCEPTABLE_ERROR: u128 = 1000000;

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -1,13 +1,10 @@
 mod test_math {
     use debug::PrintTrait;
-
     use integer::BoundedU128;
-
-    use opus::utils::math::{pow, sqrt};
-    use opus::utils::wadray;
-    use opus::utils::wadray::{Ray, RAY_ONE};
-
     use opus::tests::common::assert_equalish;
+    use opus::utils::math::{pow, sqrt};
+    use opus::utils::wadray::{Ray, RAY_ONE};
+    use opus::utils::wadray;
 
     #[test]
     #[available_gas(20000000000)]

--- a/src/tests/utils/test_reentrancy_guard.cairo
+++ b/src/tests/utils/test_reentrancy_guard.cairo
@@ -1,8 +1,7 @@
 mod tests {
-    use opus::utils::reentrancy_guard::reentrancy_guard_component;
-    use opus::utils::reentrancy_guard::reentrancy_guard_component::{ReentrancyGuardHelpers};
-
     use opus::tests::utils::mock_reentrancy_guard::{IMockReentrancyGuard, mock_reentrancy_guard};
+    use opus::utils::reentrancy_guard::reentrancy_guard_component::{ReentrancyGuardHelpers};
+    use opus::utils::reentrancy_guard::reentrancy_guard_component;
 
     fn state() -> mock_reentrancy_guard::ContractState {
         mock_reentrancy_guard::contract_state_for_testing()

--- a/src/tests/utils/test_wadray.cairo
+++ b/src/tests/utils/test_wadray.cairo
@@ -1,10 +1,9 @@
 mod test_wadray {
-    use opus::utils::wadray;
     use opus::utils::wadray::{
         DIFF, fixed_point_to_wad, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, rdiv_wr, rmul_rw, rmul_wr, Wad,
         WAD_ONE, WAD_DECIMALS, WAD_SCALE, wdiv_rw, rdiv_ww, wmul_rw, wmul_wr
     };
-
+    use opus::utils::wadray;
 
     #[test]
     fn test_add() {

--- a/src/tests/utils/test_wadray_signed.cairo
+++ b/src/tests/utils/test_wadray_signed.cairo
@@ -1,12 +1,10 @@
 mod test_wadray_signed {
     use debug::PrintTrait;
     use math::Oneable;
-
-    use opus::utils::wadray_signed;
-    use opus::utils::wadray_signed::{SignedRay, SignedRayOneable, SignedRayZeroable};
-    use opus::utils::wadray;
     use opus::utils::wadray::{Ray, RAY_ONE, Wad, WAD_ONE};
-
+    use opus::utils::wadray;
+    use opus::utils::wadray_signed::{SignedRay, SignedRayOneable, SignedRayZeroable};
+    use opus::utils::wadray_signed;
 
     #[test]
     fn test_add_sub() {

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -1,10 +1,10 @@
 use cmp::min;
 use integer::{u256_safe_div_rem, u256_try_as_non_zero};
-use starknet::{ContractAddress, StorePacking};
 
 use opus::interfaces::IAbsorber::IBlesserDispatcher;
-use opus::utils::wadray;
 use opus::utils::wadray::Wad;
+use opus::utils::wadray;
+use starknet::{ContractAddress, StorePacking};
 
 const TWO_POW_32: felt252 = 0x100000000;
 const TWO_POW_64: felt252 = 0x10000000000000000;

--- a/src/utils/access_control.cairo
+++ b/src/utils/access_control.cairo
@@ -15,8 +15,8 @@ trait IAccessControl<TContractState> {
 
 #[starknet::component]
 mod access_control_component {
-    use starknet::{ContractAddress, get_caller_address};
     use starknet::contract_address::ContractAddressZeroable;
+    use starknet::{ContractAddress, get_caller_address};
 
     #[storage]
     struct Storage {

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,8 +1,7 @@
 use integer::u256_sqrt;
 use math::Oneable;
-
-use opus::utils::wadray;
 use opus::utils::wadray::Ray;
+use opus::utils::wadray;
 
 fn sqrt(x: Ray) -> Ray {
     let scaled_val: u256 = x.val.into() * wadray::RAY_SCALE.into();

--- a/src/utils/wadray.cairo
+++ b/src/utils/wadray.cairo
@@ -1,7 +1,5 @@
-use debug::PrintTrait;
 use integer::BoundedInt;
 use math::Oneable;
-
 use opus::utils::math::pow;
 
 const WAD_DECIMALS: u8 = 18;
@@ -482,13 +480,13 @@ impl RayOneable of Oneable<Ray> {
 }
 
 // Debug print
-impl WadPrintImpl of PrintTrait<Wad> {
+impl WadPrintImpl of debug::PrintTrait<Wad> {
     fn print(self: Wad) {
         self.val.print();
     }
 }
 
-impl RayPrintImpl of PrintTrait<Ray> {
+impl RayPrintImpl of debug::PrintTrait<Ray> {
     fn print(self: Ray) {
         self.val.print();
     }

--- a/src/utils/wadray_signed.cairo
+++ b/src/utils/wadray_signed.cairo
@@ -1,8 +1,6 @@
 use math::Oneable;
-
-
-use opus::utils::wadray;
 use opus::utils::wadray::{Ray, RAY_ONE, Wad};
+use opus::utils::wadray;
 
 const HALF_PRIME: felt252 =
     1809251394333065606848661391547535052811553607665798349986546028067936010240;
@@ -132,8 +130,6 @@ impl SignedRayAddEq of AddEq<SignedRay> {
         self = self + other;
     }
 }
-
-use debug::PrintTrait;
 
 impl SignedRayPartialOrd of PartialOrd<SignedRay> {
     #[inline(always)]


### PR DESCRIPTION
Resolves #464. Removes the newlines as suggested in the issue as well, so now there's one coherent block of `use` statements.

I think it works pretty alright. Thoughts?