### PR TITLE
ci: dont run CI on draft PRs

### DIFF
--- a/.github/workflows/caracal.yml
+++ b/.github/workflows/caracal.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: '! github.event.pull_request.draft'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: '! github.event.pull_request.draft'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The CI runs on draft PRs because of the [`synchronize` type](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request) - so every push to a branch that's a draft PR will trigger a new run.

Since we're using draft PRs as staging and for design reviews, the test suite isn't often yet updated and would predictably fail. Furthermore, our test suite is currently running for quite a long time, unnecessarily eating resources for these drafts. We often cancel the test runs manually.

This PR adds a condition not to run the CI jobs if a PR is a draft.