### PR TITLE
script: add gate deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Once you kill your Devnet instance, the state is lost unless the latest `devnet_
 | Gate[STRK]  | `0x031a96fe18fe3fdab28822c82c81471f1802800723c8f3e209f1d9da53bc637d` |
 | Gate[WBTC]  | `0x05bc1c8a78667fac3bf9617903dbf2c1bfe3937e1d37ada3d8b86bf70fb7926e` |
 | Gate[WSTETH] | `0x02d1e95661e7726022071c06a95cdae092595954096c373cde24a34bb3984cbf` |
+| Gate[xSTRK] | `0x04a3e7dffd8e74a706be9abe6474e07fbbcf41e1be71387514c4977d54dbc428` |
+| Gate[sSTRK] | `0x03b709f3ab9bc072a195b907fb2c27688723b6e4abb812a8941def819f929bd8` |
 | Pragma      | `0x0734abeebd842926c860f3f82d23a7d2e0a24c8756d7f6b88a7456dc95a7e0fd` |
 | Purger      | `0x0149c1539f39945ce1f63917ff6076845888ab40e9327640cb78dcaebfed42e4` |
 | Receptor    | `0x059c159d9a87a34f17c4991e81b0d937aaf86a29f682ce0951536265bd6a1678` |

--- a/scripts/deployment/deploy_mainnet_alpha-mainnet_state.json
+++ b/scripts/deployment/deploy_mainnet_alpha-mainnet_state.json
@@ -1026,6 +1026,28 @@
         "status": "Success",
         "timestamp": 1730900237,
         "misc": null
+      },
+      "204eaaf9f37541e98f6aa621bfae3804d58fca6184170227979be6a05af5bb8a": {
+        "name": "deploy",
+        "output": {
+          "type": "DeployResponse",
+          "contract_address": "0x4a3e7dffd8e74a706be9abe6474e07fbbcf41e1be71387514c4977d54dbc428",
+          "transaction_hash": "0x28205ab99459c04b908a6ffa04cf67a60f520d069227c659fe7935d381f8191"
+        },
+        "status": "Success",
+        "timestamp": 1733363267,
+        "misc": null
+      },
+      "1861967d07085e1bf5bd5e86075acdcb5103b1ed4e937d3bdeff2edf318b41af": {
+        "name": "deploy",
+        "output": {
+          "type": "DeployResponse",
+          "contract_address": "0x3b709f3ab9bc072a195b907fb2c27688723b6e4abb812a8941def819f929bd8",
+          "transaction_hash": "0x79f074dd2c69a8b58f013d5d920fda2ced22a52dc5f149fa581265d3c71c458"
+        },
+        "status": "Success",
+        "timestamp": 1733363485,
+        "misc": null
       }
     }
   }

--- a/scripts/deployment/src/deploy_mainnet.cairo
+++ b/scripts/deployment/src/deploy_mainnet.cairo
@@ -45,6 +45,8 @@ fn main() {
     let strk: ContractAddress = addresses::strk_addr();
     let wbtc: ContractAddress = addresses::mainnet::wbtc();
     let wsteth: ContractAddress = addresses::mainnet::wsteth();
+    let xstrk: ContractAddress = addresses::mainnet::xstrk();
+    let sstrk: ContractAddress = addresses::mainnet::sstrk();
 
     let eth_gate: ContractAddress = core_deployment::deploy_gate(gate_class_hash, shrine, eth, sentinel, "ETH");
     let strk_gate: ContractAddress = core_deployment::deploy_gate(gate_class_hash, shrine, strk, sentinel, "STRK");
@@ -52,6 +54,8 @@ fn main() {
     let wsteth_gate: ContractAddress = core_deployment::deploy_gate(
         gate_class_hash, shrine, wsteth, sentinel, "WSTETH"
     );
+    let xstrk_gate: ContractAddress = core_deployment::deploy_gate(gate_class_hash, shrine, xstrk, sentinel, "xSTRK");
+    let sstrk_gate: ContractAddress = core_deployment::deploy_gate(gate_class_hash, shrine, sstrk, sentinel, "sSTRK");
 
     println!("Deploying oracles");
     let pragma: ContractAddress = core_deployment::deploy_pragma(
@@ -83,6 +87,8 @@ fn main() {
     utils::grant_role(shrine, usdc_transmuter_restricted, shrine_roles::transmuter(), "SHR -> TR[USDC]");
 
     // Adding ETH, STRK, WBTC and WSTETH yangs
+    // The admin role has been transferred to the multisig so any new collateral needs to 
+    // be added with the multisig.
     println!("Setting up Shrine");
 
     utils::add_yang_to_sentinel(
@@ -165,6 +171,9 @@ fn main() {
     utils::set_yang_pair_id_for_oracle(pragma, wbtc, WBTC_USD_PAIR_ID);
     utils::set_yang_pair_id_for_oracle(pragma, wsteth, WSTETH_USD_PAIR_ID);
 
+    // The admin role has been transferred to the multisig so any new pair IDs 
+    // need to be added with the multisig.
+
     // Set initial allocation
     let twenty_pct: felt252 = (20 * RAY_PERCENT).into();
     let eighty_pct: felt252 = (80 * RAY_PERCENT).into();
@@ -222,6 +231,8 @@ fn main() {
     println!("Gate[STRK]: {}", strk_gate);
     println!("Gate[WBTC]: {}", wbtc_gate);
     println!("Gate[WSTETH]: {}", wsteth_gate);
+    println!("Gate[xSTRK]: {}", xstrk_gate);
+    println!("Gate[sSTRK]: {}", sstrk_gate);
     println!("Pragma: {}", pragma);
     println!("Purger: {}", purger);
     println!("Receptor: {}", receptor);

--- a/scripts/src/addresses.cairo
+++ b/scripts/src/addresses.cairo
@@ -235,6 +235,14 @@ pub mod mainnet {
         0x042b8f0484674ca266ac5d08e4ac6a3fe65bd3129795def2dca5c34ecc5f96d2.try_into().expect('invalid WSTETH address')
     }
 
+    pub fn xstrk() -> ContractAddress {
+        0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a.try_into().expect('invalid xSTRK address')
+    }
+
+    pub fn sstrk() -> ContractAddress {
+        0x0356f304b154d29d2a8fe22f1cb9107a9b564a733cf6b4cc47fd121ac1af90c9.try_into().expect('invalid sSTRK address')
+    }
+
     // External
 
     // https://docs.ekubo.org/integration-guides/reference/contract-addresses
@@ -318,6 +326,10 @@ pub mod mainnet {
         0x0498edfaf50ca5855666a700c25dd629d577eb9afccdf3b5977aec79aee55ada.try_into().unwrap()
     }
 
+    pub fn sstrk_gate() -> ContractAddress {
+        0x03b709f3ab9bc072a195b907fb2c27688723b6e4abb812a8941def819f929bd8.try_into().unwrap()
+    }
+
     pub fn strk_gate() -> ContractAddress {
         0x031a96fe18fe3fdab28822c82c81471f1802800723c8f3e209f1d9da53bc637d.try_into().unwrap()
     }
@@ -332,5 +344,9 @@ pub mod mainnet {
 
     pub fn wsteth_gate() -> ContractAddress {
         0x02d1e95661e7726022071c06a95cdae092595954096c373cde24a34bb3984cbf.try_into().unwrap()
+    }
+
+    pub fn xstrk_gate() -> ContractAddress {
+        0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a.try_into().unwrap()
     }
 }


### PR DESCRIPTION
This PR adds the deployments for xSTRK and sSTRK gates. Other steps will need to be handled with the multisig since ownership has been transferred from the deployment wallet.