### PR TITLE
fix: conversion of Ekubo x128 to Wad

### DIFF
--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -9,7 +9,7 @@ pub mod receptor {
     use opus::interfaces::IReceptor::IReceptor;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::QuoteTokenInfo;
-    use opus::utils::math::{median_of_three, scale_x128_to_wad};
+    use opus::utils::math::{median_of_three, ekubo_oracle_price_to_wad};
     use starknet::{ContractAddress, get_block_timestamp};
     use wadray::{Wad, WAD_DECIMALS};
 
@@ -62,7 +62,7 @@ pub mod receptor {
     }
 
     //
-    // Events 
+    // Events
     //
 
     #[event]
@@ -166,7 +166,7 @@ pub mod receptor {
                 let quote_token_info: QuoteTokenInfo = self.quote_tokens.read(index);
                 let quote: u256 = oracle_extension
                     .get_price_x128_over_last(cash, quote_token_info.address, twap_duration);
-                let scaled_quote: Wad = scale_x128_to_wad(quote, quote_token_info.decimals);
+                let scaled_quote: Wad = ekubo_oracle_price_to_wad(quote, quote_token_info.decimals);
 
                 quotes.append(scaled_quote);
                 index += 1;

--- a/src/tests/receptor/test_receptor.cairo
+++ b/src/tests/receptor/test_receptor.cairo
@@ -236,9 +236,9 @@ mod test_receptor {
         // actual mainnet values from 1727418625 start time to 1727429425 end time
         // converted in python
         let prices: Span<u256> = array![
-            340309250276362099785975626643777172060, // 1.000158012403645039602034587 DAI / CASH
-            340527434977254803682969657, // 1.001440899252887204535902704 USDC / CASH
-            340328625112763872478829777, // 1.000271899695698999556601210 USDT / CASH
+            340309250276362099785975626643777172060, // 1.000079003081079 DAI / CASH
+            340527434977254803682969657, // 1.0007201902894171 USDC / CASH
+            340328625112763872478829777, // 1.000135940607925 USDT / CASH
         ]
             .span();
         receptor_utils::set_next_prices(
@@ -251,9 +251,9 @@ mod test_receptor {
         let quotes: Span<Wad> = receptor.get_quotes();
         let expected_yin_spot_price: Wad = *quotes[2];
         let mut expected_prices: Span<Wad> = array![
-            1000158012403645039_u128.into(), // DAI
-            1001440899252887204_u128.into(), // USDC
-            1000271899695698999_u128.into(), // USDT
+            1000079003081079000_u128.into(), // DAI
+            1000720190289417000_u128.into(), // USDC
+            1000135940607925000_u128.into(), // USDT
         ]
             .span();
         let error_margin: Wad = 200_u128.into();

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -95,23 +95,23 @@ mod test_math {
         // 18 decimals
         let x128_val: u256 = 340351451218700252552422283729072753607;
         let actual: Wad = scale_x128_to_wad(x128_val, 18);
-        let expected: Wad = 1000406082226072611_u128.into();
+        let expected: Wad = 1000203020504373800_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #1');
 
         let x128_val: u256 = 339351451218700252552422283729072753607;
         let actual: Wad = scale_x128_to_wad(x128_val, 18);
-        let expected: Wad = 994536053393236430_u128.into();
+        let expected: Wad = 997264284627318000_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #2');
 
         // 6 decimals
         let x128_val: u256 = 340245254854570020996364378;
         let actual: Wad = scale_x128_to_wad(x128_val, 6);
-        let expected: Wad = 999781886772824962_u128.into();
+        let expected: Wad = 999890937439091300_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #3');
 
         let x128_val: u256 = 341245254854570020996364378;
         let actual: Wad = scale_x128_to_wad(x128_val, 6);
-        let expected: Wad = 1005667353683370322_u128.into();
+        let expected: Wad = 1002829673316147100_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #4');
     }
 

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -2,7 +2,7 @@ mod test_math {
     use core::integer::BoundedInt;
     use core::num::traits::Zero;
     use opus::tests::common::assert_equalish;
-    use opus::utils::math::{median_of_three, pow, scale_x128_to_wad, sqrt};
+    use opus::utils::math::{median_of_three, pow, ekubo_oracle_price_to_wad, sqrt};
     use wadray::{Ray, RAY_ONE, Wad};
 
     #[test]
@@ -89,28 +89,28 @@ mod test_math {
     }
 
     #[test]
-    fn test_scale_x128_to_wad() {
+    fn test_ekubo_oracle_price_to_wad() {
         let error_margin: Wad = 200_u128.into();
 
         // 18 decimals
         let x128_val: u256 = 340351451218700252552422283729072753607;
-        let actual: Wad = scale_x128_to_wad(x128_val, 18);
+        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 18);
         let expected: Wad = 1000203020504373800_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #1');
 
         let x128_val: u256 = 339351451218700252552422283729072753607;
-        let actual: Wad = scale_x128_to_wad(x128_val, 18);
+        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 18);
         let expected: Wad = 997264284627318000_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #2');
 
         // 6 decimals
         let x128_val: u256 = 340245254854570020996364378;
-        let actual: Wad = scale_x128_to_wad(x128_val, 6);
+        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 6);
         let expected: Wad = 999890937439091300_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #3');
 
         let x128_val: u256 = 341245254854570020996364378;
-        let actual: Wad = scale_x128_to_wad(x128_val, 6);
+        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 6);
         let expected: Wad = 1002829673316147100_u128.into();
         assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #4');
     }

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -47,8 +47,8 @@ pub fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
 
 // If the quote token has less than 18 decimal precision, then the
 // x128 value needs to be scaled up by the quote token's decimals
-// https://docs.ekubo.org/integration-guides/reference/reading-pool-price
-pub fn scale_x128_to_wad(n: u256, decimals: u8) -> Wad {
+// See https://docs.ekubo.org/integration-guides/reference/reading-pool-price
+pub fn ekubo_oracle_price_to_wad(n: u256, decimals: u8) -> Wad {
     // we multiply by WAD_SCALE to get it into Wad precision and then mul again
     // by the appropriate precision, all before dividing to prevent precision loss
     let val: u256 = n * WAD_SCALE.into() * pow(10, WAD_DECIMALS - decimals).into() / TWO_POW_128.into();

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -48,6 +48,8 @@ pub fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
 // If the quote token has less than 18 decimal precision, then the
 // x128 value needs to be scaled up by the quote token's decimals
 // See https://docs.ekubo.org/integration-guides/reference/reading-pool-price
+// for conversion of x128 values from the Ekubo Core. However, take note that 
+// Ekubo oracle extension already gives the squared price.
 pub fn ekubo_oracle_price_to_wad(n: u256, decimals: u8) -> Wad {
     // we multiply by WAD_SCALE to get it into Wad precision and then mul again
     // by the appropriate precision, all before dividing to prevent precision loss

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -49,20 +49,9 @@ pub fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
 // x128 value needs to be scaled up by the quote token's decimals
 // https://docs.ekubo.org/integration-guides/reference/reading-pool-price
 pub fn scale_x128_to_wad(n: u256, decimals: u8) -> Wad {
-    let decimals_diff: u8 = WAD_DECIMALS - decimals;
-
-    // Scale value up to Wad precision first to avoid precision loss during division
-    let wad_scale: u256 = WAD_SCALE.into();
-    let scaled: u256 = n * wad_scale * pow(10, decimals_diff).into();
-    let sqrt: u256 = scaled / TWO_POW_128.into();
-
-    // `sqrt` is of Wad precision here so the result will be of 10 ** 36 precision
-    let sq: u512 = u256_wide_mul(sqrt, sqrt);
-
-    // Scale the value back to Wad precision
-    let (val, _) = u512_safe_div_rem_by_u256(sq, wad_scale.try_into().unwrap());
-
-    let val: u256 = val.try_into().unwrap();
+    // we multiply by WAD_SCALE to get it into Wad precision and then mul again
+    // by the appropriate precision, all before dividing to prevent precision loss
+    let val: u256 = n * WAD_SCALE.into() * pow(10, WAD_DECIMALS - decimals).into() / TWO_POW_128.into();
     val.try_into().unwrap()
 }
 


### PR DESCRIPTION
Ekubo oracle price gives us already squared price (unlike the Core contract), so there's no need to do extra math. PR updates the way how we convert an x128 value to Wad - we just need to scale it up and div by 2^128.