### PR TITLE
refactor: use Ekubo oracle adapter component for Receptor

### DIFF
--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -9,7 +9,8 @@ pub mod receptor {
     use opus::interfaces::IReceptor::IReceptor;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::QuoteTokenInfo;
-    use opus::utils::math::{median_of_three, ekubo_oracle_price_to_wad};
+    use opus::utils::ekubo_oracle_adapter::{ekubo_oracle_adapter_component, IEkuboOracleAdapter};
+    use opus::utils::math::median_of_three;
     use starknet::{ContractAddress, get_block_timestamp};
     use wadray::{Wad, WAD_DECIMALS};
 
@@ -23,14 +24,13 @@ pub mod receptor {
     impl AccessControlPublic = access_control_component::AccessControl<ContractState>;
     impl AccessControlHelpers = access_control_component::AccessControlHelpers<ContractState>;
 
+    component!(path: ekubo_oracle_adapter_component, storage: ekubo_oracle_adapter, event: EkuboOracleAdapterEvent);
+
+    impl EkuboOracleAdapterHelpers = ekubo_oracle_adapter_component::EkuboOracleAdapterHelpers<ContractState>;
+
     //
     // Constants
     //
-
-    const LOOP_START: u32 = 1;
-    pub const NUM_QUOTE_TOKENS: u32 = 3;
-
-    pub const MIN_TWAP_DURATION: u64 = 60; // seconds; acts as a sanity check
 
     pub const LOWER_UPDATE_FREQUENCY_BOUND: u64 = 15; // seconds (approx. Starknet block prod goal)
     pub const UPPER_UPDATE_FREQUENCY_BOUND: u64 = 4 * 60 * 60; // 4 hours * 60 minutes * 60 seconds
@@ -44,16 +44,10 @@ pub mod receptor {
         // components
         #[substorage(v0)]
         access_control: access_control_component::Storage,
+        #[substorage(v0)]
+        ekubo_oracle_adapter: ekubo_oracle_adapter_component::Storage,
         // Shrine associated with this module
         shrine: IShrineDispatcher,
-        // Ekubo oracle extension for reading TWAP
-        oracle_extension: IEkuboOracleExtensionDispatcher,
-        // Collection of quote tokens, in no particular order
-        // Starts from 1
-        // (idx) -> (token to be quoted per CASH)
-        quote_tokens: LegacyMap<u32, QuoteTokenInfo>,
-        // The duration in seconds for reading TWAP from Ekubo
-        twap_duration: u64,
         // Block timestamp of the last `update_yin_price_internal` execution
         last_update_yin_price_call_timestamp: u64,
         // The minimal time difference in seconds of how often we
@@ -69,10 +63,9 @@ pub mod receptor {
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
     pub enum Event {
         AccessControlEvent: access_control_component::Event,
+        EkuboOracleAdapterEvent: ekubo_oracle_adapter_component::Event,
         InvalidQuotes: InvalidQuotes,
-        QuoteTokensUpdated: QuoteTokensUpdated,
         ValidQuotes: ValidQuotes,
-        TwapDurationUpdated: TwapDurationUpdated,
         UpdateFrequencyUpdated: UpdateFrequencyUpdated,
     }
 
@@ -84,17 +77,6 @@ pub mod receptor {
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
     pub struct ValidQuotes {
         pub quotes: Span<Wad>
-    }
-
-    #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    pub struct QuoteTokensUpdated {
-        pub quote_tokens: Span<QuoteTokenInfo>
-    }
-
-    #[derive(Copy, Drop, starknet::Event, PartialEq)]
-    pub struct TwapDurationUpdated {
-        pub old_duration: u64,
-        pub new_duration: u64
     }
 
     #[derive(Copy, Drop, starknet::Event, PartialEq)]
@@ -121,10 +103,48 @@ pub mod receptor {
 
         self.shrine.write(IShrineDispatcher { contract_address: shrine });
 
-        self.set_oracle_extension_helper(oracle_extension);
-        self.set_twap_duration_helper(twap_duration);
-        self.set_quote_tokens_helper(quote_tokens);
+        self.ekubo_oracle_adapter.set_oracle_extension(oracle_extension);
+        self.ekubo_oracle_adapter.set_twap_duration(twap_duration);
+        self.ekubo_oracle_adapter.set_quote_tokens(quote_tokens);
+
         self.set_update_frequency_helper(update_frequency);
+    }
+
+    //
+    // External Ekubo oracle config functions
+    //
+
+    #[abi(embed_v0)]
+    impl IEkuboOracleAdapterImpl of IEkuboOracleAdapter<ContractState> {
+        fn get_oracle_extension(self: @ContractState) -> ContractAddress {
+            self.ekubo_oracle_adapter.get_oracle_extension().contract_address
+        }
+
+        fn get_quote_tokens(self: @ContractState) -> Span<QuoteTokenInfo> {
+            self.ekubo_oracle_adapter.get_quote_tokens()
+        }
+
+        fn get_twap_duration(self: @ContractState) -> u64 {
+            self.ekubo_oracle_adapter.get_twap_duration()
+        }
+
+        fn set_oracle_extension(ref self: ContractState, oracle_extension: ContractAddress) {
+            self.access_control.assert_has_role(receptor_roles::SET_QUOTE_TOKENS);
+
+            self.ekubo_oracle_adapter.set_oracle_extension(oracle_extension);
+        }
+
+        fn set_quote_tokens(ref self: ContractState, quote_tokens: Span<ContractAddress>) {
+            self.access_control.assert_has_role(receptor_roles::SET_QUOTE_TOKENS);
+
+            self.ekubo_oracle_adapter.set_quote_tokens(quote_tokens);
+        }
+
+        fn set_twap_duration(ref self: ContractState, twap_duration: u64) {
+            self.access_control.assert_has_role(receptor_roles::SET_TWAP_DURATION);
+
+            self.ekubo_oracle_adapter.set_twap_duration(twap_duration);
+        }
     }
 
     //
@@ -133,64 +153,12 @@ pub mod receptor {
 
     #[abi(embed_v0)]
     impl IReceptorImpl of IReceptor<ContractState> {
-        fn get_oracle_extension(self: @ContractState) -> ContractAddress {
-            self.oracle_extension.read().contract_address
-        }
-
-        fn get_quote_tokens(self: @ContractState) -> Span<QuoteTokenInfo> {
-            let mut quote_tokens: Array<QuoteTokenInfo> = Default::default();
-            let mut index: u32 = LOOP_START;
-            let end_index = LOOP_START + NUM_QUOTE_TOKENS;
-            loop {
-                if index == end_index {
-                    break quote_tokens.span();
-                }
-                quote_tokens.append(self.quote_tokens.read(index));
-                index += 1;
-            }
-        }
-
         fn get_quotes(self: @ContractState) -> Span<Wad> {
-            let oracle_extension = self.oracle_extension.read();
-            let twap_duration = self.twap_duration.read();
-            let cash = self.shrine.read().contract_address;
-
-            let mut quotes: Array<Wad> = Default::default();
-            let mut index: u32 = LOOP_START;
-            let end_index = LOOP_START + NUM_QUOTE_TOKENS;
-            loop {
-                if index == end_index {
-                    break quotes.span();
-                }
-
-                let quote_token_info: QuoteTokenInfo = self.quote_tokens.read(index);
-                let quote: u256 = oracle_extension
-                    .get_price_x128_over_last(cash, quote_token_info.address, twap_duration);
-                let scaled_quote: Wad = ekubo_oracle_price_to_wad(quote, quote_token_info.decimals);
-
-                quotes.append(scaled_quote);
-                index += 1;
-            }
-        }
-
-        fn get_twap_duration(self: @ContractState) -> u64 {
-            self.twap_duration.read()
+            self.ekubo_oracle_adapter.get_quotes(self.shrine.read().contract_address)
         }
 
         fn get_update_frequency(self: @ContractState) -> u64 {
             self.update_frequency.read()
-        }
-
-        fn set_oracle_extension(ref self: ContractState, oracle_extension: ContractAddress) {
-            self.access_control.assert_has_role(receptor_roles::SET_ORACLE_EXTENSION);
-
-            self.set_oracle_extension_helper(oracle_extension);
-        }
-
-        fn set_quote_tokens(ref self: ContractState, quote_tokens: Span<ContractAddress>) {
-            self.access_control.assert_has_role(receptor_roles::SET_QUOTE_TOKENS);
-
-            self.set_quote_tokens_helper(quote_tokens);
         }
 
         fn set_update_frequency(ref self: ContractState, new_frequency: u64) {
@@ -201,12 +169,6 @@ pub mod receptor {
             );
 
             self.set_update_frequency_helper(new_frequency);
-        }
-
-        fn set_twap_duration(ref self: ContractState, twap_duration: u64) {
-            self.access_control.assert_has_role(receptor_roles::SET_TWAP_DURATION);
-
-            self.set_twap_duration_helper(twap_duration);
         }
 
         fn update_yin_price(ref self: ContractState) {
@@ -235,47 +197,6 @@ pub mod receptor {
 
     #[generate_trait]
     impl ReceptorHelpers of ReceptorHelpersTrait {
-        fn set_oracle_extension_helper(ref self: ContractState, oracle_extension: ContractAddress) {
-            assert(oracle_extension.is_non_zero(), 'REC: Zero address for extension');
-
-            self.oracle_extension.write(IEkuboOracleExtensionDispatcher { contract_address: oracle_extension });
-        }
-
-        // Note that this function does not check for duplicate tokens.
-        fn set_quote_tokens_helper(ref self: ContractState, quote_tokens: Span<ContractAddress>) {
-            assert(quote_tokens.len() == NUM_QUOTE_TOKENS, 'REC: Not 3 quote tokens');
-
-            let mut index = LOOP_START;
-            let mut quote_tokens_copy = quote_tokens;
-            let mut quote_tokens_info: Array<QuoteTokenInfo> = Default::default();
-            loop {
-                match quote_tokens_copy.pop_front() {
-                    Option::Some(quote_token) => {
-                        let token = IERC20Dispatcher { contract_address: *quote_token };
-                        let decimals: u8 = token.decimals();
-                        assert(decimals <= WAD_DECIMALS, 'REC: Too many decimals');
-
-                        let quote_token_info = QuoteTokenInfo { address: *quote_token, decimals };
-                        self.quote_tokens.write(index, quote_token_info);
-                        quote_tokens_info.append(quote_token_info);
-                        index += 1;
-                    },
-                    Option::None => { break; }
-                }
-            };
-
-            self.emit(QuoteTokensUpdated { quote_tokens: quote_tokens_info.span() });
-        }
-
-        fn set_twap_duration_helper(ref self: ContractState, twap_duration: u64) {
-            assert(twap_duration >= MIN_TWAP_DURATION, 'REC: TWAP duration too low');
-
-            let old_duration: u64 = self.twap_duration.read();
-            self.twap_duration.write(twap_duration);
-
-            self.emit(TwapDurationUpdated { old_duration, new_duration: twap_duration });
-        }
-
         fn set_update_frequency_helper(ref self: ContractState, new_frequency: u64) {
             let old_frequency: u64 = self.update_frequency.read();
             self.update_frequency.write(new_frequency);

--- a/src/interfaces/IReceptor.cairo
+++ b/src/interfaces/IReceptor.cairo
@@ -1,19 +1,11 @@
-use opus::types::QuoteTokenInfo;
-use starknet::ContractAddress;
 use wadray::Wad;
 
 #[starknet::interface]
 pub trait IReceptor<TContractState> {
     // getters
-    fn get_oracle_extension(self: @TContractState) -> ContractAddress;
-    fn get_quote_tokens(self: @TContractState) -> Span<QuoteTokenInfo>;
     fn get_quotes(self: @TContractState) -> Span<Wad>;
-    fn get_twap_duration(self: @TContractState) -> u64;
     fn get_update_frequency(self: @TContractState) -> u64;
     // setters
-    fn set_oracle_extension(ref self: TContractState, oracle_extension: ContractAddress);
-    fn set_quote_tokens(ref self: TContractState, quote_tokens: Span<ContractAddress>);
-    fn set_twap_duration(ref self: TContractState, twap_duration: u64);
     fn set_update_frequency(ref self: TContractState, new_frequency: u64);
     fn update_yin_price(ref self: TContractState);
 }

--- a/src/tests/receptor/test_receptor.cairo
+++ b/src/tests/receptor/test_receptor.cairo
@@ -12,6 +12,9 @@ mod test_receptor {
     use opus::tests::receptor::utils::receptor_utils;
     use opus::tests::shrine::utils::shrine_utils;
     use opus::types::QuoteTokenInfo;
+    use opus::utils::ekubo_oracle_adapter::{
+        ekubo_oracle_adapter_component, IEkuboOracleAdapterDispatcher, IEkuboOracleAdapterDispatcherTrait
+    };
     use snforge_std::{
         declare, start_warp, start_prank, stop_prank, CheatTarget, spy_events, SpyOn, EventSpy, EventAssertions
     };
@@ -31,8 +34,13 @@ mod test_receptor {
         assert(receptor_ac.get_admin() == admin, 'wrong admin');
         assert(receptor_ac.get_roles(admin) == receptor_roles::default_admin_role(), 'wrong role');
 
-        assert_eq!(receptor.get_oracle_extension(), mock_ekubo_oracle_extension_addr, "wrong extension addr");
-        assert_eq!(receptor.get_twap_duration(), receptor_utils::INITIAL_TWAP_DURATION, "wrong twap duration");
+        let ekubo_oracle_adapter = IEkuboOracleAdapterDispatcher { contract_address: receptor.contract_address };
+        assert_eq!(
+            ekubo_oracle_adapter.get_oracle_extension(), mock_ekubo_oracle_extension_addr, "wrong extension addr"
+        );
+        assert_eq!(
+            ekubo_oracle_adapter.get_twap_duration(), receptor_utils::INITIAL_TWAP_DURATION, "wrong twap duration"
+        );
 
         let expected_quote_tokens_info: Span<QuoteTokenInfo> = array![
             QuoteTokenInfo { address: *quote_tokens[0], decimals: constants::DAI_DECIMALS },
@@ -40,76 +48,20 @@ mod test_receptor {
             QuoteTokenInfo { address: *quote_tokens[2], decimals: constants::USDT_DECIMALS },
         ]
             .span();
-        assert_eq!(receptor.get_quote_tokens(), expected_quote_tokens_info, "wrong quote tokens");
+        assert_eq!(ekubo_oracle_adapter.get_quote_tokens(), expected_quote_tokens_info, "wrong quote tokens");
     }
 
     // Parameters
-
-    #[test]
-    fn test_set_oracle_extension() {
-        let token_class = declare("erc20_mintable").unwrap();
-        let (_, receptor, _, _) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
-
-        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
-        let new_addr: ContractAddress = receptor_utils::mock_oracle_extension();
-        receptor.set_oracle_extension(new_addr);
-
-        assert_eq!(receptor.get_oracle_extension(), new_addr, "wrong extension addr");
-    }
 
     #[test]
     #[should_panic(expected: ('Caller missing role',))]
     fn test_set_oracle_extension_unauthorized() {
         let token_class = declare("erc20_mintable").unwrap();
         let (_, receptor, _, _) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
+        let ekubo_oracle_adapter = IEkuboOracleAdapterDispatcher { contract_address: receptor.contract_address };
 
         start_prank(CheatTarget::One(receptor.contract_address), common::badguy());
-        receptor.set_oracle_extension(receptor_utils::mock_oracle_extension());
-    }
-
-    #[test]
-    fn test_set_quote_tokens() {
-        let token_class = declare("erc20_mintable").unwrap();
-        let (_, receptor, _, quote_tokens) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
-        let mut spy = spy_events(SpyOn::One(receptor.contract_address));
-
-        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
-
-        let lusd: ContractAddress = common::lusd_token_deploy(Option::Some(token_class));
-        let new_quote_tokens: Span<ContractAddress> = array![*quote_tokens[0], *quote_tokens[1], lusd].span();
-        receptor.set_quote_tokens(new_quote_tokens);
-
-        let expected_quote_tokens_info: Span<QuoteTokenInfo> = array![
-            QuoteTokenInfo { address: *quote_tokens[0], decimals: constants::DAI_DECIMALS },
-            QuoteTokenInfo { address: *quote_tokens[1], decimals: constants::USDC_DECIMALS },
-            QuoteTokenInfo { address: lusd, decimals: constants::LUSD_DECIMALS },
-        ]
-            .span();
-        assert_eq!(receptor.get_quote_tokens(), expected_quote_tokens_info, "wrong quote tokens");
-
-        let expected_events = array![
-            (
-                receptor.contract_address,
-                receptor_contract::Event::QuoteTokensUpdated(
-                    receptor_contract::QuoteTokensUpdated { quote_tokens: expected_quote_tokens_info }
-                )
-            )
-        ];
-
-        spy.assert_emitted(@expected_events);
-    }
-
-    #[test]
-    #[should_panic(expected: ('REC: Too many decimals',))]
-    fn test_set_quote_tokens_too_many_decimals() {
-        let token_class = declare("erc20_mintable").unwrap();
-        let (_, receptor, _, quote_tokens) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
-
-        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin());
-
-        let invalid_token: ContractAddress = receptor_utils::invalid_token(Option::Some(token_class));
-        let new_quote_tokens: Span<ContractAddress> = array![*quote_tokens[0], *quote_tokens[1], invalid_token].span();
-        receptor.set_quote_tokens(new_quote_tokens);
+        ekubo_oracle_adapter.set_oracle_extension(receptor_utils::mock_oracle_extension());
     }
 
     #[test]
@@ -117,42 +69,10 @@ mod test_receptor {
     fn test_set_quote_tokens_unauthorized() {
         let token_class = declare("erc20_mintable").unwrap();
         let (_, receptor, _, quote_tokens) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
+        let ekubo_oracle_adapter = IEkuboOracleAdapterDispatcher { contract_address: receptor.contract_address };
 
         start_prank(CheatTarget::One(receptor.contract_address), common::badguy());
-        receptor.set_quote_tokens(quote_tokens);
-    }
-
-    #[test]
-    fn test_set_twap_duration_pass() {
-        let token_class = declare("erc20_mintable").unwrap();
-        let (_, receptor, _, _) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
-        let mut spy = spy_events(SpyOn::One(receptor.contract_address));
-
-        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin().into());
-        let old_duration: u64 = receptor_utils::INITIAL_TWAP_DURATION;
-        let new_duration: u64 = old_duration + 1;
-        receptor.set_twap_duration(new_duration);
-
-        let expected_events = array![
-            (
-                receptor.contract_address,
-                receptor_contract::Event::TwapDurationUpdated(
-                    receptor_contract::TwapDurationUpdated { old_duration, new_duration }
-                )
-            )
-        ];
-
-        spy.assert_emitted(@expected_events);
-    }
-
-    #[test]
-    #[should_panic(expected: ('REC: TWAP duration too low',))]
-    fn test_set_twap_duration_zero_fail() {
-        let token_class = declare("erc20_mintable").unwrap();
-        let (_, receptor, _, _) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
-
-        start_prank(CheatTarget::One(receptor.contract_address), shrine_utils::admin().into());
-        receptor.set_twap_duration(receptor_contract::MIN_TWAP_DURATION - 1);
+        ekubo_oracle_adapter.set_quote_tokens(quote_tokens);
     }
 
     #[test]
@@ -160,9 +80,10 @@ mod test_receptor {
     fn test_set_twap_duration_unauthorized_fail() {
         let token_class = declare("erc20_mintable").unwrap();
         let (_, receptor, _, _) = receptor_utils::receptor_deploy(Option::None, Option::Some(token_class));
+        let ekubo_oracle_adapter = IEkuboOracleAdapterDispatcher { contract_address: receptor.contract_address };
 
         start_prank(CheatTarget::One(receptor.contract_address), common::badguy());
-        receptor.set_twap_duration(receptor_utils::INITIAL_TWAP_DURATION + 1);
+        ekubo_oracle_adapter.set_twap_duration(receptor_utils::INITIAL_TWAP_DURATION + 1);
     }
 
     #[test]

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -2,7 +2,7 @@ mod test_math {
     use core::integer::BoundedInt;
     use core::num::traits::Zero;
     use opus::tests::common::assert_equalish;
-    use opus::utils::math::{convert_ekubo_oracle_price_to_wad, median_of_three, pow, ekubo_oracle_price_to_wad, sqrt};
+    use opus::utils::math::{convert_ekubo_oracle_price_to_wad, median_of_three, pow, sqrt};
     use wadray::{Ray, RAY_ONE, Wad};
 
     #[test]

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -89,33 +89,6 @@ mod test_math {
     }
 
     #[test]
-    fn test_ekubo_oracle_price_to_wad() {
-        let error_margin: Wad = 200_u128.into();
-
-        // 18 decimals
-        let x128_val: u256 = 340351451218700252552422283729072753607;
-        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 18);
-        let expected: Wad = 1000203020504373800_u128.into();
-        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #1');
-
-        let x128_val: u256 = 339351451218700252552422283729072753607;
-        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 18);
-        let expected: Wad = 997264284627318000_u128.into();
-        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #2');
-
-        // 6 decimals
-        let x128_val: u256 = 340245254854570020996364378;
-        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 6);
-        let expected: Wad = 999890937439091300_u128.into();
-        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #3');
-
-        let x128_val: u256 = 341245254854570020996364378;
-        let actual: Wad = ekubo_oracle_price_to_wad(x128_val, 6);
-        let expected: Wad = 1002829673316147100_u128.into();
-        assert_equalish(actual, expected, error_margin, 'wrong x128 to wad #4');
-    }
-
-    #[test]
     fn test_convert_ekubo_oracle_price_to_wad() {
         let error_margin: Wad = 200_u128.into();
 

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -45,21 +45,9 @@ pub fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
     u128_rdiv(lhs, rhs.val)
 }
 
-// NOTE: This has been deprecated in favour of `convert_ekubo_oracle_price_to_wad`.
-//       It should be used only if the quote token is guaranteed to be equal to or 
-//       smaller than the base token's decimals.
-// If the quote token has less than 18 decimal precision, then the
-// x128 value needs to be scaled up by the quote token's decimals
 // See https://docs.ekubo.org/integration-guides/reference/reading-pool-price
 // for conversion of x128 values from the Ekubo Core. However, take note that 
 // Ekubo oracle extension already gives the squared price.
-pub fn ekubo_oracle_price_to_wad(n: u256, decimals: u8) -> Wad {
-    // we multiply by WAD_SCALE to get it into Wad precision and then mul again
-    // by the appropriate precision, all before dividing to prevent precision loss
-    let val: u256 = n * WAD_SCALE.into() * pow(10, WAD_DECIMALS - decimals).into() / TWO_POW_128.into();
-    val.try_into().unwrap()
-}
-
 pub fn convert_ekubo_oracle_price_to_wad(n: u256, base_decimals: u8, quote_decimals: u8) -> Wad {
     // Adjust the scale based on the difference in precision between the base asset 
     // and the quote asset


### PR DESCRIPTION
This PR refactors the Receptor module to use the Ekubo oracle adapter component. It also removes duplicate tests and helper functions.