### PR TITLE
test: recovery mode liquidations

### DIFF
--- a/src/tests/purger/test_purger.cairo
+++ b/src/tests/purger/test_purger.cairo
@@ -395,21 +395,19 @@ mod test_purger {
                                         before_debt,
                                         *threshold
                                     );
-                                } else {
-                                    if (*is_recovery_mode) {
-                                        let (_, _, dummy_value, dummy_debt) = shrine
-                                            .get_trove_info(dummy_trove);
+                                } else if (*is_recovery_mode) {
+                                    let (_, _, dummy_value, dummy_debt) = shrine
+                                        .get_trove_info(dummy_trove);
 
-                                        purger_utils::lower_prices_to_raise_trove_ltv(
-                                            shrine,
-                                            mock_pragma,
-                                            yangs,
-                                            yang_pair_ids,
-                                            dummy_value,
-                                            dummy_debt,
-                                            dummy_threshold
-                                        );
-                                    }
+                                    purger_utils::lower_prices_to_raise_trove_ltv(
+                                        shrine,
+                                        mock_pragma,
+                                        yangs,
+                                        yang_pair_ids,
+                                        dummy_value,
+                                        dummy_debt,
+                                        dummy_threshold
+                                    );
                                 }
 
                                 let (adjusted_threshold, ltv, _, _) = shrine

--- a/src/tests/purger/utils.cairo
+++ b/src/tests/purger/utils.cairo
@@ -555,7 +555,7 @@ mod purger_utils {
         let (rm_threshold, shrine_ltv) = shrine.get_recovery_mode_threshold();
         let (_, shrine_value) = shrine.get_shrine_threshold_and_value();
 
-        // Add 10% to the amount needed to activate RM
+        // Add 1% to the amount needed to activate RM
         let amt_to_activate_rm: Wad = wadray::rmul_rw(
             (RAY_ONE + RAY_PERCENT).into(),
             (wadray::rmul_rw(rm_threshold, shrine_value)


### PR DESCRIPTION
This PR adds recovery mode parametrization to purger's tests. Resolves #416.

I did not add recovery mode parametrization to the following tests:
~~1. `test_preview_absorb_below_trove_debt_parametrized`: the scaling of the recovery mode thresholds depends on the shrine LTV, which cannot be fixed because the protocol LTV needed to push Shrine into recovery mode differs for each test case. As a result, it is difficult to calculate the expected recovery mode LTVs and max close amount before hand.~~
~~2. `test_absorb_low_thresholds`: Already includes recovery mode because the test relies on `set_thresholds` and sets thresholds for all yangs to the low value.~~
3. `test_liquidate_suspended_yang_threshold_near_zero`: This test causes my machine to freeze and then the tests just stop abruptly, presumably like what we observed in the CI. Perhaps we can add a TODO and see if starknet-foundry would resolve this?

With the recovery mode parametrization, the CI time more than doubles from ~2 hours to ~4.5 hours. Is there any utility to splitting purger tests into its own CI run?