### PR TITLE
chore: bump `starknet` to `v2.6.4`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.6.3
+scarb 2.6.5
 starknet-foundry 0.23.0

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,7 +19,7 @@ allowed-libfuncs-deny = true
 sierra-replace-ids = true
 
 [dependencies]
-starknet = ">= 2.6.0"
+starknet = ">= 2.6.4"
 wadray = { git = "https://github.com/lindy-labs/wadray.git", tag = "v0.3.0" }
 access_control = { git = "https://github.com/lindy-labs/access_control.git", tag = "v0.3.0" }
 

--- a/scripts/Scarb.toml
+++ b/scripts/Scarb.toml
@@ -8,12 +8,12 @@ members = ["deployment", "simulation"]
 
 [dependencies]
 sncast_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.23.0" }
-starknet = ">=2.6.3"
+starknet = ">=2.6.4"
 opus = { path = "../" }
 
 [workspace.dependencies]
 sncast_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.23.0" }
-starknet = ">=2.6.3"
+starknet = ">=2.6.4"
 opus = { path = "../" }
 scripts = { path = "./" }
 


### PR DESCRIPTION
Fix #586.