### PR TITLE
fix(receptor): update role for receptor function

### DIFF
--- a/src/core/receptor.cairo
+++ b/src/core/receptor.cairo
@@ -129,7 +129,7 @@ pub mod receptor {
         }
 
         fn set_oracle_extension(ref self: ContractState, oracle_extension: ContractAddress) {
-            self.access_control.assert_has_role(receptor_roles::SET_QUOTE_TOKENS);
+            self.access_control.assert_has_role(receptor_roles::SET_ORACLE_EXTENSION);
 
             self.ekubo_oracle_adapter.set_oracle_extension(oracle_extension);
         }


### PR DESCRIPTION
This PR fixes a minor bug introduced in https://github.com/lindy-labs/opus_contracts/commit/06f7bb6b35914a6eb89c4ad4258606ced5d5e7ea where the wrong role is used for `receptor.set_oracle_extension`.