### PR TITLE
chore: pin dependency versions in CI

### DIFF
--- a/.github/workflows/caracal.yml
+++ b/.github/workflows/caracal.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "nightly"
+          scarb-version: "2.3.1"
 
       - name: Run Caracal
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - run: scarb fmt --check
       - run: scarb build
 
-      - run: |
-          curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
-          snfoundryup
-          snforge test
+      - uses: foundry-rs/setup-snfoundry@v2
+        with:
+          starknet-foundry-version: "0.11.0"
+      - run: snforge test


### PR DESCRIPTION
Quick fix for CI
- Use Starknet Foundry's Github action, pinned to `0.11.0`
- Pin Scarb to `2.3.1` in Caracal's CI