### PR TITLE
chore: remove unused event

### DIFF
--- a/src/external/pragma.cairo
+++ b/src/external/pragma.cairo
@@ -86,13 +86,6 @@ mod pragma {
     }
 
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    struct OracleAddressUpdated {
-        old_address: ContractAddress,
-        new_address: ContractAddress
-    }
-
-
-    #[derive(Copy, Drop, starknet::Event, PartialEq)]
     struct PriceValidityThresholdsUpdated {
         old_thresholds: PriceValidityThresholds,
         new_thresholds: PriceValidityThresholds


### PR DESCRIPTION
Fix for [QA finding](https://github.com/code-423n4/2024-01-opus-findings/blob/main/data/Mike_Bello90-Q.md#7--the-oracleaddressupdated-event-is-not-added-to-the-enum-event-in-pragma-contract)