### PR TITLE
script: update liquidation simulation

### DIFF
--- a/scripts/simulation/Scarb.toml
+++ b/scripts/simulation/Scarb.toml
@@ -16,6 +16,14 @@ setup_trove = """
 rm open_trove_alpha-sepolia_state.json 2> /dev/null; 
 sncast --account devnet_user1 --accounts-file ../devnet_accounts.json --url http://localhost:5050 script run open_trove --package simulation"""
 
+setup_liquidation = """
+rm open_trove_alpha-sepolia_state.json 2> /dev/null; sncast --profile devnet-user1 script run open_trove --package simulation; 
+rm open_trove_alpha-sepolia_state.json 2> /dev/null; sncast --profile devnet-user2 script run open_trove --package simulation;
+rm open_trove_max_forge_alpha-sepolia_state.json 2> /dev/null; sncast --profile devnet-user3 script run open_trove_max_forge --package simulation;
+curl -X POST http://localhost:5050/increase_time -H "Content-Type: application/json" -d '{ "time": 1800  }';
+rm crash_prices_alpha-sepolia_state.json 2> /dev/null; sncast --profile devnet-user1 script run crash_prices --package simulation;"""
+
+
 setup_absorption = """
 rm open_trove_alpha-sepolia_state.json 2> /dev/null; sncast --profile devnet-user1 script run open_trove --package simulation; 
 rm open_trove_alpha-sepolia_state.json 2> /dev/null; sncast --profile devnet-user2 script run open_trove --package simulation;

--- a/scripts/simulation/src/crash_prices.cairo
+++ b/scripts/simulation/src/crash_prices.cairo
@@ -8,7 +8,7 @@ use starknet::ContractAddress;
 use wadray::Ray;
 
 fn main() {
-    let pct_initial_price: Ray = 750000000000000000000000000_u128.into(); // 75% (Ray)
+    let pct_initial_price: Ray = 900000000000000000000000000_u128.into(); // 90% (Ray)
 
     let eth_pragma_price: u128 = wad_to_fixed_point(
         wadray::rmul_wr(constants::INITIAL_ETH_PRICE.into(), pct_initial_price), PRAGMA_DECIMALS

--- a/scripts/simulation/src/open_trove.cairo
+++ b/scripts/simulation/src/open_trove.cairo
@@ -14,7 +14,7 @@ fn main() {
         2,
         // eth
         addresses::eth_addr().into(),
-        // 1 eth (Wad)
+        // 10 eth (Wad)
         10000000000000000000.into(),
         // strk
         addresses::strk_addr().into(),

--- a/scripts/simulation/src/open_trove_max_forge.cairo
+++ b/scripts/simulation/src/open_trove_max_forge.cairo
@@ -14,8 +14,8 @@ fn main() {
         2,
         // eth
         addresses::eth_addr().into(),
-        // 0.5 eth (Wad)
-        5000000000000000000.into(),
+        // 5 eth (Wad)
+        (5 * WAD_ONE).into(),
         // strk
         addresses::strk_addr().into(),
         (50 * WAD_ONE).into(),


### PR DESCRIPTION
This PR modifies the existing scripts for simulating a liquidation to support a simple run of the liquidation bot on devnet out-of-the-box.