### PR TITLE
chore: bump dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.11.4
-starknet-foundry 0.41.0
+scarb 2.13.1
+starknet-foundry 0.52.0
 voyager 2.0.1

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -27,21 +27,21 @@ dependencies = [
 
 [[package]]
 name = "sncast_std"
-version = "0.41.0"
+version = "0.52.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:0884539863cd2b802eec9bcaecdb810fe130969e766f178d1e42220ddf65344d"
+checksum = "sha256:19aa29c5c8952f410d72357f165a04640c8cc0efd678b53ad70d222ab785fec4"
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.41.0"
+version = "0.52.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:7228a3ea74d8decfb2294cee9251b537bbd58b3e243e9327f55e72a99ab5fb53"
+checksum = "sha256:c33027f8ac078e4bbfc0bd1b7e7849ffe2e6bdd6c24649d0b5ede145095b4743"
 
 [[package]]
 name = "snforge_std"
-version = "0.41.0"
+version = "0.52.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:edf116cbf62cbe2487f188cf28ceb9f42b08cfa14e197524281c3ce932f4a5e6"
+checksum = "sha256:db8d395191bb2b526c44cee65b10a4044dc59e23a1c1d8009a73c7035760ed6b"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -38,6 +38,7 @@ allow-prebuilt-plugins = ["snforge_std"]
 [tool.fmt]
 sort-module-level-items = true
 max-line-length = 120
+breaking-behavior = { tuple = "LineByLine", fixed_array = "LineByLine", macro_call = "LineByLine" }
 
 [tool.snforge]
 max_n_steps = 15000000

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,13 +19,13 @@ allowed-libfuncs-deny = true
 sierra-replace-ids = true
 
 [dependencies]
-starknet = ">= 2.11.4"
+starknet = ">= 2.13.0"
 wadray = ">= 0.6.1"
-access_control = ">= 0.4.0"
+access_control = ">= 0.5.0"
 
 [dev-dependencies]
-snforge_std = ">= 0.38.0"
-assert_macros = ">= 2.11.4"
+snforge_std = ">= 0.52.0"
+assert_macros = ">= 2.13.0"
 
 [scripts]
 restart_devnet = "rm devnet_dump.json 2> /dev/null; starknet-devnet --seed 1087810753 --gas-price 1000 --initial-balance 1000000000000000000000000 --dump-on exit --dump-path devnet_dump.json"

--- a/scripts/Scarb.toml
+++ b/scripts/Scarb.toml
@@ -7,14 +7,14 @@ edition = "2024_07"
 members = ["deployment", "simulation"]
 
 [dependencies]
-sncast_std = ">=0.41.0"
-starknet = ">=2.11.4"
+sncast_std = ">=0.52.0"
+starknet = ">=2.13.0"
 wadray = ">=0.6.1"
 opus = { path = "../" }
 
 [workspace.dependencies]
-sncast_std = ">=0.41.0"
-starknet = ">=2.11.4"
+sncast_std = ">=0.52.0"
+starknet = ">=2.13.0"
 wadray = ">=0.6.1"
 opus = { path = "../" }
 scripts = { path = "./" }

--- a/scripts/Scarb.toml
+++ b/scripts/Scarb.toml
@@ -43,3 +43,4 @@ fmt.workspace = true
 [workspace.tool.fmt]
 sort-module-level-items = true
 max-line-length = 120
+breaking-behavior = { tuple = "LineByLine", fixed_array = "LineByLine", macro_call = "LineByLine" }

--- a/src/core/flash_mint.cairo
+++ b/src/core/flash_mint.cairo
@@ -121,10 +121,7 @@ pub mod flash_mint {
             // flash loans still work when total yin is at or exceeds the debt ceiling
             let ceiling: Wad = shrine.get_debt_ceiling();
             let total_yin: Wad = shrine.get_total_yin();
-            let budget_adjustment: Wad = match shrine.get_budget().try_into() {
-                Option::Some(surplus) => { surplus },
-                Option::None => { Zero::zero() },
-            };
+            let budget_adjustment: Wad = shrine.get_budget().try_into().unwrap_or(Zero::zero());
             let adjust_ceiling: bool = total_yin + amount_wad + budget_adjustment > ceiling;
             if adjust_ceiling {
                 shrine.set_debt_ceiling(total_yin + amount_wad + budget_adjustment);

--- a/src/core/shrine.cairo
+++ b/src/core/shrine.cairo
@@ -1249,10 +1249,7 @@ pub mod shrine {
         // is less than the debt ceiling. Otherwise, if the budget is negative (i.e. there is a deficit),
         // check that the new total amount of yin is less than the debt ceiling.
         fn assert_le_debt_ceiling(self: @ContractState, new_total_yin: Wad, new_budget: SignedWad) {
-            let budget_adjustment: Wad = match new_budget.try_into() {
-                Option::Some(surplus) => { surplus },
-                Option::None => { Zero::zero() },
-            };
+            let budget_adjustment: Wad = new_budget.try_into().unwrap_or(Zero::zero());
             let new_total_debt: Wad = new_total_yin + budget_adjustment;
             assert(new_total_debt <= self.debt_ceiling.read(), 'SH: Debt ceiling reached');
         }

--- a/src/core/transmuter.cairo
+++ b/src/core/transmuter.cairo
@@ -468,7 +468,7 @@ pub mod transmuter {
             let receiver: ContractAddress = self.receiver.read();
             yin.transfer(receiver, (yin_amt - settle_amt).into());
 
-            self.transfer_asset_to_receiver(self.asset.read(), Bounded::MAX);
+            let _ = self.transfer_asset_to_receiver(self.asset.read(), Bounded::MAX);
 
             // Emit event
             self.emit(Settle { deficit: total_transmuted })

--- a/src/core/transmuter_restricted.cairo
+++ b/src/core/transmuter_restricted.cairo
@@ -10,7 +10,7 @@ pub mod transmuter_restricted {
     use opus::utils::math::{fixed_point_to_wad, wad_to_fixed_point};
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
-    use wadray::{Ray, WAD_ONE, Wad};
+    use wadray::{Ray, Wad};
 
     //
     // Components
@@ -458,7 +458,7 @@ pub mod transmuter_restricted {
             let receiver: ContractAddress = self.receiver.read();
             yin.transfer(receiver, (yin_amt - settle_amt).into());
 
-            self.transfer_asset_to_receiver(self.asset.read(), Bounded::MAX);
+            let _ = self.transfer_asset_to_receiver(self.asset.read(), Bounded::MAX);
 
             // Emit event
             self.emit(Settle { deficit: total_transmuted })
@@ -514,8 +514,6 @@ pub mod transmuter_restricted {
         // on-chain conditions
         #[inline(always)]
         fn assert_can_transmute(self: @ContractState, amt_to_mint: Wad) {
-            let shrine: IShrineDispatcher = self.shrine.read();
-
             let ceiling: Wad = self.ceiling.read();
             let minted: Wad = self.total_transmuted.read();
             let is_lt_ceiling: bool = minted + amt_to_mint <= ceiling;

--- a/src/tests/abbot/utils.cairo
+++ b/src/tests/abbot/utils.cairo
@@ -85,10 +85,7 @@ pub mod abbot_utils {
     }
 
     pub fn abbot_deploy(classes: Option<AbbotTestClasses>) -> AbbotTestConfig {
-        let classes = match classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_contracts(),
-        };
+        let classes = classes.unwrap_or(declare_contracts());
         let sentinel_utils::SentinelTestConfig {
             sentinel, shrine, yangs, gates,
         } =

--- a/src/tests/absorber/utils.cairo
+++ b/src/tests/absorber/utils.cairo
@@ -109,10 +109,7 @@ pub mod absorber_utils {
     }
 
     pub fn absorber_deploy(classes: Option<AbsorberTestClasses>) -> AbsorberTestConfig {
-        let classes = match classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_contracts(),
-        };
+        let classes = classes.unwrap_or(declare_contracts());
 
         let abbot_utils::AbbotTestConfig {
             shrine, sentinel, abbot, yangs, gates,
@@ -178,10 +175,7 @@ pub mod absorber_utils {
             ADMIN.into(), asset.into(), absorber.contract_address.into(), bless_amt.into(),
         ];
 
-        let blesser_class = match blesser_class {
-            Option::Some(class) => class,
-            Option::None => *declare("mock_blesser").unwrap().contract_class(),
-        };
+        let blesser_class = blesser_class.unwrap_or(*declare("mock_blesser").unwrap().contract_class());
 
         let (mock_blesser_addr, _) = blesser_class.deploy(@calldata).expect('blesser deploy failed');
 
@@ -243,10 +237,7 @@ pub mod absorber_utils {
     pub fn absorber_with_rewards_and_first_provider(
         classes: Option<AbsorberTestClasses>,
     ) -> (AbsorberTestConfig, AbsorberRewardsTestConfig) {
-        let classes = match classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_contracts(),
-        };
+        let classes = classes.unwrap_or(declare_contracts());
         let (absorber_test_config, provider, provided_amt) = absorber_with_first_provider(Option::Some(classes));
 
         let reward_tokens: Span<ContractAddress> = reward_tokens_deploy(classes.token);
@@ -475,7 +466,7 @@ pub mod absorber_utils {
                 .try_into()
                 .unwrap();
             let mut before_bal_arr: Span<u128> = *before_balances.pop_front().unwrap();
-            let expected_bal: u128 = (*before_bal_arr.pop_front().unwrap()).into() + blessed_amt.into();
+            let expected_bal: u128 = *before_bal_arr.pop_front().unwrap() + blessed_amt.into();
 
             common::assert_equalish(after_provider_bal, expected_bal, error_margin, 'wrong reward balance');
 

--- a/src/tests/absorber/utils.cairo
+++ b/src/tests/absorber/utils.cairo
@@ -175,7 +175,7 @@ pub mod absorber_utils {
             ADMIN.into(), asset.into(), absorber.contract_address.into(), bless_amt.into(),
         ];
 
-        let blesser_class = blesser_class.unwrap_or(*declare("mock_blesser").unwrap().contract_class());
+        let blesser_class = blesser_class.unwrap_or(*declare("blesser").unwrap().contract_class());
 
         let (mock_blesser_addr, _) = blesser_class.deploy(@calldata).expect('blesser deploy failed');
 

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -261,7 +261,8 @@ pub fn mock_ekubo_oracle_extension_deploy(
 ) -> IMockEkuboOracleExtensionDispatcher {
     let mut calldata: Array<felt252> = ArrayTrait::new();
 
-    let mock_ekubo_oracle_extension_class = mock_ekubo_oracle_extension_class.unwrap_or(declare_mock_ekubo_oracle_extension());
+    let mock_ekubo_oracle_extension_class = mock_ekubo_oracle_extension_class
+        .unwrap_or(declare_mock_ekubo_oracle_extension());
 
     let (mock_ekubo_oracle_extension_addr, _) = mock_ekubo_oracle_extension_class
         .deploy(@calldata)

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -161,10 +161,7 @@ pub fn lusd_token_deploy(token_class: Option<ContractClass>) -> ContractAddress 
 }
 
 pub fn quote_tokens(token_class: Option<ContractClass>) -> Span<ContractAddress> {
-    let token_class = match token_class {
-        Option::Some(class) => class,
-        Option::None => declare_token(),
-    };
+    let token_class = token_class.unwrap_or(declare_token());
     array![
         dai_token_deploy(Option::Some(token_class)),
         usdc_token_deploy(Option::Some(token_class)),
@@ -203,10 +200,7 @@ pub fn deploy_token(
         recipient.into(),
     ];
 
-    let token_class = match token_class {
-        Option::Some(class) => class,
-        Option::None => declare_token(),
-    };
+    let token_class = token_class.unwrap_or(declare_token());
 
     let (token_addr, _) = token_class.deploy(@calldata).expect('erc20 deploy failed');
     token_addr
@@ -232,10 +226,7 @@ pub fn deploy_vault(
         asset.into(),
     ];
 
-    let vault_class = match vault_class {
-        Option::Some(class) => class,
-        Option::None => *declare("erc4626_mintable").unwrap().contract_class(),
-    };
+    let vault_class = vault_class.unwrap_or(*declare("erc4626_mintable").unwrap().contract_class());
 
     let (vault_addr, _) = vault_class.deploy(@calldata).expect('erc4626 deploy failed');
 
@@ -270,10 +261,7 @@ pub fn mock_ekubo_oracle_extension_deploy(
 ) -> IMockEkuboOracleExtensionDispatcher {
     let mut calldata: Array<felt252> = ArrayTrait::new();
 
-    let mock_ekubo_oracle_extension_class = match mock_ekubo_oracle_extension_class {
-        Option::Some(class) => class,
-        Option::None => declare_mock_ekubo_oracle_extension(),
-    };
+    let mock_ekubo_oracle_extension_class = mock_ekubo_oracle_extension_class.unwrap_or(declare_mock_ekubo_oracle_extension());
 
     let (mock_ekubo_oracle_extension_addr, _) = mock_ekubo_oracle_extension_class
         .deploy(@calldata)

--- a/src/tests/equalizer/test_allocator.cairo
+++ b/src/tests/equalizer/test_allocator.cairo
@@ -47,32 +47,6 @@ mod test_allocator {
     }
 
     #[test]
-    #[should_panic(expected: 'failed allocator deploy')]
-    fn test_allocator_deploy_input_arrays_mismatch_fail() {
-        let mut recipients = equalizer_utils::initial_recipients();
-        let _ = recipients.pop_front();
-
-        equalizer_utils::allocator_deploy(recipients, equalizer_utils::initial_percentages(), Option::None);
-    }
-
-    #[test]
-    #[should_panic(expected: 'failed allocator deploy')]
-    fn test_allocator_deploy_no_recipients_fail() {
-        let recipients: Array<ContractAddress> = ArrayTrait::new();
-        let percentages: Array<Ray> = ArrayTrait::new();
-
-        let _ = equalizer_utils::allocator_deploy(recipients.span(), percentages.span(), Option::None);
-    }
-
-    #[test]
-    #[should_panic(expected: 'failed allocator deploy')]
-    fn test_allocator_deploy_invalid_percentage_fail() {
-        let _ = equalizer_utils::allocator_deploy(
-            equalizer_utils::initial_recipients(), equalizer_utils::invalid_percentages(), Option::None,
-        );
-    }
-
-    #[test]
     fn test_set_allocation_pass() {
         let allocator = equalizer_utils::allocator_deploy(
             equalizer_utils::initial_recipients(), equalizer_utils::initial_percentages(), Option::None,

--- a/src/tests/equalizer/utils.cairo
+++ b/src/tests/equalizer/utils.cairo
@@ -87,10 +87,7 @@ pub mod equalizer_utils {
             calldata.append(val.into());
         }
 
-        let allocator_class = match allocator_class {
-            Option::Some(class) => class,
-            Option::None => *declare("allocator").unwrap().contract_class(),
-        };
+        let allocator_class = allocator_class.unwrap_or(*declare("allocator").unwrap().contract_class());
         let (allocator_addr, _) = allocator_class.deploy(@calldata).expect('failed allocator deploy');
 
         IAllocatorDispatcher { contract_address: allocator_addr }

--- a/src/tests/equalizer/utils.cairo
+++ b/src/tests/equalizer/utils.cairo
@@ -103,10 +103,7 @@ pub mod equalizer_utils {
             shrine.into(), shrine_utils::ADMIN.into(), absorber.into(), stabilizer.into(),
         ];
 
-        let tcr_allocator_class = match tcr_allocator_class {
-            Option::Some(class) => class,
-            Option::None => *declare("tcr_allocator").unwrap().contract_class(),
-        };
+        let tcr_allocator_class = tcr_allocator_class.unwrap_or(*declare("tcr_allocator").unwrap().contract_class());
         let (tcr_allocator_addr, _) = tcr_allocator_class.deploy(@calldata).expect('failed tcr allocator deploy');
 
         IAllocatorDispatcher { contract_address: tcr_allocator_addr }

--- a/src/tests/external/utils.cairo
+++ b/src/tests/external/utils.cairo
@@ -53,10 +53,7 @@ pub mod pragma_utils {
     pub fn mock_pragma_deploy(mock_pragma_class: Option<ContractClass>) -> IMockPragmaDispatcher {
         let mut calldata: Array<felt252> = ArrayTrait::new();
 
-        let mock_pragma_class = match mock_pragma_class {
-            Option::Some(class) => class,
-            Option::None => *declare("mock_pragma").unwrap().contract_class(),
-        };
+        let mock_pragma_class = mock_pragma_class.unwrap_or(*declare("mock_pragma").unwrap().contract_class());
 
         let (mock_pragma_addr, _) = mock_pragma_class.deploy(@calldata).expect('mock pragma deploy failed');
 
@@ -75,10 +72,7 @@ pub mod pragma_utils {
             SOURCES_THRESHOLD.into(),
         ];
 
-        let pragma_class = match pragma_class {
-            Option::Some(class) => class,
-            Option::None => *declare("pragma").unwrap().contract_class(),
-        };
+        let pragma_class = pragma_class.unwrap_or(*declare("pragma").unwrap().contract_class());
 
         let (pragma_addr, _) = pragma_class.deploy(@calldata).expect('pragma  deploy failed');
 
@@ -202,10 +196,7 @@ pub mod ekubo_utils {
             (*quote_tokens[2]).into(),
         ];
 
-        let ekubo_class = match ekubo_class {
-            Option::Some(class) => class,
-            Option::None => *declare("ekubo").unwrap().contract_class(),
-        };
+        let ekubo_class = ekubo_class.unwrap_or(*declare("ekubo").unwrap().contract_class());
         let (ekubo_addr, _) = ekubo_class.deploy(@calldata).expect('ekubo deploy failed');
         let ekubo = IEkuboDispatcher { contract_address: ekubo_addr };
 

--- a/src/tests/gate/utils.cairo
+++ b/src/tests/gate/utils.cairo
@@ -29,10 +29,7 @@ pub mod gate_utils {
 
         let calldata: Array<felt252> = array![shrine.into(), token.into(), sentinel.into()];
 
-        let gate_class = match gate_class {
-            Option::Some(class) => class,
-            Option::None => *declare("gate").unwrap().contract_class(),
-        };
+        let gate_class = gate_class.unwrap_or(*declare("gate").unwrap().contract_class());
         let (gate_addr, _) = gate_class.deploy(@calldata).expect('gate deploy failed');
         gate_addr
     }

--- a/src/tests/purger/test_purger.cairo
+++ b/src/tests/purger/test_purger.cairo
@@ -3892,7 +3892,7 @@ mod test_purger {
         let eth_threshold: Ray = shrine_utils::YANG1_THRESHOLD.into();
 
         let target_user: ContractAddress = purger_utils::TARGET_TROVE_OWNER;
-        common::fund_user(target_user, array![eth].span(), array![(10 * eth_amt).into()].span());
+        common::fund_user(target_user, array![eth].span(), array![10 * eth_amt].span());
 
         // Have the searcher provide half of his yin to the absorber
         let searcher = purger_utils::SEARCHER;

--- a/src/tests/purger/utils.cairo
+++ b/src/tests/purger/utils.cairo
@@ -339,10 +339,7 @@ pub mod purger_utils {
     }
 
     pub fn purger_deploy(classes: Option<PurgerTestClasses>) -> PurgerTestConfig {
-        let classes = match classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_contracts(),
-        };
+        let classes = classes.unwrap_or(declare_contracts());
 
         let absorber_classes = absorber_utils::AbsorberTestClasses {
             abbot: classes.abbot,
@@ -445,10 +442,7 @@ pub mod purger_utils {
     ) -> IFlashLiquidatorDispatcher {
         let calldata = array![shrine.into(), abbot.into(), flashmint.into(), purger.into()];
 
-        let fl_class = match fl_class {
-            Option::Some(class) => class,
-            Option::None => *declare("flash_liquidator").unwrap().contract_class(),
-        };
+        let fl_class = fl_class.unwrap_or(*declare("flash_liquidator").unwrap().contract_class());
 
         let (flash_liquidator_addr, _) = fl_class.deploy(@calldata).expect('flash liquidator deploy failed');
 
@@ -650,10 +644,7 @@ pub mod purger_utils {
 
     pub fn assert_ltv_at_safety_margin(threshold: Ray, ltv: Ray, error_margin: Option<Ray>) {
         let expected_ltv: Ray = purger_contract::THRESHOLD_SAFETY_MARGIN.into() * threshold;
-        let error_margin: Ray = match error_margin {
-            Option::Some(e) => { e },
-            Option::None => { (RAY_PERCENT / 10).into() } // 0.1%
-        };
+        let error_margin: Ray = error_margin.unwrap_or((RAY_PERCENT / 10).into()); // 0.1%
         common::assert_equalish(ltv, expected_ltv, error_margin, 'LTV not within safety margin');
     }
 

--- a/src/tests/receptor/utils.cairo
+++ b/src/tests/receptor/utils.cairo
@@ -45,7 +45,8 @@ pub mod receptor_utils {
     ) -> ContractAddress {
         let mut calldata: Array<felt252> = ArrayTrait::new();
 
-        let mock_ekubo_oracle_extension_class = mock_ekubo_oracle_extension_class.unwrap_or(common::declare_mock_ekubo_oracle_extension());
+        let mock_ekubo_oracle_extension_class = mock_ekubo_oracle_extension_class
+            .unwrap_or(common::declare_mock_ekubo_oracle_extension());
 
         let (mock_ekubo_oracle_extension_addr, _) = mock_ekubo_oracle_extension_class
             .deploy(@calldata)

--- a/src/tests/receptor/utils.cairo
+++ b/src/tests/receptor/utils.cairo
@@ -45,10 +45,7 @@ pub mod receptor_utils {
     ) -> ContractAddress {
         let mut calldata: Array<felt252> = ArrayTrait::new();
 
-        let mock_ekubo_oracle_extension_class = match mock_ekubo_oracle_extension_class {
-            Option::Some(class) => class,
-            Option::None => common::declare_mock_ekubo_oracle_extension(),
-        };
+        let mock_ekubo_oracle_extension_class = mock_ekubo_oracle_extension_class.unwrap_or(common::declare_mock_ekubo_oracle_extension());
 
         let (mock_ekubo_oracle_extension_addr, _) = mock_ekubo_oracle_extension_class
             .deploy(@calldata)
@@ -79,10 +76,7 @@ pub mod receptor_utils {
             (*quote_tokens[2]).into(),
         ];
 
-        let receptor_class = match receptor_class {
-            Option::Some(class) => class,
-            Option::None => *declare("receptor").unwrap().contract_class(),
-        };
+        let receptor_class = receptor_class.unwrap_or(*declare("receptor").unwrap().contract_class());
         let (receptor_addr, _) = receptor_class.deploy(@calldata).expect('receptor deploy failed');
 
         // Grant UPDATE_YIN_SPOT_PRICE role to receptor contract

--- a/src/tests/seer/utils.cairo
+++ b/src/tests/seer/utils.cairo
@@ -70,10 +70,7 @@ pub mod seer_utils {
             ADMIN.into(), shrine.into(), sentinel_dispatcher.contract_address.into(), UPDATE_FREQUENCY.into(),
         ];
 
-        let seer_class = match seer_class {
-            Option::Some(class) => class,
-            Option::None => *declare("seer").unwrap().contract_class(),
-        };
+        let seer_class = seer_class.unwrap_or(*declare("seer").unwrap().contract_class());
 
         let (seer_addr, _) = seer_class.deploy(@calldata).expect('failed seer deploy');
 
@@ -97,10 +94,7 @@ pub mod seer_utils {
             ADMIN.into(), shrine.into(), sentinel.into(), UPDATE_FREQUENCY.into(),
         ];
 
-        let seer_class = match seer_class {
-            Option::Some(class) => class,
-            Option::None => *declare("seer").unwrap().contract_class(),
-        };
+        let seer_class = seer_class.unwrap_or(*declare("seer").unwrap().contract_class());
 
         let (seer_addr, _) = seer_class.deploy(@calldata).expect('failed seer deploy');
 
@@ -124,10 +118,7 @@ pub mod seer_utils {
     pub fn add_oracles(
         seer: ISeerDispatcher, oracle_classes: Option<OracleTestClasses>, token_class: Option<ContractClass>,
     ) -> Span<ContractAddress> {
-        let oracle_classes = match oracle_classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_oracles(),
-        };
+        let oracle_classes = oracle_classes.unwrap_or(declare_oracles());
 
         let mut oracles: Array<ContractAddress> = ArrayTrait::new();
 

--- a/src/tests/sentinel/utils.cairo
+++ b/src/tests/sentinel/utils.cairo
@@ -60,10 +60,7 @@ pub mod sentinel_utils {
     }
 
     pub fn deploy_sentinel(classes: Option<SentinelTestClasses>) -> (ISentinelDispatcher, ContractAddress) {
-        let classes = match classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_contracts(),
-        };
+        let classes = classes.unwrap_or(declare_contracts());
 
         let shrine_addr: ContractAddress = shrine_utils::shrine_deploy(classes.shrine);
 
@@ -88,10 +85,7 @@ pub mod sentinel_utils {
     }
 
     pub fn deploy_sentinel_with_gates(classes: Option<SentinelTestClasses>) -> SentinelTestConfig {
-        let classes = match classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_contracts(),
-        };
+        let classes = classes.unwrap_or(declare_contracts());
         let (sentinel, shrine_addr) = deploy_sentinel(Option::Some(classes));
 
         let (eth, eth_gate) = add_eth_yang(sentinel, shrine_addr, classes.token, classes.gate);
@@ -189,12 +183,7 @@ pub mod sentinel_utils {
         eth: ContractAddress,
         wbtc: ContractAddress,
     ) -> (Span<ContractAddress>, Span<IGateDispatcher>) {
-        let vault_class = Option::Some(
-            match vault_class {
-                Option::Some(class) => class,
-                Option::None => *declare("erc4626_mintable").unwrap().contract_class(),
-            },
-        );
+        let vault_class = Option::Some(vault_class.unwrap_or(*declare("erc4626_mintable").unwrap().contract_class()));
 
         let (eth_vault, eth_vault_gate) = add_eth_vault_yang(
             sentinel, shrine.contract_address, vault_class, gate_class, eth,
@@ -210,10 +199,7 @@ pub mod sentinel_utils {
     }
 
     pub fn deploy_sentinel_with_eth_gate(classes: Option<SentinelTestClasses>) -> SentinelTestConfig {
-        let classes = match classes {
-            Option::Some(classes) => classes,
-            Option::None => declare_contracts(),
-        };
+        let classes = classes.unwrap_or(declare_contracts());
 
         let (sentinel, shrine_addr) = deploy_sentinel(Option::Some(classes));
         let (eth, eth_gate) = add_eth_yang(sentinel, shrine_addr, classes.token, classes.gate);

--- a/src/tests/shrine/utils.cairo
+++ b/src/tests/shrine/utils.cairo
@@ -137,10 +137,7 @@ pub mod shrine_utils {
     }
 
     pub fn shrine_deploy(shrine_class: Option<ContractClass>) -> ContractAddress {
-        let shrine_class = match shrine_class {
-            Option::Some(class) => class,
-            Option::None => declare_shrine(),
-        };
+        let shrine_class = shrine_class.unwrap_or(declare_shrine());
 
         let calldata: Array<felt252> = array![ADMIN.into(), YIN_NAME, YIN_SYMBOL];
 

--- a/src/tests/transmuter/utils.cairo
+++ b/src/tests/transmuter/utils.cairo
@@ -59,10 +59,7 @@ pub mod transmuter_utils {
             ADMIN.into(), shrine.into(), asset.into(), receiver.into(), INITIAL_CEILING.into(),
         ];
 
-        let transmuter_class = match transmuter_class {
-            Option::Some(class) => class,
-            Option::None => declare_transmuter(),
-        };
+        let transmuter_class = transmuter_class.unwrap_or(declare_transmuter());
 
         let (transmuter_addr, _) = transmuter_class.deploy(@calldata).expect('transmuter deploy failed');
 

--- a/src/utils/math.cairo
+++ b/src/utils/math.cairo
@@ -34,9 +34,9 @@ pub fn convert_ekubo_oracle_price_to_wad(n: u256, base_decimals: u8, quote_decim
     // Adjust the scale based on the difference in precision between the base asset
     // and the quote asset
     let adjusted_scale: u256 = if quote_decimals <= base_decimals {
-        WAD_SCALE.into() * 10_u256.pow((base_decimals - quote_decimals).into()).into()
+        WAD_SCALE.into() * 10_u256.pow((base_decimals - quote_decimals).into())
     } else {
-        WAD_SCALE.into() / 10_u256.pow((quote_decimals - base_decimals).into()).into()
+        WAD_SCALE.into() / 10_u256.pow((quote_decimals - base_decimals).into())
     };
 
     let val = n * adjusted_scale / TWO_POW_128;


### PR DESCRIPTION
This PR bumps Cairo version to 2.13.1 so as to make use of test parametrization in starknet-foundry 0.52.0.