### PR TITLE
feat: receptor

### DIFF
--- a/src/constants.cairo
+++ b/src/constants.cairo
@@ -1,5 +1,6 @@
 // Constants for tokens
 pub const DAI_DECIMALS: u8 = 18;
+pub const LUSD_DECIMALS: u8 = 18;
 pub const USDC_DECIMALS: u8 = 6;
 pub const USDT_DECIMALS: u8 = 6;
 pub const WBTC_DECIMALS: u8 = 8;

--- a/src/constants.cairo
+++ b/src/constants.cairo
@@ -1,5 +1,7 @@
 // Constants for tokens
+pub const DAI_DECIMALS: u8 = 18;
 pub const USDC_DECIMALS: u8 = 6;
+pub const USDT_DECIMALS: u8 = 6;
 pub const WBTC_DECIMALS: u8 = 8;
 
 // Constants for oracles

--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -149,8 +149,7 @@ pub mod receptor {
 
         fn get_quotes(self: @ContractState) -> Span<Wad> {
             let oracle_extension = self.oracle_extension.read();
-            let ts = get_block_timestamp();
-            let start_time = ts - self.twap_duration.read();
+            let twap_duration = self.twap_duration.read();
             let cash = self.shrine.read().contract_address;
 
             let mut quotes: Array<Wad> = Default::default();
@@ -163,7 +162,7 @@ pub mod receptor {
 
                 let quote_token_info: QuoteTokenInfo = self.quote_tokens.read(index);
                 let quote: u256 = oracle_extension
-                    .get_price_x128_over_period(cash, quote_token_info.address, start_time, ts);
+                    .get_price_x128_over_last(cash, quote_token_info.address, twap_duration);
                 let scaled_quote: Wad = scale_x128_to_wad(quote, quote_token_info.decimals);
 
                 quotes.append(scaled_quote);

--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -7,7 +7,7 @@ pub mod receptor {
     use opus::interfaces::IReceptor::IReceptor;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::QuoteTokenInfo;
-    use opus::utils::math::{pow, scale_x128_to_wad};
+    use opus::utils::math::{median_of_three, pow, scale_x128_to_wad};
     use starknet::{ContractAddress, get_block_timestamp};
     use wadray::Wad;
 
@@ -147,7 +147,7 @@ pub mod receptor {
 
         fn get_yin_price(self: @ContractState) -> Wad {
             let quotes = self.get_quotes();
-            get_median_quote(quotes)
+            median_of_three(quotes)
         }
 
         fn set_oracle_extension(ref self: ContractState, oracle_extension: ContractAddress) {
@@ -170,7 +170,7 @@ pub mod receptor {
 
         fn update_yin_price(ref self: ContractState) {
             let quotes = self.get_quotes();
-            let yin_price: Wad = get_median_quote(quotes);
+            let yin_price: Wad = median_of_three(quotes);
             self.shrine.read().update_yin_spot_price(yin_price);
 
             self.emit(Record { quotes });
@@ -214,21 +214,6 @@ pub mod receptor {
             self.twap_duration.write(twap_duration);
 
             self.emit(TwapDurationUpdated { twap_duration });
-        }
-    }
-
-    // Returns the median of three Wad values
-    fn get_median_quote(quotes: Span<Wad>) -> Wad {
-        let a = *quotes[0];
-        let b = *quotes[1];
-        let c = *quotes[2];
-
-        if (a <= b && b <= c) || (c <= b && b <= a) {
-            b
-        } else if (b <= a && a <= c) || (c <= a && a <= b) {
-            a
-        } else {
-            c
         }
     }
 }

--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -1,0 +1,200 @@
+#[starknet::contract]
+pub mod receptor {
+    use access_control::access_control_component;
+    use core::num::traits::Zero;
+    use opus::external::interfaces::{IEkuboOracleExtensionDispatcher, IEkuboOracleExtensionDispatcherTrait};
+    use opus::interfaces::IReceptor::IReceptor;
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::types::QuoteTokenInfo;
+    use opus::utils::math::x128_to_wad;
+    use starknet::{ContractAddress, get_block_timestamp};
+    use wadray::Wad;
+
+    //
+    // Components
+    //
+
+    component!(path: access_control_component, storage: access_control, event: AccessControlEvent);
+
+    #[abi(embed_v0)]
+    impl AccessControlPublic = access_control_component::AccessControl<ContractState>;
+    impl AccessControlHelpers = access_control_component::AccessControlHelpers<ContractState>;
+
+    //
+    // Constants
+    //
+
+    pub const NUM_QUOTE_TOKENS: u32 = 3;
+
+    //
+    // Storage
+    //
+
+    #[storage]
+    struct Storage {
+        // components
+        #[substorage(v0)]
+        access_control: access_control_component::Storage,
+        shrine: IShrineDispatcher,
+        oracle_extension: IEkuboOracleExtensionDispatcher,
+        quote_tokens: LegacyMap<u32, QuoteTokenInfo>,
+        twap_duration: u64,
+    }
+
+    //
+    // Events 
+    //
+
+    #[event]
+    #[derive(Copy, Drop, starknet::Event, PartialEq)]
+    pub enum Event {
+        AccessControlEvent: access_control_component::Event,
+        QuoteTokensUpdated: QuoteTokensUpdated,
+        Record: Record,
+    }
+
+    #[derive(Copy, Drop, starknet::Event, PartialEq)]
+    pub struct QuoteTokensUpdated {
+        quote_tokens: Span<QuoteTokenInfo>
+    }
+
+    #[derive(Copy, Drop, starknet::Event, PartialEq)]
+    pub struct Record {
+        quotes: Span<Wad>
+    }
+
+    //
+    // Constructor
+    //
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        shrine: ContractAddress,
+        oracle_extension: ContractAddress,
+        quote_tokens: Span<QuoteTokenInfo>
+    ) {
+        self.shrine.write(IShrineDispatcher { contract_address: shrine });
+
+        self.set_oracle_extension_helper(oracle_extension);
+        self.set_quote_tokens_helper(quote_tokens);
+    }
+
+    //
+    // External Receptor functions
+    //
+
+    #[abi(embed_v0)]
+    impl IReceptorImpl of IReceptor<ContractState> {
+        fn get_oracle_extension(self: @ContractState) -> ContractAddress {
+            self.oracle_extension.read().contract_address
+        }
+
+        fn get_quote_tokens(self: @ContractState) -> Span<QuoteTokenInfo> {
+            let mut quote_tokens: Array<QuoteTokenInfo> = Default::default();
+            let mut index: u32 = 0;
+            loop {
+                if index == NUM_QUOTE_TOKENS {
+                    break quote_tokens.span();
+                }
+                quote_tokens.append(self.quote_tokens.read(index));
+                index += 1;
+            }
+        }
+
+        fn set_oracle_extension(ref self: ContractState, oracle_extension: ContractAddress) {
+            self.set_oracle_extension_helper(oracle_extension);
+        }
+
+        fn set_quote_tokens(ref self: ContractState, quote_tokens: Span<QuoteTokenInfo>) {
+            self.set_quote_tokens_helper(quote_tokens);
+        }
+
+        fn get_quotes(self: @ContractState) -> Span<Wad> {
+            let oracle_extension = self.oracle_extension.read();
+            let ts = get_block_timestamp();
+            let start_time = ts - self.twap_duration.read();
+            let cash = self.shrine.read().contract_address;
+
+            let mut quotes: Array<Wad> = Default::default();
+            let mut index: u32 = 0;
+            loop {
+                if index == NUM_QUOTE_TOKENS {
+                    break quotes.span();
+                }
+
+                let quote_token_info: QuoteTokenInfo = self.quote_tokens.read(index);
+
+                let quote: u256 = oracle_extension
+                    .get_price_x128_over_period(cash, quote_token_info.address, start_time, ts);
+
+                let scaled_quote: Wad = x128_to_wad(quote, quote_token_info.decimals);
+
+                assert(scaled_quote.is_non_zero(), 'REC: Quote is zero');
+
+                quotes.append(scaled_quote);
+                index += 1;
+            }
+        }
+
+        fn get_yin_price(self: @ContractState) -> Wad {
+            let quotes = self.get_quotes();
+            get_median_quote(quotes)
+        }
+
+        fn update_yin_price(ref self: ContractState) {
+            let quotes = self.get_quotes();
+            let yin_price: Wad = get_median_quote(quotes);
+            self.shrine.read().update_yin_spot_price(yin_price);
+
+            self.emit(Record { quotes });
+        }
+    }
+
+    //
+    // Internal Receptor functions
+    //
+
+    #[generate_trait]
+    impl ReceptorHelpers of ReceptorHelpersTrait {
+        fn set_oracle_extension_helper(ref self: ContractState, oracle_extension: ContractAddress) {
+            assert(oracle_extension.is_non_zero(), 'REC: Zero address for extension');
+
+            self.oracle_extension.write(IEkuboOracleExtensionDispatcher { contract_address: oracle_extension });
+        }
+
+        // Note that this function does not check for duplicate tokens.
+        fn set_quote_tokens_helper(ref self: ContractState, quote_tokens: Span<QuoteTokenInfo>) {
+            let mut index = 0;
+            let num_quote_tokens = quote_tokens.len();
+            assert(num_quote_tokens == NUM_QUOTE_TOKENS, 'REC: Not 3 quote tokens');
+
+            let mut quote_tokens_copy = quote_tokens;
+            loop {
+                if index == num_quote_tokens {
+                    break;
+                }
+                let quote_token_info: QuoteTokenInfo = *quote_tokens_copy.pop_front().unwrap();
+                self.quote_tokens.write(index, quote_token_info);
+                index += 1;
+            };
+
+            self.emit(QuoteTokensUpdated { quote_tokens });
+        }
+    }
+
+    // Returns the median of three Wad values
+    fn get_median_quote(quotes: Span<Wad>) -> Wad {
+        let a = *quotes[0];
+        let b = *quotes[1];
+        let c = *quotes[2];
+
+        if (a <= b && b <= c) || (c <= b && b <= a) {
+            b
+        } else if (b <= a && a <= c) || (c <= a && a <= b) {
+            a
+        } else {
+            c
+        }
+    }
+}

--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -178,11 +178,6 @@ pub mod receptor {
             self.update_frequency.read()
         }
 
-        fn get_yin_price(self: @ContractState) -> Wad {
-            let quotes = self.get_quotes();
-            median_of_three(quotes)
-        }
-
         fn set_oracle_extension(ref self: ContractState, oracle_extension: ContractAddress) {
             self.access_control.assert_has_role(receptor_roles::SET_ORACLE_EXTENSION);
 

--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -29,6 +29,9 @@ pub mod receptor {
 
     const LOOP_START: u32 = 1;
     pub const NUM_QUOTE_TOKENS: u32 = 3;
+
+    pub const MIN_TWAP_DURATION: u64 = 60; // seconds; acts as a sanity check
+
     pub const LOWER_UPDATE_FREQUENCY_BOUND: u64 = 15; // seconds (approx. Starknet block prod goal)
     pub const UPPER_UPDATE_FREQUENCY_BOUND: u64 = 4 * 60 * 60; // 4 hours * 60 minutes * 60 seconds
 
@@ -266,7 +269,7 @@ pub mod receptor {
         }
 
         fn set_twap_duration_helper(ref self: ContractState, twap_duration: u64) {
-            assert(twap_duration.is_non_zero(), 'REC: TWAP duration is 0');
+            assert(twap_duration >= MIN_TWAP_DURATION, 'REC: TWAP duration too low');
 
             let old_duration: u64 = self.twap_duration.read();
             self.twap_duration.write(twap_duration);

--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -9,7 +9,7 @@ pub mod receptor {
     use opus::interfaces::IReceptor::IReceptor;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::QuoteTokenInfo;
-    use opus::utils::math::{median_of_three, pow, scale_x128_to_wad};
+    use opus::utils::math::{median_of_three, scale_x128_to_wad};
     use starknet::{ContractAddress, get_block_timestamp};
     use wadray::{Wad, WAD_DECIMALS};
 

--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -7,7 +7,7 @@ pub mod receptor {
     use opus::interfaces::IReceptor::IReceptor;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::QuoteTokenInfo;
-    use opus::utils::math::pow;
+    use opus::utils::math::{pow, scale_x128_to_wad};
     use starknet::{ContractAddress, get_block_timestamp};
     use wadray::Wad;
 
@@ -26,7 +26,6 @@ pub mod receptor {
     //
 
     pub const NUM_QUOTE_TOKENS: u32 = 3;
-    const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
 
     //
     // Storage
@@ -231,13 +230,5 @@ pub mod receptor {
         } else {
             c
         }
-    }
-
-    // If the quote token has less than 18 decimal precision, then the
-    // x128 value needs to be scaled up by the quote token's decimals
-    pub fn scale_x128_to_wad(n: u256, decimals: u8) -> Wad {
-        let sqrt: u256 = n / TWO_POW_128;
-        let unscaled: u128 = (sqrt * sqrt).try_into().unwrap();
-        pow(unscaled, decimals).into()
     }
 }

--- a/src/core/roles.cairo
+++ b/src/core/roles.cairo
@@ -72,10 +72,12 @@ pub mod receptor_roles {
     pub const SET_ORACLE_EXTENSION: u128 = 1;
     pub const SET_QUOTE_TOKENS: u128 = 2;
     pub const SET_TWAP_DURATION: u128 = 4;
+    pub const SET_UPDATE_FREQUENCY: u128 = 8;
+    pub const UPDATE_YIN_PRICE: u128 = 16;
 
     #[inline(always)]
     pub fn default_admin_role() -> u128 {
-        SET_ORACLE_EXTENSION + SET_QUOTE_TOKENS + SET_TWAP_DURATION
+        SET_ORACLE_EXTENSION + SET_QUOTE_TOKENS + SET_TWAP_DURATION + SET_UPDATE_FREQUENCY + UPDATE_YIN_PRICE
     }
 }
 
@@ -186,6 +188,11 @@ pub mod shrine_roles {
     #[inline(always)]
     pub fn purger() -> u128 {
         MELT + REDISTRIBUTE + SEIZE
+    }
+
+    #[inline(always)]
+    pub fn receptor() -> u128 {
+        UPDATE_YIN_SPOT_PRICE
     }
 
     #[inline(always)]

--- a/src/core/roles.cairo
+++ b/src/core/roles.cairo
@@ -68,6 +68,17 @@ pub mod purger_roles {
     }
 }
 
+pub mod receptor_roles {
+    pub const SET_ORACLE_EXTENSION: u128 = 1;
+    pub const SET_QUOTE_TOKENS: u128 = 2;
+    pub const SET_TWAP_DURATION: u128 = 4;
+
+    #[inline(always)]
+    pub fn default_admin_role() -> u128 {
+        SET_ORACLE_EXTENSION + SET_QUOTE_TOKENS + SET_TWAP_DURATION
+    }
+}
+
 pub mod seer_roles {
     pub const SET_ORACLES: u128 = 1;
     pub const SET_UPDATE_FREQUENCY: u128 = 2;

--- a/src/external/interfaces.cairo
+++ b/src/external/interfaces.cairo
@@ -5,8 +5,8 @@ use starknet::ContractAddress;
 pub trait IEkuboOracleExtension<TContractState> {
     // Returns the geomean average price of a token as a 128.128 between the given start and end
     // time
-    fn get_price_x128_over_period(
-        self: @TContractState, base_token: ContractAddress, quote_token: ContractAddress, start_time: u64, end_time: u64
+    fn get_price_x128_over_last(
+        self: @TContractState, base_token: ContractAddress, quote_token: ContractAddress, period: u64
     ) -> u256;
 }
 

--- a/src/external/interfaces.cairo
+++ b/src/external/interfaces.cairo
@@ -1,4 +1,14 @@
 use opus::types::pragma;
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IEkuboOracleExtension<TContractState> {
+    // Returns the geomean average price of a token as a 128.128 between the given start and end
+    // time
+    fn get_price_x128_over_period(
+        self: @TContractState, base_token: ContractAddress, quote_token: ContractAddress, start_time: u64, end_time: u64
+    ) -> u256;
+}
 
 #[starknet::interface]
 pub trait IPragmaSpotOracle<TContractState> {

--- a/src/interfaces/IReceptor.cairo
+++ b/src/interfaces/IReceptor.cairo
@@ -10,9 +10,11 @@ pub trait IReceptor<TContractState> {
     fn get_quotes(self: @TContractState) -> Span<Wad>;
     fn get_twap_duration(self: @TContractState) -> u64;
     fn get_yin_price(self: @TContractState) -> Wad;
+    fn get_update_frequency(self: @TContractState) -> u64;
     // setters
     fn set_oracle_extension(ref self: TContractState, oracle_extension: ContractAddress);
     fn set_quote_tokens(ref self: TContractState, quote_tokens: Span<QuoteTokenInfo>);
     fn set_twap_duration(ref self: TContractState, twap_duration: u64);
+    fn set_update_frequency(ref self: TContractState, new_frequency: u64);
     fn update_yin_price(ref self: TContractState);
 }

--- a/src/interfaces/IReceptor.cairo
+++ b/src/interfaces/IReceptor.cairo
@@ -8,9 +8,11 @@ pub trait IReceptor<TContractState> {
     fn get_oracle_extension(self: @TContractState) -> ContractAddress;
     fn get_quote_tokens(self: @TContractState) -> Span<QuoteTokenInfo>;
     fn get_quotes(self: @TContractState) -> Span<Wad>;
+    fn get_twap_duration(self: @TContractState) -> u64;
     fn get_yin_price(self: @TContractState) -> Wad;
     // setters
     fn set_oracle_extension(ref self: TContractState, oracle_extension: ContractAddress);
     fn set_quote_tokens(ref self: TContractState, quote_tokens: Span<QuoteTokenInfo>);
+    fn set_twap_duration(ref self: TContractState, twap_duration: u64);
     fn update_yin_price(ref self: TContractState);
 }

--- a/src/interfaces/IReceptor.cairo
+++ b/src/interfaces/IReceptor.cairo
@@ -12,7 +12,7 @@ pub trait IReceptor<TContractState> {
     fn get_update_frequency(self: @TContractState) -> u64;
     // setters
     fn set_oracle_extension(ref self: TContractState, oracle_extension: ContractAddress);
-    fn set_quote_tokens(ref self: TContractState, quote_tokens: Span<QuoteTokenInfo>);
+    fn set_quote_tokens(ref self: TContractState, quote_tokens: Span<ContractAddress>);
     fn set_twap_duration(ref self: TContractState, twap_duration: u64);
     fn set_update_frequency(ref self: TContractState, new_frequency: u64);
     fn update_yin_price(ref self: TContractState);

--- a/src/interfaces/IReceptor.cairo
+++ b/src/interfaces/IReceptor.cairo
@@ -9,7 +9,6 @@ pub trait IReceptor<TContractState> {
     fn get_quote_tokens(self: @TContractState) -> Span<QuoteTokenInfo>;
     fn get_quotes(self: @TContractState) -> Span<Wad>;
     fn get_twap_duration(self: @TContractState) -> u64;
-    fn get_yin_price(self: @TContractState) -> Wad;
     fn get_update_frequency(self: @TContractState) -> u64;
     // setters
     fn set_oracle_extension(ref self: TContractState, oracle_extension: ContractAddress);

--- a/src/interfaces/IReceptor.cairo
+++ b/src/interfaces/IReceptor.cairo
@@ -1,0 +1,16 @@
+use opus::types::QuoteTokenInfo;
+use starknet::ContractAddress;
+use wadray::Wad;
+
+#[starknet::interface]
+pub trait IReceptor<TContractState> {
+    // getters
+    fn get_oracle_extension(self: @TContractState) -> ContractAddress;
+    fn get_quote_tokens(self: @TContractState) -> Span<QuoteTokenInfo>;
+    fn get_quotes(self: @TContractState) -> Span<Wad>;
+    fn get_yin_price(self: @TContractState) -> Wad;
+    // setters
+    fn set_oracle_extension(ref self: TContractState, oracle_extension: ContractAddress);
+    fn set_quote_tokens(ref self: TContractState, quote_tokens: Span<QuoteTokenInfo>);
+    fn update_yin_price(ref self: TContractState);
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -11,6 +11,7 @@ pub mod core {
     pub mod flash_mint;
     pub mod gate;
     pub mod purger;
+    pub mod receptor;
     pub mod roles;
     pub mod seer;
     pub mod sentinel;
@@ -41,6 +42,7 @@ mod interfaces {
     pub mod IOracle;
     pub mod IPragma;
     pub mod IPurger;
+    pub mod IReceptor;
     pub mod ISRC5;
     pub mod ISeer;
     pub mod ISentinel;

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -119,6 +119,10 @@ mod tests {
         mod test_purger;
         pub mod utils;
     }
+    mod receptor {
+        mod test_receptor;
+        pub mod utils;
+    }
     mod sentinel {
         mod test_sentinel;
         pub mod utils;

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -73,6 +73,7 @@ pub mod mock {
     pub mod erc20_mintable;
     pub mod flash_borrower;
     pub mod flash_liquidator;
+    pub mod mock_ekubo_oracle_extension;
     pub mod mock_pragma;
     pub mod mock_switchboard;
 }

--- a/src/mock/mock_ekubo_oracle_extension.cairo
+++ b/src/mock/mock_ekubo_oracle_extension.cairo
@@ -3,7 +3,7 @@ use starknet::ContractAddress;
 #[starknet::interface]
 pub trait IMockEkuboOracleExtension<TContractState> {
     // Timestamps are ignored
-    fn next_get_price_x128_over_period(
+    fn next_get_price_x128_over_last(
         ref self: TContractState, base_token: ContractAddress, quote_token: ContractAddress, price: u256
     );
 }
@@ -22,7 +22,7 @@ pub mod mock_ekubo_oracle_extension {
 
     #[abi(embed_v0)]
     impl IMockEkuboOracleExtensionImpl of IMockEkuboOracleExtension<ContractState> {
-        fn next_get_price_x128_over_period(
+        fn next_get_price_x128_over_last(
             ref self: ContractState, base_token: ContractAddress, quote_token: ContractAddress, price: u256
         ) {
             self.price.write((base_token, quote_token), price);
@@ -31,12 +31,8 @@ pub mod mock_ekubo_oracle_extension {
 
     #[abi(embed_v0)]
     impl IEkuboOracleExtensionImpl of IEkuboOracleExtension<ContractState> {
-        fn get_price_x128_over_period(
-            self: @ContractState,
-            base_token: ContractAddress,
-            quote_token: ContractAddress,
-            start_time: u64,
-            end_time: u64
+        fn get_price_x128_over_last(
+            self: @ContractState, base_token: ContractAddress, quote_token: ContractAddress, period: u64
         ) -> u256 {
             self.price.read((base_token, quote_token))
         }

--- a/src/mock/mock_ekubo_oracle_extension.cairo
+++ b/src/mock/mock_ekubo_oracle_extension.cairo
@@ -1,0 +1,44 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IMockEkuboOracleExtension<TContractState> {
+    // Timestamps are ignored
+    fn next_get_price_x128_over_period(
+        ref self: TContractState, base_token: ContractAddress, quote_token: ContractAddress, price: u256
+    );
+}
+
+#[starknet::contract]
+pub mod mock_ekubo_oracle_extension {
+    use opus::external::interfaces::IEkuboOracleExtension;
+    use starknet::ContractAddress;
+    use super::IMockEkuboOracleExtension;
+
+    #[storage]
+    struct Storage {
+        // Mapping from (base token, quote token) to x128 price
+        price: LegacyMap::<(ContractAddress, ContractAddress), u256>,
+    }
+
+    #[abi(embed_v0)]
+    impl IMockEkuboOracleExtensionImpl of IMockEkuboOracleExtension<ContractState> {
+        fn next_get_price_x128_over_period(
+            ref self: ContractState, base_token: ContractAddress, quote_token: ContractAddress, price: u256
+        ) {
+            self.price.write((base_token, quote_token), price);
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl IEkuboOracleExtensionImpl of IEkuboOracleExtension<ContractState> {
+        fn get_price_x128_over_period(
+            self: @ContractState,
+            base_token: ContractAddress,
+            quote_token: ContractAddress,
+            start_time: u64,
+            end_time: u64
+        ) -> u256 {
+            self.price.read((base_token, quote_token))
+        }
+    }
+}

--- a/src/tests/receptor/test_receptor.cairo
+++ b/src/tests/receptor/test_receptor.cairo
@@ -1,0 +1,31 @@
+mod test_receptor {
+    use opus::constants::{DAI_DECIMALS, USDC_DECIMALS, USDT_DECIMALS};
+    use opus::core::receptor::receptor as receptor_contract;
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::receptor::utils::receptor_utils;
+    use opus::tests::shrine::utils::shrine_utils;
+    use opus::types::QuoteTokenInfo;
+
+
+    #[test]
+    fn test_receptor_deploy() {
+        let shrine: IShrineDispatcher = shrine_utils::shrine_deploy_and_setup(Option::None);
+
+        let quote_tokens: Span<QuoteTokenInfo> = array![
+            QuoteTokenInfo { address: receptor_utils::mock_dai(), decimals: DAI_DECIMALS },
+            QuoteTokenInfo { address: receptor_utils::mock_usdc(), decimals: USDC_DECIMALS },
+            QuoteTokenInfo { address: receptor_utils::mock_usdt(), decimals: USDT_DECIMALS },
+        ]
+            .span();
+
+        let receptor = receptor_utils::receptor_deploy(
+            shrine.contract_address,
+            receptor_utils::mock_oracle_extension(),
+            receptor_utils::INITIAL_TWAP_DURATION,
+            quote_tokens,
+            Option::None
+        );
+
+        println!("Receptor deployed");
+    }
+}

--- a/src/tests/receptor/test_receptor.cairo
+++ b/src/tests/receptor/test_receptor.cairo
@@ -1,31 +1,307 @@
 mod test_receptor {
-    use opus::constants::{DAI_DECIMALS, USDC_DECIMALS, USDT_DECIMALS};
+    use access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
     use opus::core::receptor::receptor as receptor_contract;
+    use opus::core::roles::receptor_roles;
+    use opus::core::shrine::shrine as shrine_contract;
+    use opus::external::interfaces::{ITaskDispatcher, ITaskDispatcherTrait};
+    use opus::interfaces::IReceptor::{IReceptorDispatcher, IReceptorDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::tests::common;
     use opus::tests::receptor::utils::receptor_utils;
     use opus::tests::shrine::utils::shrine_utils;
     use opus::types::QuoteTokenInfo;
+    use snforge_std::{start_warp, start_prank, stop_prank, CheatTarget, spy_events, SpyOn, EventSpy, EventAssertions};
+    use starknet::{ContractAddress, get_block_timestamp};
+    use wadray::Wad;
 
 
     #[test]
     fn test_receptor_deploy() {
-        let shrine: IShrineDispatcher = shrine_utils::shrine_deploy_and_setup(Option::None);
+        let (_, receptor, mock_ekubo_oracle_extension_addr) = receptor_utils::receptor_deploy(Option::None);
 
-        let quote_tokens: Span<QuoteTokenInfo> = array![
-            QuoteTokenInfo { address: receptor_utils::mock_dai(), decimals: DAI_DECIMALS },
-            QuoteTokenInfo { address: receptor_utils::mock_usdc(), decimals: USDC_DECIMALS },
-            QuoteTokenInfo { address: receptor_utils::mock_usdt(), decimals: USDT_DECIMALS },
+        let receptor_ac = IAccessControlDispatcher { contract_address: receptor.contract_address };
+        let admin = shrine_utils::admin();
+        assert(receptor_ac.get_admin() == admin, 'wrong admin');
+        assert(receptor_ac.get_roles(admin) == receptor_roles::default_admin_role(), 'wrong role');
+
+        assert_eq!(receptor.get_oracle_extension(), mock_ekubo_oracle_extension_addr, "wrong extension addr");
+        assert_eq!(receptor.get_twap_duration(), receptor_utils::INITIAL_TWAP_DURATION, "wrong twap duration");
+        assert_eq!(receptor.get_quote_tokens(), receptor_utils::quote_tokens(), "wrong quote tokens");
+    }
+
+    // Parameters
+
+    #[test]
+    fn test_set_oracle_extension() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+
+        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
+        let new_addr: ContractAddress = receptor_utils::mock_oracle_extension();
+        receptor.set_oracle_extension(new_addr);
+
+        assert_eq!(receptor.get_oracle_extension(), new_addr, "wrong extension addr");
+    }
+
+    #[test]
+    #[should_panic(expected: ('Caller missing role',))]
+    fn test_set_oracle_extension_unauthorized() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+
+        start_prank(CheatTarget::One(receptor.contract_address), common::badguy());
+        receptor.set_oracle_extension(receptor_utils::mock_oracle_extension());
+    }
+
+    #[test]
+    fn test_set_twap_duration_pass() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+        let mut spy = spy_events(SpyOn::One(receptor.contract_address));
+
+        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin().into());
+        let old_duration: u64 = receptor_utils::INITIAL_TWAP_DURATION;
+        let new_duration: u64 = old_duration + 1;
+        receptor.set_twap_duration(new_duration);
+
+        let expected_events = array![
+            (
+                receptor.contract_address,
+                receptor_contract::Event::TwapDurationUpdated(
+                    receptor_contract::TwapDurationUpdated { old_duration, new_duration }
+                )
+            )
+        ];
+
+        spy.assert_emitted(@expected_events);
+    }
+
+    #[test]
+    #[should_panic(expected: ('REC: TWAP duration is 0',))]
+    fn test_set_twap_duration_zero_fail() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+
+        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin().into());
+        receptor.set_twap_duration(0);
+    }
+
+    #[test]
+    #[should_panic(expected: ('Caller missing role',))]
+    fn test_set_twap_duration_unauthorized_fail() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+
+        start_prank(CheatTarget::One(receptor.contract_address), common::badguy());
+        receptor.set_twap_duration(receptor_utils::INITIAL_TWAP_DURATION + 1);
+    }
+
+    #[test]
+    fn test_set_update_frequency_pass() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+        let mut spy = spy_events(SpyOn::One(receptor.contract_address));
+
+        let old_frequency: u64 = receptor_utils::INITIAL_UPDATE_FREQUENCY;
+        let new_frequency: u64 = old_frequency + 1;
+        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
+        receptor.set_update_frequency(new_frequency);
+
+        assert_eq!(receptor.get_update_frequency(), new_frequency, "wrong update frequency");
+
+        let expected_events = array![
+            (
+                receptor.contract_address,
+                receptor_contract::Event::UpdateFrequencyUpdated(
+                    receptor_contract::UpdateFrequencyUpdated { old_frequency, new_frequency }
+                )
+            )
+        ];
+
+        spy.assert_emitted(@expected_events);
+    }
+
+    #[test]
+    #[should_panic(expected: ('Caller missing role',))]
+    fn test_set_update_frequency_unauthorized() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+        start_prank(CheatTarget::One(receptor.contract_address), common::badguy());
+        receptor.set_update_frequency(receptor_utils::INITIAL_UPDATE_FREQUENCY - 1);
+    }
+
+    #[test]
+    #[should_panic(expected: ('REC: Frequency out of bounds',))]
+    fn test_set_update_frequency_oob_lower() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+
+        let new_frequency: u64 = receptor_contract::LOWER_UPDATE_FREQUENCY_BOUND - 1;
+        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
+        receptor.set_update_frequency(new_frequency);
+    }
+
+    #[test]
+    #[should_panic(expected: ('REC: Frequency out of bounds',))]
+    fn test_set_update_frequency_oob_higher() {
+        let (_, receptor, _) = receptor_utils::receptor_deploy(Option::None);
+
+        let new_frequency: u64 = receptor_contract::UPPER_UPDATE_FREQUENCY_BOUND + 1;
+        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
+        receptor.set_update_frequency(new_frequency);
+    }
+
+    // Core functionality
+
+    #[test]
+    fn test_update_yin_price() {
+        let (shrine, receptor, mock_ekubo_oracle_extension_addr) = receptor_utils::receptor_deploy(Option::None);
+        let mut shrine_spy = spy_events(SpyOn::One(shrine.contract_address));
+        let mut receptor_spy = spy_events(SpyOn::One(receptor.contract_address));
+
+        let before_yin_spot_price: Wad = shrine.get_yin_spot_price();
+
+        let quote_tokens: Span<QuoteTokenInfo> = receptor_utils::quote_tokens();
+        // actual mainnet values from 1727418625 start time to 1727429425 end time
+        // converted in python
+        let prices: Span<u256> = array![
+            340309250276362099785975626643777172060, // 1.000158012403645039602034587 DAI / CASH
+            340527434977254803682969657, // 1.001440899252887204535902704 USDC / CASH
+            340328625112763872478829777, // 1.000271899695698999556601210 USDT / CASH
         ]
             .span();
-
-        let receptor = receptor_utils::receptor_deploy(
-            shrine.contract_address,
-            receptor_utils::mock_oracle_extension(),
-            receptor_utils::INITIAL_TWAP_DURATION,
-            quote_tokens,
-            Option::None
+        receptor_utils::set_next_prices(
+            shrine.contract_address, mock_ekubo_oracle_extension_addr, quote_tokens, prices,
         );
 
-        println!("Receptor deployed");
+        let next_ts = get_block_timestamp() + receptor_utils::INITIAL_UPDATE_FREQUENCY;
+        start_warp(CheatTarget::All, next_ts);
+
+        let quotes: Span<Wad> = receptor.get_quotes();
+        let expected_yin_spot_price: Wad = *quotes[2];
+        let mut expected_prices: Span<Wad> = array![
+            1000158012403645039_u128.into(), // DAI
+            1001440899252887204_u128.into(), // USDC
+            1000271899695698999_u128.into(), // USDT
+        ]
+            .span();
+        let error_margin: Wad = 200_u128.into();
+
+        let mut quotes_copy = quotes;
+        loop {
+            match quotes_copy.pop_front() {
+                Option::Some(quote) => {
+                    let expected: Wad = *expected_prices.pop_front().unwrap();
+                    common::assert_equalish(*quote, expected, error_margin, 'wrong quote');
+                },
+                Option::None => { break; },
+            };
+        };
+
+        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
+        receptor.update_yin_price();
+
+        let after_yin_spot_price: Wad = shrine.get_yin_spot_price();
+        assert_eq!(after_yin_spot_price, expected_yin_spot_price, "wrong yin price in shrine #1");
+
+        let expected_receptor_events = array![
+            (
+                receptor.contract_address,
+                receptor_contract::Event::ValidQuotes(receptor_contract::ValidQuotes { quotes })
+            )
+        ];
+        receptor_spy.assert_emitted(@expected_receptor_events);
+
+        let expected_shrine_events = array![
+            (
+                shrine.contract_address,
+                shrine_contract::Event::YinPriceUpdated(
+                    shrine_contract::YinPriceUpdated {
+                        old_price: before_yin_spot_price, new_price: after_yin_spot_price
+                    }
+                )
+            )
+        ];
+        shrine_spy.assert_emitted(@expected_shrine_events);
+
+        // test unsuccessful update due to a zero price quote
+        let prices: Span<u256> = array![
+            340309250276362099785975626643777172060, // 1.000158012403645039602034587 DAI / CASH
+            0, // 1.001440899252887204535902704 USDC / CASH
+            340328625112763872478829777, // 1.000271899695698999556601210 USDT / CASH
+        ]
+            .span();
+        receptor_utils::set_next_prices(
+            shrine.contract_address, mock_ekubo_oracle_extension_addr, quote_tokens, prices,
+        );
+
+        let next_ts = get_block_timestamp() + receptor_utils::INITIAL_UPDATE_FREQUENCY;
+        start_warp(CheatTarget::All, next_ts);
+
+        let quotes: Span<Wad> = receptor.get_quotes();
+
+        receptor.update_yin_price();
+
+        assert_eq!(shrine.get_yin_spot_price(), expected_yin_spot_price, "wrong yin price in shrine #2");
+
+        let expected_receptor_events = array![
+            (
+                receptor.contract_address,
+                receptor_contract::Event::InvalidQuotes(receptor_contract::InvalidQuotes { quotes })
+            )
+        ];
+        receptor_spy.assert_emitted(@expected_receptor_events);
+    }
+
+    #[test]
+    fn test_update_yin_price_via_execute_task() {
+        let (shrine, receptor, mock_ekubo_oracle_extension_addr) = receptor_utils::receptor_deploy(Option::None);
+
+        let quote_tokens: Span<QuoteTokenInfo> = receptor_utils::quote_tokens();
+        // actual mainnet values from 1727418625 start time to 1727429425 end time
+        // converted in python
+        let prices: Span<u256> = array![
+            340309250276362099785975626643777172060, // 1.000158012403645039602034587 DAI / CASH
+            340527434977254803682969657, // 1.001440899252887204535902704 USDC / CASH
+            340328625112763872478829777, // 1.000271899695698999556601210 USDT / CASH
+        ]
+            .span();
+        receptor_utils::set_next_prices(
+            shrine.contract_address, mock_ekubo_oracle_extension_addr, quote_tokens, prices,
+        );
+
+        let next_ts = get_block_timestamp() + receptor_utils::INITIAL_UPDATE_FREQUENCY;
+        start_warp(CheatTarget::All, next_ts);
+
+        ITaskDispatcher { contract_address: receptor.contract_address }.execute_task();
+
+        let quotes: Span<Wad> = receptor.get_quotes();
+        let expected_yin_spot_price: Wad = *quotes[2];
+
+        let after_yin_spot_price: Wad = shrine.get_yin_spot_price();
+        assert_eq!(after_yin_spot_price, expected_yin_spot_price, "wrong yin price in shrine #1");
+    }
+
+    #[test]
+    fn test_probe_task() {
+        let (shrine, receptor, mock_ekubo_oracle_extension_addr) = receptor_utils::receptor_deploy(Option::None);
+
+        let quote_tokens: Span<QuoteTokenInfo> = receptor_utils::quote_tokens();
+        // actual mainnet values from 1727418625 start time to 1727429425 end time
+        // converted in python
+        let prices: Span<u256> = array![
+            340309250276362099785975626643777172060, // 1.000158012403645039602034587 DAI / CASH
+            340527434977254803682969657, // 1.001440899252887204535902704 USDC / CASH
+            340328625112763872478829777, // 1.000271899695698999556601210 USDT / CASH
+        ]
+            .span();
+        receptor_utils::set_next_prices(
+            shrine.contract_address, mock_ekubo_oracle_extension_addr, quote_tokens, prices,
+        );
+
+        let task = ITaskDispatcher { contract_address: receptor.contract_address };
+        assert(task.probe_task(), 'should be ready 1');
+
+        task.execute_task();
+
+        assert(!task.probe_task(), 'should not be ready 1');
+
+        start_warp(CheatTarget::All, get_block_timestamp() + receptor.get_update_frequency() - 1);
+        assert(!task.probe_task(), 'should not be ready 2');
+
+        start_warp(CheatTarget::All, get_block_timestamp() + 1);
+        assert(task.probe_task(), 'should be ready 2');
     }
 }

--- a/src/tests/receptor/test_receptor.cairo
+++ b/src/tests/receptor/test_receptor.cairo
@@ -145,13 +145,13 @@ mod test_receptor {
     }
 
     #[test]
-    #[should_panic(expected: ('REC: TWAP duration is 0',))]
+    #[should_panic(expected: ('REC: TWAP duration too low',))]
     fn test_set_twap_duration_zero_fail() {
         let token_class = declare("erc20_mintable").unwrap();
         let (_, receptor, _, _) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
 
         start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin().into());
-        receptor.set_twap_duration(0);
+        receptor.set_twap_duration(receptor_contract::MIN_TWAP_DURATION - 1);
     }
 
     #[test]

--- a/src/tests/receptor/utils.cairo
+++ b/src/tests/receptor/utils.cairo
@@ -1,0 +1,77 @@
+pub mod receptor_utils {
+    // use opus::interfaces::IERC20::{
+    //     IERC20Dispatcher, IERC20DispatcherTrait, IMintableDispatcher, IMintableDispatcherTrait
+    // };
+    // use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    // use opus::tests::common;
+    use opus::constants::{DAI_DECIMALS, USDC_DECIMALS, USDT_DECIMALS};
+    //use core::integer::BoundedInt;
+    //use core::num::traits::Zero;
+    use opus::core::receptor::receptor as receptor_contract;
+    use opus::tests::shrine::utils::shrine_utils;
+    use opus::types::QuoteTokenInfo;
+    use snforge_std::{declare, ContractClass, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget};
+    use starknet::ContractAddress;
+    use wadray::Wad;
+
+
+    //
+    // Address constants
+    //
+
+    pub const INITIAL_TWAP_DURATION: u64 = 10800; // 3 hrs
+
+    pub fn mock_usdc() -> ContractAddress {
+        'mock USDC'.try_into().unwrap()
+    }
+
+    pub fn mock_usdt() -> ContractAddress {
+        'mock USDT'.try_into().unwrap()
+    }
+
+    pub fn mock_dai() -> ContractAddress {
+        'mock DAI'.try_into().unwrap()
+    }
+
+    pub fn mock_oracle_extension() -> ContractAddress {
+        'mock oracle extension'.try_into().unwrap()
+    }
+
+    //
+    // Test setup helpers
+    //
+
+    pub fn receptor_deploy(
+        shrine: ContractAddress,
+        oracle_extension: ContractAddress,
+        twap_duration: u64,
+        mut quote_tokens: Span<QuoteTokenInfo>,
+        receptor_class: Option<ContractClass>
+    ) -> ContractAddress {
+        start_warp(CheatTarget::All, shrine_utils::DEPLOYMENT_TIMESTAMP);
+
+        let mut calldata: Array<felt252> = array![
+            shrine_utils::admin().into(),
+            shrine.into(),
+            oracle_extension.into(),
+            twap_duration.into(),
+            quote_tokens.len().into()
+        ];
+        loop {
+            match quote_tokens.pop_front() {
+                Option::Some(quote_token) => {
+                    calldata.append((*quote_token.address).into());
+                    calldata.append((*quote_token.decimals).into());
+                },
+                Option::None => { break; }
+            };
+        };
+
+        let receptor_class = match receptor_class {
+            Option::Some(class) => class,
+            Option::None => declare("receptor").unwrap(),
+        };
+        let (receptor_addr, _) = receptor_class.deploy(@calldata).expect('receptor deploy failed');
+        receptor_addr
+    }
+}

--- a/src/tests/receptor/utils.cairo
+++ b/src/tests/receptor/utils.cairo
@@ -140,7 +140,7 @@ pub mod receptor_utils {
             match quote_tokens.pop_front() {
                 Option::Some(quote_token) => {
                     mock_ekubo_oracle_extension_setter
-                        .next_get_price_x128_over_period(shrine_addr, *quote_token, *prices.pop_front().unwrap(),);
+                        .next_get_price_x128_over_lastd(shrine_addr, *quote_token, *prices.pop_front().unwrap(),);
                 },
                 Option::None => { break; }
             };

--- a/src/tests/receptor/utils.cairo
+++ b/src/tests/receptor/utils.cairo
@@ -34,6 +34,10 @@ pub mod receptor_utils {
         'mock DAI'.try_into().unwrap()
     }
 
+    pub fn mock_lusd() -> ContractAddress {
+        'mock LUSD'.try_into().unwrap()
+    }
+
     pub fn mock_oracle_extension() -> ContractAddress {
         'mock oracle extension'.try_into().unwrap()
     }

--- a/src/tests/receptor/utils.cairo
+++ b/src/tests/receptor/utils.cairo
@@ -140,7 +140,7 @@ pub mod receptor_utils {
             match quote_tokens.pop_front() {
                 Option::Some(quote_token) => {
                     mock_ekubo_oracle_extension_setter
-                        .next_get_price_x128_over_lastd(shrine_addr, *quote_token, *prices.pop_front().unwrap(),);
+                        .next_get_price_x128_over_last(shrine_addr, *quote_token, *prices.pop_front().unwrap(),);
                 },
                 Option::None => { break; }
             };

--- a/src/tests/receptor/utils.cairo
+++ b/src/tests/receptor/utils.cairo
@@ -1,13 +1,13 @@
 pub mod receptor_utils {
-    // use opus::interfaces::IERC20::{
-    //     IERC20Dispatcher, IERC20DispatcherTrait, IMintableDispatcher, IMintableDispatcherTrait
-    // };
-    // use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    // use opus::tests::common;
+    use access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
     use opus::constants::{DAI_DECIMALS, USDC_DECIMALS, USDT_DECIMALS};
-    //use core::integer::BoundedInt;
-    //use core::num::traits::Zero;
     use opus::core::receptor::receptor as receptor_contract;
+    use opus::core::roles::shrine_roles;
+    use opus::interfaces::IReceptor::{IReceptorDispatcher, IReceptorDispatcherTrait};
+    use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
+    use opus::mock::mock_ekubo_oracle_extension::{
+        IMockEkuboOracleExtensionDispatcher, IMockEkuboOracleExtensionDispatcherTrait
+    };
     use opus::tests::shrine::utils::shrine_utils;
     use opus::types::QuoteTokenInfo;
     use snforge_std::{declare, ContractClass, ContractClassTrait, start_prank, stop_prank, start_warp, CheatTarget};
@@ -16,10 +16,11 @@ pub mod receptor_utils {
 
 
     //
-    // Address constants
+    // constants
     //
 
     pub const INITIAL_TWAP_DURATION: u64 = 10800; // 3 hrs
+    pub const INITIAL_UPDATE_FREQUENCY: u64 = 1800; // 30 mins
 
     pub fn mock_usdc() -> ContractAddress {
         'mock USDC'.try_into().unwrap()
@@ -37,24 +38,52 @@ pub mod receptor_utils {
         'mock oracle extension'.try_into().unwrap()
     }
 
+    pub fn quote_tokens() -> Span<QuoteTokenInfo> {
+        array![
+            QuoteTokenInfo { address: mock_dai(), decimals: DAI_DECIMALS },
+            QuoteTokenInfo { address: mock_usdc(), decimals: USDC_DECIMALS },
+            QuoteTokenInfo { address: mock_usdt(), decimals: USDT_DECIMALS },
+        ]
+            .span()
+    }
+
     //
     // Test setup helpers
     //
 
-    pub fn receptor_deploy(
-        shrine: ContractAddress,
-        oracle_extension: ContractAddress,
-        twap_duration: u64,
-        mut quote_tokens: Span<QuoteTokenInfo>,
-        receptor_class: Option<ContractClass>
+    pub fn mock_ekubo_oracle_extension_deploy(
+        mock_ekubo_oracle_extension_class: Option<ContractClass>
     ) -> ContractAddress {
+        let mut calldata: Array<felt252> = ArrayTrait::new();
+
+        let mock_ekubo_oracle_extension_class = match mock_ekubo_oracle_extension_class {
+            Option::Some(class) => class,
+            Option::None => declare("mock_ekubo_oracle_extension").unwrap(),
+        };
+
+        let (mock_ekubo_oracle_extension_addr, _) = mock_ekubo_oracle_extension_class
+            .deploy(@calldata)
+            .expect('mock ekubo oracle ext failed');
+
+        mock_ekubo_oracle_extension_addr
+    }
+
+    pub fn receptor_deploy(
+        receptor_class: Option<ContractClass>
+    ) -> (IShrineDispatcher, IReceptorDispatcher, ContractAddress) {
         start_warp(CheatTarget::All, shrine_utils::DEPLOYMENT_TIMESTAMP);
+
+        let mut quote_tokens = quote_tokens();
+
+        let shrine: IShrineDispatcher = shrine_utils::shrine_deploy_and_setup(Option::None);
+        let mock_ekubo_oracle_extension_addr: ContractAddress = mock_ekubo_oracle_extension_deploy(Option::None);
 
         let mut calldata: Array<felt252> = array![
             shrine_utils::admin().into(),
-            shrine.into(),
-            oracle_extension.into(),
-            twap_duration.into(),
+            shrine.contract_address.into(),
+            mock_ekubo_oracle_extension_addr.into(),
+            INITIAL_UPDATE_FREQUENCY.into(),
+            INITIAL_TWAP_DURATION.into(),
             quote_tokens.len().into()
         ];
         loop {
@@ -72,6 +101,38 @@ pub mod receptor_utils {
             Option::None => declare("receptor").unwrap(),
         };
         let (receptor_addr, _) = receptor_class.deploy(@calldata).expect('receptor deploy failed');
-        receptor_addr
+
+        // Grant UPDATE_YIN_SPOT_PRICE role to receptor contract
+        start_prank(CheatTarget::One(shrine.contract_address), shrine_utils::admin());
+        let shrine_accesscontrol = IAccessControlDispatcher { contract_address: shrine.contract_address };
+        shrine_accesscontrol.grant_role(shrine_roles::receptor(), receptor_addr);
+        stop_prank(CheatTarget::One(shrine.contract_address));
+
+        (shrine, IReceptorDispatcher { contract_address: receptor_addr }, mock_ekubo_oracle_extension_addr)
+    }
+
+    pub fn set_next_prices(
+        shrine_addr: ContractAddress,
+        mock_ekubo_oracle_extension_addr: ContractAddress,
+        mut quote_tokens: Span<QuoteTokenInfo>,
+        mut prices: Span<u256>
+    ) {
+        let mock_ekubo_oracle_extension_setter = IMockEkuboOracleExtensionDispatcher {
+            contract_address: mock_ekubo_oracle_extension_addr
+        };
+
+        assert_eq!(quote_tokens.len(), prices.len(), "unequal len");
+
+        loop {
+            match quote_tokens.pop_front() {
+                Option::Some(quote_token) => {
+                    mock_ekubo_oracle_extension_setter
+                        .next_get_price_x128_over_period(
+                            shrine_addr, *quote_token.address, *prices.pop_front().unwrap(),
+                        );
+                },
+                Option::None => { break; }
+            };
+        };
     }
 }

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -2,8 +2,8 @@ mod test_math {
     use core::integer::BoundedInt;
     use core::num::traits::Zero;
     use opus::tests::common::assert_equalish;
-    use opus::utils::math::{pow, sqrt};
-    use wadray::{Ray, RAY_ONE};
+    use opus::utils::math::{pow, scale_x128_to_wad, sqrt};
+    use wadray::{Ray, RAY_ONE, Wad};
 
     #[test]
     fn test_sqrt() {
@@ -86,5 +86,32 @@ mod test_math {
         assert_equalish(
             pow::<Ray>(1414213562373095048801688724_u128.into(), 4), (4 * RAY_ONE).into(), ERROR_MARGIN, 'wrong pow #6'
         );
+    }
+
+    #[test]
+    fn test_scale_x128_to_wad() {
+        let error_margin: Wad = 200_u128.into();
+
+        // 18 decimals
+        let x128_val: u256 = 340351451218700252552422283729072753607;
+        let actual: Wad = scale_x128_to_wad(x128_val, 18);
+        let expected: Wad = 1000406082226072611_u128.into();
+        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #1');
+
+        let x128_val: u256 = 339351451218700252552422283729072753607;
+        let actual: Wad = scale_x128_to_wad(x128_val, 18);
+        let expected: Wad = 994536053393236430_u128.into();
+        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #2');
+
+        // 6 decimals
+        let x128_val: u256 = 340245254854570020996364378;
+        let actual: Wad = scale_x128_to_wad(x128_val, 6);
+        let expected: Wad = 999781886772824962_u128.into();
+        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #3');
+
+        let x128_val: u256 = 341245254854570020996364378;
+        let actual: Wad = scale_x128_to_wad(x128_val, 6);
+        let expected: Wad = 1005667353683370322_u128.into();
+        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #4');
     }
 }

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -2,7 +2,7 @@ mod test_math {
     use core::integer::BoundedInt;
     use core::num::traits::Zero;
     use opus::tests::common::assert_equalish;
-    use opus::utils::math::{pow, scale_x128_to_wad, sqrt};
+    use opus::utils::math::{median_of_three, pow, scale_x128_to_wad, sqrt};
     use wadray::{Ray, RAY_ONE, Wad};
 
     #[test]
@@ -113,5 +113,17 @@ mod test_math {
         let actual: Wad = scale_x128_to_wad(x128_val, 6);
         let expected: Wad = 1005667353683370322_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #4');
+    }
+
+    #[test]
+    fn test_median_of_three() {
+        let values: Span<u128> = array![1, 2, 3].span();
+        assert_eq!(median_of_three(values), 2, "wrong median #1");
+
+        let values: Span<u128> = array![2, 2, 3].span();
+        assert_eq!(median_of_three(values), 2, "wrong median #1");
+
+        let values: Span<u128> = array![2, 2, 2].span();
+        assert_eq!(median_of_three(values), 2, "wrong median #1");
     }
 }

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -181,6 +181,16 @@ impl RequestStorePacking of StorePacking<Request, felt252> {
 }
 
 //
+// Receptor
+//
+
+#[derive(Copy, Debug, Drop, PartialEq, Serde, starknet::Store)]
+pub struct QuoteTokenInfo {
+    pub address: ContractAddress,
+    pub decimals: u8,
+}
+
+//
 // Pragma
 //
 

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,6 +1,4 @@
-use core::integer::u256_sqrt;
-
-use core::integer::{u256_wide_mul, u512, u512_safe_div_rem_by_u256};
+use core::integer::{u256_sqrt, u256_wide_mul, u512, u512_safe_div_rem_by_u256};
 use core::num::traits::One;
 use core::traits::DivRem;
 use wadray::{Ray, u128_rdiv, u128_rmul, Wad, WAD_DECIMALS, WAD_SCALE};

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -55,7 +55,7 @@ pub fn scale_x128_to_wad(n: u256, decimals: u8) -> Wad {
 
     // Scale value up to Wad precision first to avoid precision loss during division
     let wad_scale: u256 = WAD_SCALE.into();
-    let scaled: u256 = n * wad_scale.into() * pow(10, decimals_diff).into();
+    let scaled: u256 = n * wad_scale * pow(10, decimals_diff).into();
     let sqrt: u256 = scaled / TWO_POW_128.into();
 
     // `sqrt` is of Wad precision here so the result will be of 10 ** 36 precision

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -67,3 +67,20 @@ pub fn scale_x128_to_wad(n: u256, decimals: u8) -> Wad {
     let val: u256 = val.try_into().unwrap();
     val.try_into().unwrap()
 }
+
+
+pub fn median_of_three<T, impl TPartialOrd: PartialOrd<T>, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(
+    values: Span<T>
+) -> T {
+    let a = *values[0];
+    let b = *values[1];
+    let c = *values[2];
+
+    if (a <= b && b <= c) || (c <= b && b <= a) {
+        b
+    } else if (b <= a && a <= c) || (c <= a && a <= b) {
+        a
+    } else {
+        c
+    }
+}

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -2,8 +2,6 @@ use core::integer::u256_sqrt;
 use core::num::traits::One;
 use wadray::{Ray, u128_rdiv, u128_rmul, Wad, WAD_DECIMALS};
 
-const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
-
 
 pub fn sqrt(x: Ray) -> Ray {
     let scaled_val: u256 = x.val.into() * wadray::RAY_SCALE.into();
@@ -44,8 +42,3 @@ pub fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
     u128_rdiv(lhs, rhs.val)
 }
 
-pub fn x128_to_wad(n: u256, decimals: u8) -> Wad {
-    let sqrt: u256 = n / TWO_POW_128;
-    let unscaled: u128 = (sqrt * sqrt).try_into().unwrap();
-    pow(unscaled, WAD_DECIMALS - decimals).into()
-}

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -2,6 +2,8 @@ use core::integer::u256_sqrt;
 use core::num::traits::One;
 use wadray::{Ray, u128_rdiv, u128_rmul, Wad, WAD_DECIMALS};
 
+const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
+
 
 pub fn sqrt(x: Ray) -> Ray {
     let scaled_val: u256 = x.val.into() * wadray::RAY_SCALE.into();
@@ -40,4 +42,10 @@ pub fn scale_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
 #[inline(always)]
 pub fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
     u128_rdiv(lhs, rhs.val)
+}
+
+pub fn x128_to_wad(n: u256, decimals: u8) -> Wad {
+    let sqrt: u256 = n / TWO_POW_128;
+    let unscaled: u128 = (sqrt * sqrt).try_into().unwrap();
+    pow(unscaled, WAD_DECIMALS - decimals).into()
 }

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,7 +1,12 @@
 use core::integer::u256_sqrt;
-use core::num::traits::One;
-use wadray::{Ray, u128_rdiv, u128_rmul, Wad, WAD_DECIMALS};
 
+use core::integer::{u256_wide_mul, u512, u512_safe_div_rem_by_u256};
+use core::num::traits::One;
+use core::traits::DivRem;
+use wadray::{Ray, u128_rdiv, u128_rmul, Wad, WAD_DECIMALS, WAD_SCALE};
+
+
+const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
 
 pub fn sqrt(x: Ray) -> Ray {
     let scaled_val: u256 = x.val.into() * wadray::RAY_SCALE.into();
@@ -42,3 +47,23 @@ pub fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
     u128_rdiv(lhs, rhs.val)
 }
 
+// If the quote token has less than 18 decimal precision, then the
+// x128 value needs to be scaled up by the quote token's decimals
+// https://docs.ekubo.org/integration-guides/reference/reading-pool-price
+pub fn scale_x128_to_wad(n: u256, decimals: u8) -> Wad {
+    let decimals_diff: u8 = WAD_DECIMALS - decimals;
+
+    // Scale value up to Wad precision first to avoid precision loss during division
+    let wad_scale: u256 = WAD_SCALE.into();
+    let scaled: u256 = n * wad_scale.into() * pow(10, decimals_diff).into();
+    let sqrt: u256 = scaled / TWO_POW_128.into();
+
+    // `sqrt` is of Wad precision here so the result will be of 10 ** 36 precision
+    let sq: u512 = u256_wide_mul(sqrt, sqrt);
+
+    // Scale the value back to Wad precision
+    let (val, _) = u512_safe_div_rem_by_u256(sq, wad_scale.try_into().unwrap());
+
+    let val: u256 = val.try_into().unwrap();
+    val.try_into().unwrap()
+}


### PR DESCRIPTION
This PR adds the Receptor (open to suggestions for names) module that submits yin's price to Shrine for the Controller to actuate on.

The yin price is taken as the median of CASH-{DAI, USDC, USDT} pairs from Ekubo's oracle extension, based on a TWAP duration that can be adjusted by admin. The quote tokens can also be adjusted if desired in the future e.g. swapping one of them out for LUSD. I considered taking the median of an arbitrary number of quotes, but that would make the contract unnecessary complex e.g. implementing a heap to sort any number of quotes.

Additionally, the Receptor module also implements the ITask interface to streamline its interaction by keepers. Therefore, the primary method of updating yin's price is via `ITask.execute_task()`. Nevertheless, there is also a `update_yin_price` that is restricted by access control that allows the update frequency of the task to be bypassed, similar to `seer.update_prices()` and `seer.execute_task()`. At the moment, this is not necessary, but it gives some flexibility for the future in case the yin's price needs to be updated in some user flow.

Initially, I wanted to include the Sepolia and mainnet scripts in this PR, but I think they can be taken up separately while UX design is ongoing.