### PR TITLE
chore[refactor]: use `Pow` trait

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -48,6 +48,5 @@ dependencies = [
 
 [[package]]
 name = "wadray"
-version = "0.5.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:efdcf25d14a3fdeed662a0f8de17b89a998166e3f884139197b4367337c2e8e2"
+version = "0.6.1"
+source = "git+https://github.com/tserg/cairo-wadray.git?branch=bump%2Fv0.6.1#6e7c125b969678ac32ef068bebc61e4a8c3ca810"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -20,7 +20,7 @@ sierra-replace-ids = true
 
 [dependencies]
 starknet = ">= 2.11.4"
-wadray = ">= 0.5.0"
+wadray = ">= 0.6.1"
 access_control = ">= 0.4.0"
 
 [dev-dependencies]

--- a/scripts/Scarb.lock
+++ b/scripts/Scarb.lock
@@ -52,6 +52,6 @@ checksum = "sha256:0884539863cd2b802eec9bcaecdb810fe130969e766f178d1e42220ddf653
 
 [[package]]
 name = "wadray"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:efdcf25d14a3fdeed662a0f8de17b89a998166e3f884139197b4367337c2e8e2"
+checksum = "sha256:09bd9792f7f91b3fdfabca48e77cc141c53ccdbbcb957c28ce222eac864a92d1"

--- a/scripts/Scarb.toml
+++ b/scripts/Scarb.toml
@@ -9,13 +9,13 @@ members = ["deployment", "simulation"]
 [dependencies]
 sncast_std = ">=0.41.0"
 starknet = ">=2.11.4"
-wadray = ">=0.5.0"
+wadray = ">=0.6.1"
 opus = { path = "../" }
 
 [workspace.dependencies]
 sncast_std = ">=0.41.0"
 starknet = ">=2.11.4"
-wadray = ">=0.5.0"
+wadray = ">=0.6.1"
 opus = { path = "../" }
 scripts = { path = "./" }
 

--- a/src/core/controller.cairo
+++ b/src/core/controller.cairo
@@ -1,11 +1,10 @@
 #[starknet::contract]
 pub mod controller {
     use access_control::access_control_component;
-    use core::num::traits::{Sqrt, Zero};
+    use core::num::traits::{Pow, Sqrt, Zero};
     use opus::core::roles::controller_roles;
     use opus::interfaces::IController::IController;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::math;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_block_timestamp};
     use wadray::{RAY_ONE, Ray, Signed, SignedRay, Wad, wad_to_signed_ray};
@@ -292,8 +291,8 @@ pub mod controller {
         } else {
             error.try_into().unwrap()
         };
-        let denominator: SignedRay = Sqrt::sqrt(RAY_ONE.into() + math::pow(error_ray, beta)).into();
-        math::pow(error, alpha) / denominator
+        let denominator: SignedRay = Sqrt::sqrt(RAY_ONE.into() + error_ray.pow(beta.into())).into();
+        error.pow(alpha.into()) / denominator
     }
 
     #[inline(always)]

--- a/src/core/controller.cairo
+++ b/src/core/controller.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub mod controller {
     use access_control::access_control_component;
-    use core::num::traits::Zero;
+    use core::num::traits::{Sqrt, Zero};
     use opus::core::roles::controller_roles;
     use opus::interfaces::IController::IController;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
@@ -292,7 +292,7 @@ pub mod controller {
         } else {
             error.try_into().unwrap()
         };
-        let denominator: SignedRay = math::sqrt(RAY_ONE.into() + math::pow(error_ray, beta)).into();
+        let denominator: SignedRay = Sqrt::sqrt(RAY_ONE.into() + math::pow(error_ray, beta)).into();
         math::pow(error, alpha) / denominator
     }
 

--- a/src/core/gate.cairo
+++ b/src/core/gate.cairo
@@ -1,10 +1,10 @@
 #[starknet::contract]
 pub mod gate {
-    use core::num::traits::Zero;
+    use core::num::traits::{Pow, Zero};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::IGate;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
-    use opus::utils::math::{fixed_point_to_wad, pow};
+    use opus::utils::math::fixed_point_to_wad;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
     use wadray::{WAD_DECIMALS, WAD_ONE, Wad};
@@ -165,7 +165,7 @@ pub mod gate {
                 // Scale `yang_amt` down by the difference to match the decimal
                 // precision of the asset. If asset is of `Wad` precision, then
                 // the same value is returned
-                yang_amt.into() / pow(10_u128, WAD_DECIMALS - decimals)
+                yang_amt.into() / 10_u128.pow((WAD_DECIMALS - decimals).into())
             } else {
                 // use u256 to avoid precision loss from Wad multiplication
                 let res: u256 = (yang_amt.into() * get_total_assets_helper(asset).into()) / total_yang.into();

--- a/src/core/seer.cairo
+++ b/src/core/seer.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub mod seer {
     use access_control::access_control_component;
-    use core::num::traits::Zero;
+    use core::num::traits::{Pow, Zero};
     use opus::core::roles::seer_roles;
     use opus::external::interfaces::ITask;
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -11,7 +11,6 @@ pub mod seer {
     use opus::interfaces::ISentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::{ConversionRateInfo, InternalPriceType, PriceType, YangSuspensionStatus};
-    use opus::utils::math::pow;
     use starknet::storage::{
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
@@ -205,7 +204,7 @@ pub mod seer {
 
                     let asset_decimals: u8 = IERC20Dispatcher { contract_address: asset }.decimals();
                     assert(asset_decimals <= WAD_DECIMALS, 'SEER: Too many decimals');
-                    let conversion_rate_scale: u128 = pow(10_u128, (WAD_DECIMALS - asset_decimals).into());
+                    let conversion_rate_scale: u128 = 10_u128.pow((WAD_DECIMALS - asset_decimals).into());
 
                     InternalPriceType::Vault(ConversionRateInfo { asset, conversion_rate_scale })
                 },

--- a/src/core/sentinel.cairo
+++ b/src/core/sentinel.cairo
@@ -1,14 +1,14 @@
 #[starknet::contract]
 pub mod sentinel {
     use access_control::access_control_component;
-    use core::num::traits::Zero;
+    use core::num::traits::{Pow, Zero};
     use opus::core::roles::sentinel_roles;
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::{IGateDispatcher, IGateDispatcherTrait};
     use opus::interfaces::ISentinel::ISentinel;
     use opus::interfaces::IShrine::{IShrineDispatcher, IShrineDispatcherTrait};
     use opus::types::YangSuspensionStatus;
-    use opus::utils::math::{fixed_point_to_wad, pow};
+    use opus::utils::math::fixed_point_to_wad;
     use starknet::storage::{
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
@@ -203,7 +203,7 @@ pub mod sentinel {
             // Require an initial deposit when adding a yang to prevent first depositor from front-running
             let yang_erc20 = IERC20Dispatcher { contract_address: yang };
             let yang_decimals = yang_erc20.decimals();
-            let initial_deposit_amt: u128 = pow(10_u128, yang_decimals / 2);
+            let initial_deposit_amt: u128 = 10_u128.pow((yang_decimals / 2).into());
 
             // scale `asset_amt` up by the difference to match `Wad` precision of yang
             let initial_yang_amt: Wad = fixed_point_to_wad(initial_deposit_amt, yang_decimals);

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -1,4 +1,4 @@
-use core::num::traits::Zero;
+use core::num::traits::{Pow, Zero};
 use opus::constants::{DAI_DECIMALS, LUSD_DECIMALS, USDC_DECIMALS, USDT_DECIMALS};
 use opus::core::shrine::shrine;
 use opus::interfaces::IAbbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
@@ -10,7 +10,6 @@ use opus::mock::mock_ekubo_oracle_extension::IMockEkuboOracleExtensionDispatcher
 use opus::tests::sentinel::utils::sentinel_utils;
 use opus::tests::shrine::utils::shrine_utils;
 use opus::types::{AssetBalance, Reward};
-use opus::utils::math::pow;
 use snforge_std::{
     ContractClass, ContractClassTrait, DeclareResultTrait, Event, declare, start_cheat_block_timestamp_global,
     start_cheat_caller_address, stop_cheat_caller_address,
@@ -242,7 +241,9 @@ pub fn deploy_vault(
 
     // Mock initial conversion rate of 1 : 1
     IMockERC4626Dispatcher { contract_address: vault_addr }
-        .set_convert_to_assets_per_wad_scale(pow(10, IERC20Dispatcher { contract_address: asset }.decimals()));
+        .set_convert_to_assets_per_wad_scale(
+            10_u128.pow(IERC20Dispatcher { contract_address: asset }.decimals().into()).into(),
+        );
 
     vault_addr
 }

--- a/src/tests/external/test_pragma.cairo
+++ b/src/tests/external/test_pragma.cairo
@@ -1,6 +1,6 @@
 mod test_pragma {
     use access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use core::num::traits::Zero;
+    use core::num::traits::{Pow, Zero};
     use core::result::ResultTrait;
     use opus::constants::{ETH_USD_PAIR_ID, PRAGMA_DECIMALS};
     use opus::core::shrine::shrine;
@@ -15,7 +15,6 @@ mod test_pragma {
     use opus::tests::seer::utils::seer_utils;
     use opus::tests::sentinel::utils::sentinel_utils;
     use opus::types::pragma::{AggregationMode, PairSettings, PragmaPricesResponse, PriceValidityThresholds};
-    use opus::utils::math::pow;
     use snforge_std::{
         EventSpyAssertionsTrait, spy_events, start_cheat_block_timestamp_global, start_cheat_caller_address,
         stop_cheat_caller_address,
@@ -24,6 +23,7 @@ mod test_pragma {
     use wadray::{WAD_DECIMALS, WAD_SCALE, Wad};
 
     const TS: u64 = 1700000000; // arbitrary timestamp
+    const PRAGMA_SCALE: u128 = 10_u128.pow(PRAGMA_DECIMALS.into());
 
     //
     // Tests - Deployment and setters
@@ -160,7 +160,7 @@ mod test_pragma {
             'Pepe', 'PEPE', 18, 0.into(), common::NON_ZERO_ADDR, Option::None,
         );
         let pepe_token_pair_id: felt252 = pragma_utils::PEPE_USD_PAIR_ID;
-        let price: u128 = 999 * pow(10_u128, PRAGMA_DECIMALS);
+        let price: u128 = 999 * PRAGMA_SCALE;
         let current_ts: u64 = get_block_timestamp();
         // Seed first price update for PEPE token so that `Pragma.set_yang_pair_settings` passes
         pragma_utils::mock_valid_price_update(mock_pragma, pepe_token, price.into(), current_ts);
@@ -196,7 +196,7 @@ mod test_pragma {
         let pepe_token_pair_id: felt252 = pragma_utils::PEPE_USD_PAIR_ID;
         let pair_settings = PairSettings { pair_id: pepe_token_pair_id, aggregation_mode: AggregationMode::Median };
 
-        let price: u128 = 999 * pow(10_u128, PRAGMA_DECIMALS);
+        let price: u128 = 999 * PRAGMA_SCALE;
         let current_ts: u64 = get_block_timestamp();
         // Seed first price update for PEPE token so that `Pragma.set_yang_pair_settings` passes
         pragma_utils::mock_valid_price_update(mock_pragma, pepe_token, price.into(), current_ts);
@@ -307,9 +307,7 @@ mod test_pragma {
     fn test_set_yang_pair_settings_spot_too_many_decimals_fail() {
         let PragmaTestConfig { pragma, mock_pragma } = pragma_utils::pragma_deploy(Option::None, Option::None);
 
-        let pragma_price_scale: u128 = pow(10_u128, PRAGMA_DECIMALS);
-
-        let pepe_price: u128 = 1000000 * pragma_price_scale; // random price
+        let pepe_price: u128 = 1000000 * PRAGMA_SCALE; // random price
         let invalid_decimals: u32 = (WAD_DECIMALS + 1).into();
         let pepe_response = PragmaPricesResponse {
             price: pepe_price,
@@ -333,9 +331,7 @@ mod test_pragma {
     fn test_set_yang_pair_settings_twap_too_many_decimals_fail() {
         let PragmaTestConfig { pragma, mock_pragma } = pragma_utils::pragma_deploy(Option::None, Option::None);
 
-        let pragma_price_scale: u128 = pow(10_u128, PRAGMA_DECIMALS);
-
-        let pepe_price: u128 = 1000000 * pragma_price_scale; // random price
+        let pepe_price: u128 = 1000000 * PRAGMA_SCALE; // random price
         let pepe_spot_response = PragmaPricesResponse {
             price: pepe_price,
             decimals: PRAGMA_DECIMALS.into(),

--- a/src/tests/external/utils.cairo
+++ b/src/tests/external/utils.cairo
@@ -9,7 +9,7 @@ pub fn pepe_token_addr() -> ContractAddress {
 }
 
 pub mod pragma_utils {
-    use core::traits::Into;
+    use core::num::traits::Pow;
     use opus::constants::{ETH_USD_PAIR_ID, PRAGMA_DECIMALS, WBTC_USD_PAIR_ID};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IOracle::{IOracleDispatcher, IOracleDispatcherTrait};
@@ -17,7 +17,6 @@ pub mod pragma_utils {
     use opus::mock::mock_pragma::{IMockPragmaDispatcher, IMockPragmaDispatcherTrait};
     use opus::tests::seer::utils::seer_utils::{ETH_INIT_PRICE, WBTC_INIT_PRICE};
     use opus::types::pragma::{AggregationMode, PairSettings, PragmaPricesResponse};
-    use opus::utils::math::pow;
     use snforge_std::{
         ContractClass, ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
         stop_cheat_caller_address,
@@ -115,7 +114,7 @@ pub mod pragma_utils {
     //
 
     pub fn convert_price_to_pragma_scale(price: Wad) -> u128 {
-        let scale: u128 = pow(10_u128, WAD_DECIMALS - PRAGMA_DECIMALS);
+        let scale: u128 = 10_u128.pow((WAD_DECIMALS - PRAGMA_DECIMALS).into());
         price.into() / scale
     }
 

--- a/src/tests/purger/test_purger.cairo
+++ b/src/tests/purger/test_purger.cairo
@@ -1,7 +1,7 @@
 mod test_purger {
     use access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
     use core::cmp::{max, min};
-    use core::num::traits::{Bounded, Zero};
+    use core::num::traits::{Bounded, Pow, Zero};
     use opus::core::absorber::absorber as absorber_contract;
     use opus::core::purger::purger as purger_contract;
     use opus::core::roles::purger_roles;
@@ -20,7 +20,7 @@ mod test_purger {
     use opus::tests::purger::utils::purger_utils::PurgerTestConfig;
     use opus::tests::shrine::utils::shrine_utils;
     use opus::types::{AssetBalance, Health, HealthTrait};
-    use opus::utils::math::{pow, scale_u128_by_ray};
+    use opus::utils::math::scale_u128_by_ray;
     use snforge_std::{
         EventSpyAssertionsTrait, EventSpyTrait, EventsFilterTrait, spy_events, start_cheat_block_timestamp_global,
         start_cheat_caller_address, stop_cheat_caller_address,
@@ -291,7 +291,7 @@ mod test_purger {
             } else {
                 let target_trove_yang_amts: Span<Wad> = array![
                     purger_utils::TARGET_TROVE_ETH_DEPOSIT_AMT.into(),
-                    (purger_utils::TARGET_TROVE_WBTC_DEPOSIT_AMT * pow(10_u128, 10)).into(),
+                    (purger_utils::TARGET_TROVE_WBTC_DEPOSIT_AMT * 10_u128.pow(10)).into(),
                 ]
                     .span();
 
@@ -536,7 +536,7 @@ mod test_purger {
                 // not lowering it.
                 let target_trove_yang_amts: Span<Wad> = array![
                     purger_utils::TARGET_TROVE_ETH_DEPOSIT_AMT.into(),
-                    (purger_utils::TARGET_TROVE_WBTC_DEPOSIT_AMT * pow(10_u128, 10)).into(),
+                    (purger_utils::TARGET_TROVE_WBTC_DEPOSIT_AMT * 10_u128.pow(10)).into(),
                 ]
                     .span();
 
@@ -1937,9 +1937,8 @@ mod test_purger {
                 let remainder_trove_yang: Wad = shrine.get_deposit(*yangs_copy.pop_front().unwrap(), target_trove);
                 let remainder_asset_amt: u128 = gate.convert_to_assets(remainder_trove_yang);
 
-                let error_margin: u128 = pow(
-                    10_u128, IERC20Dispatcher { contract_address: gate.get_asset() }.decimals() / 2,
-                );
+                let error_margin: u128 = 10_u128
+                    .pow((IERC20Dispatcher { contract_address: gate.get_asset() }.decimals() / 2).into());
                 common::assert_equalish(
                     remainder_asset_amt, *expected_asset_amt, error_margin, 'wrong remainder yang asset',
                 );

--- a/src/tests/sentinel/utils.cairo
+++ b/src/tests/sentinel/utils.cairo
@@ -1,6 +1,6 @@
 pub mod sentinel_utils {
     use access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
-    use core::num::traits::Bounded;
+    use core::num::traits::{Bounded, Pow};
     use opus::core::roles::{sentinel_roles, shrine_roles};
     use opus::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use opus::interfaces::IGate::IGateDispatcher;
@@ -9,7 +9,6 @@ pub mod sentinel_utils {
     use opus::tests::common;
     use opus::tests::gate::utils::gate_utils;
     use opus::tests::shrine::utils::shrine_utils;
-    use opus::utils::math::pow;
     use snforge_std::{
         ContractClass, ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
         stop_cheat_caller_address,
@@ -310,6 +309,6 @@ pub mod sentinel_utils {
     }
 
     pub fn get_initial_asset_amt(asset_addr: ContractAddress) -> u128 {
-        pow(10_u128, IERC20Dispatcher { contract_address: asset_addr }.decimals() / 2)
+        10_u128.pow((IERC20Dispatcher { contract_address: asset_addr }.decimals() / 2).into())
     }
 }

--- a/src/tests/transmuter/test_transmuter.cairo
+++ b/src/tests/transmuter/test_transmuter.cairo
@@ -1,7 +1,7 @@
 mod test_transmuter {
     use access_control::{IAccessControlDispatcher, IAccessControlDispatcherTrait};
     use core::cmp::min;
-    use core::num::traits::{Bounded, Zero};
+    use core::num::traits::{Bounded, Pow, Zero};
     use opus::core::roles::transmuter_roles;
     use opus::core::transmuter::transmuter as transmuter_contract;
     use opus::interfaces::IERC20::{
@@ -13,7 +13,7 @@ mod test_transmuter {
     use opus::tests::shrine::utils::shrine_utils;
     use opus::tests::transmuter::utils::transmuter_utils;
     use opus::tests::transmuter::utils::transmuter_utils::TransmuterTestConfig;
-    use opus::utils::math::{fixed_point_to_wad, pow, wad_to_fixed_point};
+    use opus::utils::math::{fixed_point_to_wad, wad_to_fixed_point};
     use snforge_std::{
         ContractClass, EventSpyAssertionsTrait, spy_events, start_cheat_caller_address, stop_cheat_caller_address,
     };
@@ -416,7 +416,7 @@ mod test_transmuter {
 
             // Set up transmute amount to be equivalent to 1_000 (Wad) yin
             let asset_decimals: u8 = asset.decimals();
-            let transmute_amt: u128 = real_transmute_amt * pow(10, asset_decimals);
+            let transmute_amt: u128 = real_transmute_amt * 10_u128.pow(asset_decimals.into());
 
             let mut expected_wad_transmuted_amts_copy = expected_wad_transmuted_amts;
 
@@ -591,7 +591,7 @@ mod test_transmuter {
             // Transmute an amount of yin to set up Transmuter for reverse
             let asset_decimals: u8 = asset.decimals();
             let real_transmute_amt: u128 = reverse_fees.len().into() * real_reverse_amt;
-            let asset_decimal_scale: u128 = pow(10, asset_decimals);
+            let asset_decimal_scale: u128 = 10_u128.pow(asset_decimals.into());
             let transmute_amt: u128 = real_transmute_amt * asset_decimal_scale;
 
             start_cheat_caller_address(transmuter.contract_address, user);
@@ -754,7 +754,7 @@ mod test_transmuter {
                 shrine, transmuter, shrine_debt_ceiling, seed_amt, receiver, user,
             );
 
-            let mut transmute_asset_amts: Span<u128> = array![0, 1000 * pow(10, asset_decimals)].span();
+            let mut transmute_asset_amts: Span<u128> = array![0, 1000 * 10_u128.pow(asset_decimals.into())].span();
 
             for transmute_asset_amt in transmute_asset_amts {
                 let mut spy = spy_events();
@@ -840,7 +840,7 @@ mod test_transmuter {
                     Option::Some(token_class),
                 );
                 let secondary_asset_erc20 = IERC20Dispatcher { contract_address: secondary_asset };
-                let secondary_asset_amt: u128 = pow(10, *secondary_asset_decimal);
+                let secondary_asset_amt: u128 = 10_u128.pow((*secondary_asset_decimal).into());
 
                 let shrine_debt_ceiling: Wad = transmuter_utils::INITIAL_CEILING.into();
                 let seed_amt: Wad = (100000 * WAD_ONE).into();
@@ -958,7 +958,7 @@ mod test_transmuter {
         };
         let asset_decimals: u8 = asset.decimals();
 
-        let transmute_asset_amts: Span<u128> = array![0, 1000 * pow(10, asset_decimals)].span();
+        let transmute_asset_amts: Span<u128> = array![0, 1000 * 10_u128.pow(asset_decimals.into())].span();
 
         for transmute_asset_amt in transmute_asset_amts {
             // parametrize amount of yin in Transmuter at time of settlement
@@ -1135,8 +1135,8 @@ mod test_transmuter {
                 transmuter_utils::nonwad_usd_stable_deploy(Option::Some(token_class))
             };
             let asset_decimals: u8 = asset.decimals();
-            let asset_decimal_scale: u128 = pow(10, asset_decimals);
-            let transmute_asset_amt: u128 = 1000 * pow(10, asset_decimals);
+            let asset_decimal_scale: u128 = 10_u128.pow(asset_decimals.into());
+            let transmute_asset_amt: u128 = 1000 * asset_decimal_scale;
 
             let shrine: IShrineDispatcher = shrine_utils::shrine_setup_with_feed(Option::Some(shrine_class));
 

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -1,68 +1,7 @@
 mod test_math {
-    use core::num::traits::{Bounded, Zero};
     use opus::tests::common::assert_equalish;
-    use opus::utils::math::{convert_ekubo_oracle_price_to_wad, median_of_three, pow, sqrt};
+    use opus::utils::math::{convert_ekubo_oracle_price_to_wad, median_of_three, pow};
     use wadray::{RAY_ONE, Ray, Wad};
-
-    #[test]
-    fn test_sqrt() {
-        let ERROR_MARGIN: Ray = 1_u128.into();
-
-        assert(sqrt(0_u128.into()) == Zero::zero(), 'wrong sqrt #1');
-
-        // Ground truth tests
-
-        // 1000
-        assert_equalish(
-            sqrt(1000000000000000000000000000000_u128.into()),
-            31622776601683793319988935444_u128.into(),
-            ERROR_MARGIN,
-            'wrong sqrt #2',
-        );
-
-        // 6969
-        assert_equalish(
-            sqrt(6969000000000000000000000000000_u128.into()),
-            83480536653761396384637711221_u128.into(),
-            ERROR_MARGIN,
-            'wrong sqrt #3',
-        );
-
-        // pi
-        assert_equalish(
-            sqrt(3141592653589793238462643383_u128.into()),
-            1772453850905516027298167483_u128.into(),
-            ERROR_MARGIN,
-            'wrong sqrt #4',
-        );
-
-        // e
-        assert_equalish(
-            sqrt(2718281828459045235360287471_u128.into()),
-            1648721270700128146848650787_u128.into(),
-            ERROR_MARGIN,
-            'wrong sqrt #5',
-        );
-
-        // Testing the property x = sqrt(x)^2
-
-        let ERROR_MARGIN = 1000_u128.into();
-
-        assert_equalish((4 * RAY_ONE).into(), pow(sqrt((4 * RAY_ONE).into()), 2), ERROR_MARGIN, 'wrong sqrt #6');
-
-        assert_equalish((1000 * RAY_ONE).into(), pow(sqrt((1000 * RAY_ONE).into()), 2), ERROR_MARGIN, 'wrong sqrt #7');
-
-        // tau
-        assert_equalish(
-            6283185307179586476925286766_u128.into(),
-            pow(sqrt(6283185307179586476925286766_u128.into()), 2),
-            ERROR_MARGIN,
-            'wrong sqrt #8',
-        );
-
-        // testing the maximum possible value `sqrt` could accept doesn't cause it to fail
-        sqrt(Bounded::MAX);
-    }
 
     #[test]
     fn test_pow() {

--- a/src/tests/utils/test_math.cairo
+++ b/src/tests/utils/test_math.cairo
@@ -1,30 +1,7 @@
 mod test_math {
     use opus::tests::common::assert_equalish;
-    use opus::utils::math::{convert_ekubo_oracle_price_to_wad, median_of_three, pow};
-    use wadray::{RAY_ONE, Ray, Wad};
-
-    #[test]
-    fn test_pow() {
-        // u128 tests
-        assert(pow(5_u128, 3) == 125_u128, 'wrong pow #1');
-        assert(pow(5_u128, 0) == 1_u128, 'wrong pow #2');
-        assert(pow(5_u128, 1) == 5_u128, 'wrong pow #3');
-        assert(pow(5_u128, 2) == 25_u128, 'wrong pow #4');
-
-        // Ray tests
-        let ERROR_MARGIN = 1000_u128.into();
-
-        assert_equalish(
-            pow::<Ray>(3141592653589793238462643383_u128.into(), 2),
-            9869604401089358618834490999_u128.into(),
-            ERROR_MARGIN,
-            'wrong pow #5',
-        );
-
-        assert_equalish(
-            pow::<Ray>(1414213562373095048801688724_u128.into(), 4), (4 * RAY_ONE).into(), ERROR_MARGIN, 'wrong pow #6',
-        );
-    }
+    use opus::utils::math::{convert_ekubo_oracle_price_to_wad, median_of_three};
+    use wadray::Wad;
 
     #[test]
     fn test_convert_ekubo_oracle_price_to_wad() {

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,31 +1,19 @@
-use core::num::traits::One;
+use core::num::traits::Pow;
 use wadray::{Ray, WAD_DECIMALS, WAD_SCALE, Wad, u128_rdiv, u128_rmul};
 
 
 const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
 
 
-pub fn pow<T, impl TMul: Mul<T>, impl TOne: One<T>, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(x: T, mut n: u8) -> T {
-    if n == 0 {
-        TOne::one()
-    } else if n == 1 {
-        x
-    } else if n % 2 == 0 {
-        pow(x * x, n / 2)
-    } else {
-        x * pow(x * x, (n - 1) / 2)
-    }
-}
-
 pub fn fixed_point_to_wad(n: u128, decimals: u8) -> Wad {
     assert(decimals <= WAD_DECIMALS, 'More than 18 decimals');
-    let scale: u128 = pow(10_u128, WAD_DECIMALS - decimals);
+    let scale: u128 = 10_u128.pow((WAD_DECIMALS - decimals).into());
     (n * scale).into()
 }
 
 pub fn wad_to_fixed_point(n: Wad, decimals: u8) -> u128 {
     assert(decimals <= WAD_DECIMALS, 'More than 18 decimals');
-    let scale: u128 = pow(10_u128, WAD_DECIMALS - decimals);
+    let scale: u128 = 10_u128.pow((WAD_DECIMALS - decimals).into());
     n.into() / scale
 }
 
@@ -46,9 +34,9 @@ pub fn convert_ekubo_oracle_price_to_wad(n: u256, base_decimals: u8, quote_decim
     // Adjust the scale based on the difference in precision between the base asset
     // and the quote asset
     let adjusted_scale: u256 = if quote_decimals <= base_decimals {
-        WAD_SCALE.into() * pow(10_u256, (base_decimals - quote_decimals).into())
+        WAD_SCALE.into() * 10_u256.pow((base_decimals - quote_decimals).into()).into()
     } else {
-        WAD_SCALE.into() / pow(10_u256, (quote_decimals - base_decimals).into())
+        WAD_SCALE.into() / 10_u256.pow((quote_decimals - base_decimals).into()).into()
     };
 
     let val = n * adjusted_scale / TWO_POW_128;

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -1,13 +1,9 @@
-use core::num::traits::{One, Sqrt};
+use core::num::traits::One;
 use wadray::{Ray, WAD_DECIMALS, WAD_SCALE, Wad, u128_rdiv, u128_rmul};
 
 
 const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
 
-pub fn sqrt(x: Ray) -> Ray {
-    let scaled_val: u256 = x.into() * wadray::RAY_SCALE.into();
-    Sqrt::sqrt(scaled_val).into()
-}
 
 pub fn pow<T, impl TMul: Mul<T>, impl TOne: One<T>, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(x: T, mut n: u8) -> T {
     if n == 0 {


### PR DESCRIPTION
Resolves #623.

This PR uses the `Pow` trait for pow operations. For base numeric types, use the corelib. For wadray, this requires the package to be bumped to v0.6.1.