### PR TITLE
script: deploy receptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Once you kill your Devnet instance, the state is lost unless the latest `devnet_
 | Gate[WSTETH] | `0x02d1e95661e7726022071c06a95cdae092595954096c373cde24a34bb3984cbf` |
 | Pragma      | `0x0734abeebd842926c860f3f82d23a7d2e0a24c8756d7f6b88a7456dc95a7e0fd` |
 | Purger      | `0x0149c1539f39945ce1f63917ff6076845888ab40e9327640cb78dcaebfed42e4` |
+| Receptor    | `0x11ded1ba51cd7fd7dff2ad5e92ed6c1bc7b5c905b7d5961a803f069a195341a`  |
 | Seer        | `0x07b4d65be7415812cea9edcfce5cf169217f4a53fce84e693fe8efb5be9f0437` |
 | Sentinel    | `0x06428ec3221f369792df13e7d59580902f1bfabd56a81d30224f4f282ba380cd` |
 | Shrine      | `0x0498edfaf50ca5855666a700c25dd629d577eb9afccdf3b5977aec79aee55ada` |

--- a/scripts/deployment/Scarb.toml
+++ b/scripts/deployment/Scarb.toml
@@ -26,6 +26,7 @@ build-external-contracts = [
     "opus::core::flash_mint::flash_mint",
     "opus::core::gate::gate",
     "opus::core::purger::purger",
+    "opus::core::receptor::receptor",
     "opus::core::seer::seer",
     "opus::core::sentinel::sentinel",
     "opus::core::shrine::shrine",

--- a/scripts/deployment/deploy_mainnet_alpha-mainnet_state.json
+++ b/scripts/deployment/deploy_mainnet_alpha-mainnet_state.json
@@ -1004,6 +1004,28 @@
         "status": "Success",
         "timestamp": 1719851246,
         "misc": null
+      },
+      "9fd28df144c99f124f3073ec264f4dfc262383fd0d7dc7cceb146566b7332a8a": {
+        "name": "declare",
+        "output": {
+          "type": "DeclareResponse",
+          "class_hash": "0x57bd7a6dbd72ec03094ac473b62c97e24f7244d7e622a42a3ec7d86ef2cd0b5",
+          "transaction_hash": "0x175f42b42cf1bafb788415944b768ca17970b759588f0d2eca0ede75b759379"
+        },
+        "status": "Success",
+        "timestamp": 1727965110,
+        "misc": null
+      },
+      "8452980510542669c3c0d25b7a2f58058f2bc0eedf6e76aa627b64885e909371": {
+        "name": "deploy",
+        "output": {
+          "type": "DeployResponse",
+          "contract_address": "0x11ded1ba51cd7fd7dff2ad5e92ed6c1bc7b5c905b7d5961a803f069a195341a",
+          "transaction_hash": "0x77d94ce478d41aac063bab7b5809c8098840295522ce615def5cc8365f8276e"
+        },
+        "status": "Success",
+        "timestamp": 1727965117,
+        "misc": null
       }
     }
   }

--- a/scripts/deployment/snfoundry.toml
+++ b/scripts/deployment/snfoundry.toml
@@ -6,7 +6,7 @@ url = "http://127.0.0.1:5050"
 [sncast.mainnet]
 account = "../mainnet_admin.json"
 keystore = "../mainnet_admin_keystore.json"
-url = ""
+url = "https://free-rpc.nethermind.io/mainnet-juno"
 
 [sncast.sepolia]
 account = "../sepolia_admin.json"

--- a/scripts/deployment/src/deploy_mainnet.cairo
+++ b/scripts/deployment/src/deploy_mainnet.cairo
@@ -224,6 +224,7 @@ fn main() {
     println!("Gate[WSTETH]: {}", wsteth_gate);
     println!("Pragma: {}", pragma);
     println!("Purger: {}", purger);
+    println!("Receptor: {}", receptor);
     println!("Seer: {}", seer);
     println!("Sentinel: {}", sentinel);
     println!("Shrine: {}", shrine);

--- a/scripts/deployment/src/deploy_mainnet.cairo
+++ b/scripts/deployment/src/deploy_mainnet.cairo
@@ -17,7 +17,7 @@ fn main() {
 
     println!("Deploying contracts");
 
-    // Deploy core contracts
+    // Deploy core contracts for launch
     let shrine: ContractAddress = core_deployment::deploy_shrine(admin);
     let flash_mint: ContractAddress = core_deployment::deploy_flash_mint(shrine);
     let sentinel: ContractAddress = core_deployment::deploy_sentinel(admin, shrine);
@@ -29,6 +29,9 @@ fn main() {
     let equalizer: ContractAddress = core_deployment::deploy_equalizer(admin, shrine, allocator);
     let caretaker: ContractAddress = core_deployment::deploy_caretaker(admin, shrine, abbot, sentinel, equalizer);
     let controller: ContractAddress = core_deployment::deploy_controller(admin, shrine);
+
+    // Deploy core contracts after launch
+    let receptor: ContractAddress = core_deployment::deploy_receptor(addresses::mainnet::multisig(), shrine);
 
     // Deploy transmuter
     let usdc_transmuter_restricted: ContractAddress = core_deployment::deploy_transmuter_restricted(

--- a/scripts/src/addresses.cairo
+++ b/scripts/src/addresses.cairo
@@ -211,20 +211,37 @@ pub mod mainnet {
     }
 
     // Tokens
-
+    //
+    // Unless otherwise stated, token's address is available at:
     // https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json
+
+    pub fn dai() -> ContractAddress {
+        0x05574eb6b8789a91466f902c380d978e472db68170ff82a5b650b95a58ddf4ad.try_into().expect('invalid DAI address')
+    }
+
     pub fn usdc() -> ContractAddress {
         0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8.try_into().expect('invalid USDC address')
     }
 
-    // https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json
+    pub fn usdt() -> ContractAddress {
+        0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8.try_into().expect('invalid USDC address')
+    }
+
     pub fn wbtc() -> ContractAddress {
         0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac.try_into().expect('invalid WBTC address')
     }
 
-    // https://research.lido.fi/t/wsteth-deployment-on-starknet/6335
     pub fn wsteth() -> ContractAddress {
         0x042b8f0484674ca266ac5d08e4ac6a3fe65bd3129795def2dca5c34ecc5f96d2.try_into().expect('invalid WSTETH address')
+    }
+
+    // External
+
+    // https://docs.ekubo.org/integration-guides/reference/contract-addresses
+    pub fn ekubo_oracle_extension() -> ContractAddress {
+        0x005e470ff654d834983a46b8f29dfa99963d5044b993cb7b9c92243a69dab38f
+            .try_into()
+            .expect('invalid ekubo oracle addr');
     }
 
     // https://github.com/Astraly-Labs/pragma-oracle?tab=readme-ov-file#deployment-addresses

--- a/scripts/src/addresses.cairo
+++ b/scripts/src/addresses.cairo
@@ -302,6 +302,10 @@ pub mod mainnet {
         0x0149c1539f39945ce1f63917ff6076845888ab40e9327640cb78dcaebfed42e4.try_into().unwrap()
     }
 
+    pub fn receptor() -> ContractAddress {
+        0x11ded1ba51cd7fd7dff2ad5e92ed6c1bc7b5c905b7d5961a803f069a195341a.try_into().unwrap()
+    }
+
     pub fn seer() -> ContractAddress {
         0x07b4d65be7415812cea9edcfce5cf169217f4a53fce84e693fe8efb5be9f0437.try_into().unwrap()
     }

--- a/scripts/src/addresses.cairo
+++ b/scripts/src/addresses.cairo
@@ -241,7 +241,7 @@ pub mod mainnet {
     pub fn ekubo_oracle_extension() -> ContractAddress {
         0x005e470ff654d834983a46b8f29dfa99963d5044b993cb7b9c92243a69dab38f
             .try_into()
-            .expect('invalid ekubo oracle addr');
+            .expect('invalid ekubo oracle addr')
     }
 
     // https://github.com/Astraly-Labs/pragma-oracle?tab=readme-ov-file#deployment-addresses


### PR DESCRIPTION
This PR adds a script to deploy receptor on mainnet. It does not grant permission yet for the Receptor to call `shrine.update_yin_spot_price()`, which can be done when the UI is ready.

Initial parameters are ~16.6 mins for update frequency (same as Seer), and 3hrs for TWAP.

I initially wanted to add support for Sepolia, but the prices on Sepolia are too way off (USDC/CASH is ~1.74, but DAI/CASH is ~0.00024) to be meaningful. This can be verified [here](https://sepolia.voyager.online/contract/0x003ccf3ee24638dd5f1a51ceb783e120695f53893f6fd947cc2dcabb3f86dc65#readContract) using the fake USDC (0x07ab0b8855a61f480b4423c46c32fa7c553f0aac3531bbddaa282d86244f7a23) and fake DAI (0x06f2a0dfeff180133de890ad69c6ba294574c5f34a67890fd22464f348c4d03c) by Ekubo.